### PR TITLE
feat(api): add session browsing backend api

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
 pnpm exec lint-staged
+pnpm run typecheck
+pnpm run test

--- a/api/package.json
+++ b/api/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@hono/node-server": "^1.19.11",
     "hono": "^4.7.0"
   },
   "devDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@chat-logbook/api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "^4.7.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.1.0"
+  }
+}

--- a/api/src/__fixtures__/history-partial.jsonl
+++ b/api/src/__fixtures__/history-partial.jsonl
@@ -1,0 +1,4 @@
+{"display":"Normal entry","timestamp":1700000000000,"project":"/Users/test/project-a","sessionId":"session-1"}
+{"timestamp":1700001000000,"project":"/Users/test/project-b","sessionId":"session-2"}
+{"display":"No project","timestamp":1700002000000,"sessionId":"session-3"}
+{"display":"No timestamp","project":"/Users/test/project-a","sessionId":"session-4"}

--- a/api/src/__fixtures__/history.jsonl
+++ b/api/src/__fixtures__/history.jsonl
@@ -1,0 +1,6 @@
+{"display":"Build a login page","pastedContents":{},"timestamp":1700000000000,"project":"/Users/test/project-a","sessionId":"session-1"}
+{"display":"Add validation","pastedContents":{},"timestamp":1700000100000,"project":"/Users/test/project-a","sessionId":"session-1"}
+{"display":"/clear","pastedContents":{},"timestamp":1700000200000,"project":"/Users/test/project-a","sessionId":"session-1"}
+{"display":"Fix the bug in auth","pastedContents":{},"timestamp":1700001000000,"project":"/Users/test/project-b","sessionId":"session-2"}
+{"display":"/init","pastedContents":{},"timestamp":1700002000000,"project":"/Users/test/project-a","sessionId":"session-3"}
+{"display":"Refactor the parser","pastedContents":{},"timestamp":1700002100000,"project":"/Users/test/project-a","sessionId":"session-3"}

--- a/api/src/__fixtures__/projects/project-a/session-1.jsonl
+++ b/api/src/__fixtures__/projects/project-a/session-1.jsonl
@@ -1,0 +1,9 @@
+{"type":"file-history-snapshot","messageId":"msg-1","snapshot":{"trackedFileBackups":{},"timestamp":"2024-01-01T00:00:00Z"}}
+{"type":"user","message":{"role":"user","content":"<local-command-caveat>system message</local-command-caveat>"},"isMeta":true,"uuid":"msg-meta","timestamp":"2024-01-01T00:00:01Z","sessionId":"session-1","isSidechain":false}
+{"type":"user","message":{"role":"user","content":"Build a login page"},"isMeta":false,"uuid":"msg-2","timestamp":"2024-01-01T00:00:02Z","sessionId":"session-1","isSidechain":false}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Sure, I'll build a login page for you."}]},"uuid":"msg-3","timestamp":"2024-01-01T00:00:03Z","sessionId":"session-1","isSidechain":false}
+{"type":"progress","data":{"type":"agent_progress","prompt":"searching..."},"uuid":"msg-4","timestamp":"2024-01-01T00:00:04Z"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"Let me think about this..."},{"type":"text","text":"Here's the implementation."}]},"uuid":"msg-5","timestamp":"2024-01-01T00:00:05Z","sessionId":"session-1","isSidechain":false}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"src/index.ts"}}]},"uuid":"msg-6","timestamp":"2024-01-01T00:00:06Z","sessionId":"session-1","isSidechain":false}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-1","content":"file contents here"}]},"uuid":"msg-7","timestamp":"2024-01-01T00:00:07Z","sessionId":"session-1","isSidechain":false}
+{"type":"system","subtype":"turn_duration","durationMs":5000,"uuid":"msg-8","timestamp":"2024-01-01T00:00:08Z"}

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -1,0 +1,50 @@
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { createApp } from "./app.js";
+import type { Session, Message } from "./parser.js";
+
+const fixturesDir = path.join(import.meta.dirname, "__fixtures__");
+
+describe("GET /api/sessions", () => {
+  it("returns a list of sessions", async () => {
+    const app = createApp(fixturesDir);
+    const res = await app.request("/api/sessions");
+
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { sessions: Session[] };
+    expect(body.sessions).toHaveLength(3);
+    expect(body.sessions[0]).toHaveProperty("id");
+    expect(body.sessions[0]).toHaveProperty("title");
+    expect(body.sessions[0]).toHaveProperty("project");
+    expect(body.sessions[0]).toHaveProperty("createdAt");
+    expect(body.sessions[0]).toHaveProperty("updatedAt");
+  });
+});
+
+describe("GET /api/sessions/:id", () => {
+  it("returns messages for an existing session", async () => {
+    const app = createApp(fixturesDir);
+    const res = await app.request("/api/sessions/session-1");
+
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { messages: Message[] };
+    expect(body.messages).toBeDefined();
+    expect(body.messages.length).toBeGreaterThan(0);
+
+    const userMsg = body.messages.find((m) => m.role === "user");
+    expect(userMsg).toBeDefined();
+    expect(userMsg!.content).toBe("Build a login page");
+  });
+
+  it("returns 404 for a nonexistent session", async () => {
+    const app = createApp(fixturesDir);
+    const res = await app.request("/api/sessions/nonexistent");
+
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBeDefined();
+  });
+});

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,0 +1,25 @@
+import { Hono } from "hono";
+import { listSessions, findSessionFile, getSessionMessages } from "./parser.js";
+
+export function createApp(claudeDir: string) {
+  const app = new Hono();
+
+  app.get("/api/sessions", (c) => {
+    const sessions = listSessions(claudeDir);
+    return c.json({ sessions });
+  });
+
+  app.get("/api/sessions/:id", (c) => {
+    const sessionId = c.req.param("id");
+    const sessionPath = findSessionFile(claudeDir, sessionId);
+
+    if (!sessionPath) {
+      return c.json({ error: "Session not found" }, 404);
+    }
+
+    const messages = getSessionMessages(sessionPath);
+    return c.json({ messages });
+  });
+
+  return app;
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,0 +1,7 @@
+import { Hono } from "hono";
+
+const app = new Hono();
+
+app.get("/", (c) => c.json({ status: "ok" }));
+
+export default app;

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,7 +1,12 @@
-import { Hono } from "hono";
+import os from "node:os";
+import path from "node:path";
+import { serve } from "@hono/node-server";
+import { createApp } from "./app.js";
 
-const app = new Hono();
+const claudeDir = path.join(os.homedir(), ".claude");
+const app = createApp(claudeDir);
+const port = 3000;
 
-app.get("/", (c) => c.json({ status: "ok" }));
-
-export default app;
+serve({ fetch: app.fetch, port }, (info) => {
+  console.log(`chat-logbook listening on http://localhost:${info.port}`);
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,6 +7,6 @@ const claudeDir = path.join(os.homedir(), ".claude");
 const app = createApp(claudeDir);
 const port = 3000;
 
-serve({ fetch: app.fetch, port }, (info) => {
+serve({ fetch: app.fetch, port }, (info: { port: number }) => {
   console.log(`chat-logbook listening on http://localhost:${info.port}`);
 });

--- a/api/src/parser.test.ts
+++ b/api/src/parser.test.ts
@@ -1,0 +1,126 @@
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { listSessions, getSessionMessages, findSessionFile } from "./parser.js";
+
+const fixturesDir = path.join(import.meta.dirname, "__fixtures__");
+
+describe("listSessions", () => {
+  it("returns sessions grouped by sessionId from history.jsonl", () => {
+    const sessions = listSessions(fixturesDir);
+
+    expect(sessions).toHaveLength(3);
+
+    const session1 = sessions.find((s) => s.id === "session-1");
+    expect(session1).toBeDefined();
+    expect(session1!.title).toBe("Build a login page");
+    expect(session1!.project).toBe("/Users/test/project-a");
+    expect(session1!.createdAt).toBe(1700000000000);
+    expect(session1!.updatedAt).toBe(1700000200000);
+
+    const session2 = sessions.find((s) => s.id === "session-2");
+    expect(session2).toBeDefined();
+    expect(session2!.title).toBe("Fix the bug in auth");
+
+    const session3 = sessions.find((s) => s.id === "session-3");
+    expect(session3).toBeDefined();
+    expect(session3!.title).toBe("Refactor the parser");
+  });
+
+  it("handles missing fields with sensible defaults", () => {
+    const partialDir = path.join(fixturesDir, "..");
+    const sessions = listSessions(
+      path.join(import.meta.dirname, "__fixtures__"),
+      "history-partial.jsonl"
+    );
+
+    expect(sessions).toHaveLength(4);
+
+    const noDisplay = sessions.find((s) => s.id === "session-2");
+    expect(noDisplay!.title).toBe("Untitled");
+
+    const noProject = sessions.find((s) => s.id === "session-3");
+    expect(noProject!.project).toBe("");
+
+    const noTimestamp = sessions.find((s) => s.id === "session-4");
+    expect(noTimestamp!.createdAt).toBe(0);
+    expect(noTimestamp!.updatedAt).toBe(0);
+  });
+
+  it("returns empty array when history file does not exist", () => {
+    const sessions = listSessions("/nonexistent/path");
+    expect(sessions).toEqual([]);
+  });
+});
+
+describe("getSessionMessages", () => {
+  const sessionPath = path.join(
+    fixturesDir,
+    "projects",
+    "project-a",
+    "session-1.jsonl"
+  );
+
+  it("returns only user and assistant messages, filtering out meta, progress, system, and snapshots", () => {
+    const messages = getSessionMessages(sessionPath);
+
+    // Should have: 1 user + 3 assistant = 4 (meta user filtered, tool_result user kept)
+    const userMessages = messages.filter((m) => m.role === "user");
+    const assistantMessages = messages.filter((m) => m.role === "assistant");
+
+    expect(userMessages).toHaveLength(2);
+    expect(assistantMessages).toHaveLength(3);
+
+    // First user message should be the real one, not the meta one
+    expect(userMessages[0].content).toBe("Build a login page");
+  });
+
+  it("preserves content block types for assistant messages", () => {
+    const messages = getSessionMessages(sessionPath);
+    const assistantMessages = messages.filter((m) => m.role === "assistant");
+
+    // First assistant has text block
+    expect(assistantMessages[0].content).toEqual([
+      { type: "text", text: "Sure, I'll build a login page for you." },
+    ]);
+
+    // Second assistant has thinking + text blocks
+    expect(assistantMessages[1].content).toEqual([
+      { type: "thinking", thinking: "Let me think about this..." },
+      { type: "text", text: "Here's the implementation." },
+    ]);
+
+    // Third assistant has tool_use block
+    expect(assistantMessages[2].content).toEqual([
+      {
+        type: "tool_use",
+        id: "tool-1",
+        name: "Read",
+        input: { file_path: "src/index.ts" },
+      },
+    ]);
+  });
+
+  it("returns empty array when session file does not exist", () => {
+    const messages = getSessionMessages("/nonexistent/session.jsonl");
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("findSessionFile", () => {
+  it("finds a session file by scanning all project subdirectories", () => {
+    const result = findSessionFile(fixturesDir, "session-1");
+    expect(result).toBe(
+      path.join(fixturesDir, "projects", "project-a", "session-1.jsonl")
+    );
+  });
+
+  it("returns null when session file does not exist", () => {
+    const result = findSessionFile(fixturesDir, "nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when projects directory does not exist", () => {
+    const result = findSessionFile("/nonexistent/path", "session-1");
+    expect(result).toBeNull();
+  });
+});

--- a/api/src/parser.ts
+++ b/api/src/parser.ts
@@ -1,0 +1,153 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type ContentBlock =
+  | { type: "text"; text: string }
+  | { type: "thinking"; thinking: string }
+  | { type: "tool_use"; id: string; name: string; input: unknown }
+  | { type: "tool_result"; tool_use_id: string; content: unknown };
+
+export interface Message {
+  role: "user" | "assistant";
+  content: string | ContentBlock[];
+  timestamp: string;
+}
+
+export interface Session {
+  id: string;
+  title: string;
+  project: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface HistoryEntry {
+  display: string;
+  timestamp: number;
+  project: string;
+  sessionId: string;
+}
+
+const COMMAND_PREFIXES = ["/clear", "/init", "/compact", "/help"];
+
+function isCommand(display: string): boolean {
+  return COMMAND_PREFIXES.some((cmd) => display.startsWith(cmd));
+}
+
+function parseHistoryEntry(raw: unknown): HistoryEntry {
+  const obj = raw as Record<string, unknown>;
+  return {
+    display: typeof obj.display === "string" ? obj.display : "",
+    timestamp: typeof obj.timestamp === "number" ? obj.timestamp : 0,
+    project: typeof obj.project === "string" ? obj.project : "",
+    sessionId: typeof obj.sessionId === "string" ? obj.sessionId : "",
+  };
+}
+
+export function listSessions(
+  claudeDir: string,
+  historyFile = "history.jsonl"
+): Session[] {
+  const historyPath = path.join(claudeDir, historyFile);
+
+  if (!fs.existsSync(historyPath)) {
+    return [];
+  }
+
+  const content = fs.readFileSync(historyPath, "utf-8");
+  const lines = content.trim().split("\n").filter(Boolean);
+
+  const grouped = new Map<string, HistoryEntry[]>();
+
+  for (const line of lines) {
+    const entry = parseHistoryEntry(JSON.parse(line));
+    if (!entry.sessionId) continue;
+    const entries = grouped.get(entry.sessionId) ?? [];
+    entries.push(entry);
+    grouped.set(entry.sessionId, entries);
+  }
+
+  const sessions: Session[] = [];
+
+  for (const [id, entries] of grouped) {
+    const sorted = entries.toSorted((a, b) => a.timestamp - b.timestamp);
+    const firstNonCommand = sorted.find(
+      (e) => e.display && !isCommand(e.display)
+    );
+    const title = firstNonCommand?.display || "Untitled";
+
+    sessions.push({
+      id,
+      title,
+      project: sorted[0].project,
+      createdAt: sorted[0].timestamp,
+      updatedAt: sorted[sorted.length - 1].timestamp,
+    });
+  }
+
+  return sessions;
+}
+
+const CONVERSATION_TYPES = new Set(["user", "assistant"]);
+
+interface RawSessionEntry {
+  type: string;
+  message?: {
+    role: string;
+    content: string | ContentBlock[];
+  };
+  isMeta?: boolean;
+  isSidechain?: boolean;
+  timestamp?: string;
+}
+
+export function getSessionMessages(sessionPath: string): Message[] {
+  if (!fs.existsSync(sessionPath)) {
+    return [];
+  }
+
+  const content = fs.readFileSync(sessionPath, "utf-8");
+  const lines = content.trim().split("\n").filter(Boolean);
+
+  const messages: Message[] = [];
+
+  for (const line of lines) {
+    const entry: RawSessionEntry = JSON.parse(line);
+
+    if (!CONVERSATION_TYPES.has(entry.type)) continue;
+    if (entry.isMeta) continue;
+    if (entry.isSidechain) continue;
+    if (!entry.message) continue;
+
+    messages.push({
+      role: entry.message.role as "user" | "assistant",
+      content: entry.message.content,
+      timestamp: entry.timestamp ?? "",
+    });
+  }
+
+  return messages;
+}
+
+export function findSessionFile(
+  claudeDir: string,
+  sessionId: string
+): string | null {
+  const projectsDir = path.join(claudeDir, "projects");
+
+  if (!fs.existsSync(projectsDir)) {
+    return null;
+  }
+
+  const projectDirs = fs.readdirSync(projectsDir, { withFileTypes: true });
+
+  for (const dir of projectDirs) {
+    if (!dir.isDirectory()) continue;
+    const candidate = path.join(projectsDir, dir.name, `${sessionId}.jsonl`);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -12,7 +12,8 @@
     "rootDir": "src",
     "declaration": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "composite": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
+    "lib": ["ES2023"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    passWithNoTests: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "chat-logbook",
   "version": "0.1.0",
+  "private": true,
   "description": "A local-first conversation manager for Claude Code",
   "license": "MIT",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "pnpm -r run dev",
+    "test": "pnpm -r run test",
+    "typecheck": "pnpm -r run typecheck",
     "prepare": "husky"
   },
-  "keywords": [],
   "packageManager": "pnpm@10.32.1",
   "devDependencies": {
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
 
   api:
     dependencies:
+      "@hono/node-server":
+        specifier: ^1.19.11
+        version: 1.19.11(hono@4.12.9)
       hono:
         specifier: ^4.7.0
         version: 4.12.9
@@ -270,6 +273,15 @@ packages:
     engines: { node: ">=18" }
     cpu: [x64]
     os: [win32]
+
+  "@hono/node-server@1.19.11":
+    resolution:
+      {
+        integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==,
+      }
+    engines: { node: ">=18.14.1" }
+    peerDependencies:
+      hono: ^4
 
   "@jridgewell/sourcemap-codec@1.5.5":
     resolution:
@@ -1228,6 +1240,10 @@ snapshots:
 
   "@esbuild/win32-x64@0.27.4":
     optional: true
+
+  "@hono/node-server@1.19.11(hono@4.12.9)":
+    dependencies:
+      hono: 4.12.9
 
   "@jridgewell/sourcemap-codec@1.5.5": {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,553 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1
 
+  api:
+    dependencies:
+      hono:
+        specifier: ^4.7.0
+        version: 4.12.9
+    devDependencies:
+      "@types/node":
+        specifier: ^22.0.0
+        version: 22.19.15
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
+
 packages:
+  "@esbuild/aix-ppc64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [aix]
+
+  "@esbuild/android-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [android]
+
+  "@esbuild/android-arm@0.27.4":
+    resolution:
+      {
+        integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [android]
+
+  "@esbuild/android-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [android]
+
+  "@esbuild/darwin-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@esbuild/darwin-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@esbuild/freebsd-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [freebsd]
+
+  "@esbuild/freebsd-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@esbuild/linux-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [linux]
+
+  "@esbuild/linux-arm@0.27.4":
+    resolution:
+      {
+        integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [linux]
+
+  "@esbuild/linux-ia32@0.27.4":
+    resolution:
+      {
+        integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [linux]
+
+  "@esbuild/linux-loong64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [loong64]
+    os: [linux]
+
+  "@esbuild/linux-mips64el@0.27.4":
+    resolution:
+      {
+        integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [mips64el]
+    os: [linux]
+
+  "@esbuild/linux-ppc64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@esbuild/linux-riscv64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [riscv64]
+    os: [linux]
+
+  "@esbuild/linux-s390x@0.27.4":
+    resolution:
+      {
+        integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [s390x]
+    os: [linux]
+
+  "@esbuild/linux-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [linux]
+
+  "@esbuild/netbsd-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [netbsd]
+
+  "@esbuild/netbsd-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [netbsd]
+
+  "@esbuild/openbsd-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openbsd]
+
+  "@esbuild/openbsd-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [openbsd]
+
+  "@esbuild/openharmony-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@esbuild/sunos-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [sunos]
+
+  "@esbuild/win32-arm64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@esbuild/win32-ia32@0.27.4":
+    resolution:
+      {
+        integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [win32]
+
+  "@esbuild/win32-x64@0.27.4":
+    resolution:
+      {
+        integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [win32]
+
+  "@jridgewell/sourcemap-codec@1.5.5":
+    resolution:
+      {
+        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+      }
+
+  "@rollup/rollup-android-arm-eabi@4.60.0":
+    resolution:
+      {
+        integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==,
+      }
+    cpu: [arm]
+    os: [android]
+
+  "@rollup/rollup-android-arm64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==,
+      }
+    cpu: [arm64]
+    os: [android]
+
+  "@rollup/rollup-darwin-arm64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==,
+      }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@rollup/rollup-darwin-x64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==,
+      }
+    cpu: [x64]
+    os: [darwin]
+
+  "@rollup/rollup-freebsd-arm64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==,
+      }
+    cpu: [arm64]
+    os: [freebsd]
+
+  "@rollup/rollup-freebsd-x64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==,
+      }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@rollup/rollup-linux-arm-gnueabihf@4.60.0":
+    resolution:
+      {
+        integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==,
+      }
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-arm-musleabihf@4.60.0":
+    resolution:
+      {
+        integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==,
+      }
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-linux-arm64-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-arm64-musl@4.60.0":
+    resolution:
+      {
+        integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-linux-loong64-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==,
+      }
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-loong64-musl@4.60.0":
+    resolution:
+      {
+        integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==,
+      }
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-linux-ppc64-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==,
+      }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-ppc64-musl@4.60.0":
+    resolution:
+      {
+        integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==,
+      }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-linux-riscv64-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-riscv64-musl@4.60.0":
+    resolution:
+      {
+        integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-linux-s390x-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==,
+      }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-x64-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-x64-musl@4.60.0":
+    resolution:
+      {
+        integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-openbsd-x64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==,
+      }
+    cpu: [x64]
+    os: [openbsd]
+
+  "@rollup/rollup-openharmony-arm64@4.60.0":
+    resolution:
+      {
+        integrity: sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==,
+      }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@rollup/rollup-win32-arm64-msvc@4.60.0":
+    resolution:
+      {
+        integrity: sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==,
+      }
+    cpu: [arm64]
+    os: [win32]
+
+  "@rollup/rollup-win32-ia32-msvc@4.60.0":
+    resolution:
+      {
+        integrity: sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==,
+      }
+    cpu: [ia32]
+    os: [win32]
+
+  "@rollup/rollup-win32-x64-gnu@4.60.0":
+    resolution:
+      {
+        integrity: sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==,
+      }
+    cpu: [x64]
+    os: [win32]
+
+  "@rollup/rollup-win32-x64-msvc@4.60.0":
+    resolution:
+      {
+        integrity: sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==,
+      }
+    cpu: [x64]
+    os: [win32]
+
+  "@types/chai@5.2.3":
+    resolution:
+      {
+        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
+      }
+
+  "@types/deep-eql@4.0.2":
+    resolution:
+      {
+        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
+      }
+
+  "@types/estree@1.0.8":
+    resolution:
+      {
+        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+      }
+
+  "@types/node@22.19.15":
+    resolution:
+      {
+        integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==,
+      }
+
+  "@vitest/expect@3.2.4":
+    resolution:
+      {
+        integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==,
+      }
+
+  "@vitest/mocker@3.2.4":
+    resolution:
+      {
+        integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==,
+      }
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  "@vitest/pretty-format@3.2.4":
+    resolution:
+      {
+        integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==,
+      }
+
+  "@vitest/runner@3.2.4":
+    resolution:
+      {
+        integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==,
+      }
+
+  "@vitest/snapshot@3.2.4":
+    resolution:
+      {
+        integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==,
+      }
+
+  "@vitest/spy@3.2.4":
+    resolution:
+      {
+        integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==,
+      }
+
+  "@vitest/utils@3.2.4":
+    resolution:
+      {
+        integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==,
+      }
+
   ansi-escapes@7.3.0:
     resolution:
       {
@@ -38,6 +584,34 @@ packages:
         integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==,
       }
     engines: { node: ">=12" }
+
+  assertion-error@2.0.1:
+    resolution:
+      {
+        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
+      }
+    engines: { node: ">=12" }
+
+  cac@6.7.14:
+    resolution:
+      {
+        integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
+      }
+    engines: { node: ">=8" }
+
+  chai@5.3.3:
+    resolution:
+      {
+        integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==,
+      }
+    engines: { node: ">=18" }
+
+  check-error@2.1.3:
+    resolution:
+      {
+        integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==,
+      }
+    engines: { node: ">= 16" }
 
   cli-cursor@5.0.0:
     resolution:
@@ -66,6 +640,25 @@ packages:
       }
     engines: { node: ">=20" }
 
+  debug@4.4.3:
+    resolution:
+      {
+        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
+      }
+    engines: { node: ">=6.0" }
+    peerDependencies:
+      supports-color: "*"
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution:
+      {
+        integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
+      }
+    engines: { node: ">=6" }
+
   emoji-regex@10.6.0:
     resolution:
       {
@@ -79,11 +672,58 @@ packages:
       }
     engines: { node: ">=18" }
 
+  es-module-lexer@1.7.0:
+    resolution:
+      {
+        integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
+      }
+
+  esbuild@0.27.4:
+    resolution:
+      {
+        integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution:
+      {
+        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+      }
+
   eventemitter3@5.0.4:
     resolution:
       {
         integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
       }
+
+  expect-type@1.3.0:
+    resolution:
+      {
+        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
+      }
+    engines: { node: ">=12.0.0" }
+
+  fdir@6.5.0:
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: ">=12.0.0" }
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution:
+      {
+        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
 
   get-east-asian-width@1.5.0:
     resolution:
@@ -91,6 +731,19 @@ packages:
         integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==,
       }
     engines: { node: ">=18" }
+
+  get-tsconfig@4.13.7:
+    resolution:
+      {
+        integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==,
+      }
+
+  hono@4.12.9:
+    resolution:
+      {
+        integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==,
+      }
+    engines: { node: ">=16.9.0" }
 
   husky@9.1.7:
     resolution:
@@ -106,6 +759,12 @@ packages:
         integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==,
       }
     engines: { node: ">=18" }
+
+  js-tokens@9.0.1:
+    resolution:
+      {
+        integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==,
+      }
 
   lint-staged@16.4.0:
     resolution:
@@ -129,12 +788,38 @@ packages:
       }
     engines: { node: ">=18" }
 
+  loupe@3.2.1:
+    resolution:
+      {
+        integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
+      }
+
+  magic-string@0.30.21:
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
+
   mimic-function@5.0.1:
     resolution:
       {
         integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==,
       }
     engines: { node: ">=18" }
+
+  ms@2.1.3:
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
+
+  nanoid@3.3.11:
+    resolution:
+      {
+        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    hasBin: true
 
   onetime@7.0.0:
     resolution:
@@ -143,12 +828,38 @@ packages:
       }
     engines: { node: ">=18" }
 
+  pathe@2.0.3:
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
+
+  pathval@2.0.1:
+    resolution:
+      {
+        integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
+      }
+    engines: { node: ">= 14.16" }
+
+  picocolors@1.1.1:
+    resolution:
+      {
+        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+      }
+
   picomatch@4.0.4:
     resolution:
       {
         integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
       }
     engines: { node: ">=12" }
+
+  postcss@8.5.8:
+    resolution:
+      {
+        integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
 
   prettier@3.8.1:
     resolution:
@@ -157,6 +868,12 @@ packages:
       }
     engines: { node: ">=14" }
     hasBin: true
+
+  resolve-pkg-maps@1.0.0:
+    resolution:
+      {
+        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
+      }
 
   restore-cursor@5.1.0:
     resolution:
@@ -169,6 +886,20 @@ packages:
     resolution:
       {
         integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
+      }
+
+  rollup@4.60.0:
+    resolution:
+      {
+        integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==,
+      }
+    engines: { node: ">=18.0.0", npm: ">=8.0.0" }
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution:
+      {
+        integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
       }
 
   signal-exit@4.1.0:
@@ -191,6 +922,25 @@ packages:
         integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==,
       }
     engines: { node: ">=20" }
+
+  source-map-js@1.2.1:
+    resolution:
+      {
+        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  stackback@0.0.2:
+    resolution:
+      {
+        integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
+      }
+
+  std-env@3.10.0:
+    resolution:
+      {
+        integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
+      }
 
   string-argv@0.3.2:
     resolution:
@@ -220,12 +970,170 @@ packages:
       }
     engines: { node: ">=12" }
 
+  strip-literal@3.1.0:
+    resolution:
+      {
+        integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==,
+      }
+
+  tinybench@2.9.0:
+    resolution:
+      {
+        integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
+      }
+
+  tinyexec@0.3.2:
+    resolution:
+      {
+        integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
+      }
+
   tinyexec@1.0.4:
     resolution:
       {
         integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==,
       }
     engines: { node: ">=18" }
+
+  tinyglobby@0.2.15:
+    resolution:
+      {
+        integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
+      }
+    engines: { node: ">=12.0.0" }
+
+  tinypool@1.1.1:
+    resolution:
+      {
+        integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==,
+      }
+    engines: { node: ^18.0.0 || >=20.0.0 }
+
+  tinyrainbow@2.0.0:
+    resolution:
+      {
+        integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==,
+      }
+    engines: { node: ">=14.0.0" }
+
+  tinyspy@4.0.4:
+    resolution:
+      {
+        integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==,
+      }
+    engines: { node: ">=14.0.0" }
+
+  tsx@4.21.0:
+    resolution:
+      {
+        integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==,
+      }
+    engines: { node: ">=18.0.0" }
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution:
+      {
+        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+      }
+    engines: { node: ">=14.17" }
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution:
+      {
+        integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
+      }
+
+  vite-node@3.2.4:
+    resolution:
+      {
+        integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==,
+      }
+    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    hasBin: true
+
+  vite@7.3.1:
+    resolution:
+      {
+        integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+    peerDependencies:
+      "@types/node": ^20.19.0 || >=22.12.0
+      jiti: ">=1.21.0"
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: ">=0.54.8"
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution:
+      {
+        integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==,
+      }
+    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    hasBin: true
+    peerDependencies:
+      "@edge-runtime/vm": "*"
+      "@types/debug": ^4.1.12
+      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+      "@vitest/browser": 3.2.4
+      "@vitest/ui": 3.2.4
+      happy-dom: "*"
+      jsdom: "*"
+    peerDependenciesMeta:
+      "@edge-runtime/vm":
+        optional: true
+      "@types/debug":
+        optional: true
+      "@types/node":
+        optional: true
+      "@vitest/browser":
+        optional: true
+      "@vitest/ui":
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution:
+      {
+        integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
+      }
+    engines: { node: ">=8" }
+    hasBin: true
 
   wrap-ansi@9.0.2:
     resolution:
@@ -243,6 +1151,216 @@ packages:
     hasBin: true
 
 snapshots:
+  "@esbuild/aix-ppc64@0.27.4":
+    optional: true
+
+  "@esbuild/android-arm64@0.27.4":
+    optional: true
+
+  "@esbuild/android-arm@0.27.4":
+    optional: true
+
+  "@esbuild/android-x64@0.27.4":
+    optional: true
+
+  "@esbuild/darwin-arm64@0.27.4":
+    optional: true
+
+  "@esbuild/darwin-x64@0.27.4":
+    optional: true
+
+  "@esbuild/freebsd-arm64@0.27.4":
+    optional: true
+
+  "@esbuild/freebsd-x64@0.27.4":
+    optional: true
+
+  "@esbuild/linux-arm64@0.27.4":
+    optional: true
+
+  "@esbuild/linux-arm@0.27.4":
+    optional: true
+
+  "@esbuild/linux-ia32@0.27.4":
+    optional: true
+
+  "@esbuild/linux-loong64@0.27.4":
+    optional: true
+
+  "@esbuild/linux-mips64el@0.27.4":
+    optional: true
+
+  "@esbuild/linux-ppc64@0.27.4":
+    optional: true
+
+  "@esbuild/linux-riscv64@0.27.4":
+    optional: true
+
+  "@esbuild/linux-s390x@0.27.4":
+    optional: true
+
+  "@esbuild/linux-x64@0.27.4":
+    optional: true
+
+  "@esbuild/netbsd-arm64@0.27.4":
+    optional: true
+
+  "@esbuild/netbsd-x64@0.27.4":
+    optional: true
+
+  "@esbuild/openbsd-arm64@0.27.4":
+    optional: true
+
+  "@esbuild/openbsd-x64@0.27.4":
+    optional: true
+
+  "@esbuild/openharmony-arm64@0.27.4":
+    optional: true
+
+  "@esbuild/sunos-x64@0.27.4":
+    optional: true
+
+  "@esbuild/win32-arm64@0.27.4":
+    optional: true
+
+  "@esbuild/win32-ia32@0.27.4":
+    optional: true
+
+  "@esbuild/win32-x64@0.27.4":
+    optional: true
+
+  "@jridgewell/sourcemap-codec@1.5.5": {}
+
+  "@rollup/rollup-android-arm-eabi@4.60.0":
+    optional: true
+
+  "@rollup/rollup-android-arm64@4.60.0":
+    optional: true
+
+  "@rollup/rollup-darwin-arm64@4.60.0":
+    optional: true
+
+  "@rollup/rollup-darwin-x64@4.60.0":
+    optional: true
+
+  "@rollup/rollup-freebsd-arm64@4.60.0":
+    optional: true
+
+  "@rollup/rollup-freebsd-x64@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-arm-gnueabihf@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-arm-musleabihf@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-arm64-gnu@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-arm64-musl@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-loong64-gnu@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-loong64-musl@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-ppc64-gnu@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-ppc64-musl@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-riscv64-gnu@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-riscv64-musl@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-s390x-gnu@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-x64-gnu@4.60.0":
+    optional: true
+
+  "@rollup/rollup-linux-x64-musl@4.60.0":
+    optional: true
+
+  "@rollup/rollup-openbsd-x64@4.60.0":
+    optional: true
+
+  "@rollup/rollup-openharmony-arm64@4.60.0":
+    optional: true
+
+  "@rollup/rollup-win32-arm64-msvc@4.60.0":
+    optional: true
+
+  "@rollup/rollup-win32-ia32-msvc@4.60.0":
+    optional: true
+
+  "@rollup/rollup-win32-x64-gnu@4.60.0":
+    optional: true
+
+  "@rollup/rollup-win32-x64-msvc@4.60.0":
+    optional: true
+
+  "@types/chai@5.2.3":
+    dependencies:
+      "@types/deep-eql": 4.0.2
+      assertion-error: 2.0.1
+
+  "@types/deep-eql@4.0.2": {}
+
+  "@types/estree@1.0.8": {}
+
+  "@types/node@22.19.15":
+    dependencies:
+      undici-types: 6.21.0
+
+  "@vitest/expect@3.2.4":
+    dependencies:
+      "@types/chai": 5.2.3
+      "@vitest/spy": 3.2.4
+      "@vitest/utils": 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  "@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))":
+    dependencies:
+      "@vitest/spy": 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
+
+  "@vitest/pretty-format@3.2.4":
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  "@vitest/runner@3.2.4":
+    dependencies:
+      "@vitest/utils": 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  "@vitest/snapshot@3.2.4":
+    dependencies:
+      "@vitest/pretty-format": 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  "@vitest/spy@3.2.4":
+    dependencies:
+      tinyspy: 4.0.4
+
+  "@vitest/utils@3.2.4":
+    dependencies:
+      "@vitest/pretty-format": 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -250,6 +1368,20 @@ snapshots:
   ansi-regex@6.2.2: {}
 
   ansi-styles@6.2.3: {}
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -264,19 +1396,77 @@ snapshots:
 
   commander@14.0.3: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
   emoji-regex@10.6.0: {}
 
   environment@1.1.0: {}
 
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.4:
+    optionalDependencies:
+      "@esbuild/aix-ppc64": 0.27.4
+      "@esbuild/android-arm": 0.27.4
+      "@esbuild/android-arm64": 0.27.4
+      "@esbuild/android-x64": 0.27.4
+      "@esbuild/darwin-arm64": 0.27.4
+      "@esbuild/darwin-x64": 0.27.4
+      "@esbuild/freebsd-arm64": 0.27.4
+      "@esbuild/freebsd-x64": 0.27.4
+      "@esbuild/linux-arm": 0.27.4
+      "@esbuild/linux-arm64": 0.27.4
+      "@esbuild/linux-ia32": 0.27.4
+      "@esbuild/linux-loong64": 0.27.4
+      "@esbuild/linux-mips64el": 0.27.4
+      "@esbuild/linux-ppc64": 0.27.4
+      "@esbuild/linux-riscv64": 0.27.4
+      "@esbuild/linux-s390x": 0.27.4
+      "@esbuild/linux-x64": 0.27.4
+      "@esbuild/netbsd-arm64": 0.27.4
+      "@esbuild/netbsd-x64": 0.27.4
+      "@esbuild/openbsd-arm64": 0.27.4
+      "@esbuild/openbsd-x64": 0.27.4
+      "@esbuild/openharmony-arm64": 0.27.4
+      "@esbuild/sunos-x64": 0.27.4
+      "@esbuild/win32-arm64": 0.27.4
+      "@esbuild/win32-ia32": 0.27.4
+      "@esbuild/win32-x64": 0.27.4
+
+  estree-walker@3.0.3:
+    dependencies:
+      "@types/estree": 1.0.8
+
   eventemitter3@5.0.4: {}
 
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
   get-east-asian-width@1.5.0: {}
+
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  hono@4.12.9: {}
 
   husky@9.1.7: {}
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.5.0
+
+  js-tokens@9.0.1: {}
 
   lint-staged@16.4.0:
     dependencies:
@@ -304,15 +1494,39 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      "@jridgewell/sourcemap-codec": 1.5.5
+
   mimic-function@5.0.1: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
 
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
   picomatch@4.0.4: {}
 
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prettier@3.8.1: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   restore-cursor@5.1.0:
     dependencies:
@@ -320,6 +1534,39 @@ snapshots:
       signal-exit: 4.1.0
 
   rfdc@1.4.1: {}
+
+  rollup@4.60.0:
+    dependencies:
+      "@types/estree": 1.0.8
+    optionalDependencies:
+      "@rollup/rollup-android-arm-eabi": 4.60.0
+      "@rollup/rollup-android-arm64": 4.60.0
+      "@rollup/rollup-darwin-arm64": 4.60.0
+      "@rollup/rollup-darwin-x64": 4.60.0
+      "@rollup/rollup-freebsd-arm64": 4.60.0
+      "@rollup/rollup-freebsd-x64": 4.60.0
+      "@rollup/rollup-linux-arm-gnueabihf": 4.60.0
+      "@rollup/rollup-linux-arm-musleabihf": 4.60.0
+      "@rollup/rollup-linux-arm64-gnu": 4.60.0
+      "@rollup/rollup-linux-arm64-musl": 4.60.0
+      "@rollup/rollup-linux-loong64-gnu": 4.60.0
+      "@rollup/rollup-linux-loong64-musl": 4.60.0
+      "@rollup/rollup-linux-ppc64-gnu": 4.60.0
+      "@rollup/rollup-linux-ppc64-musl": 4.60.0
+      "@rollup/rollup-linux-riscv64-gnu": 4.60.0
+      "@rollup/rollup-linux-riscv64-musl": 4.60.0
+      "@rollup/rollup-linux-s390x-gnu": 4.60.0
+      "@rollup/rollup-linux-x64-gnu": 4.60.0
+      "@rollup/rollup-linux-x64-musl": 4.60.0
+      "@rollup/rollup-openbsd-x64": 4.60.0
+      "@rollup/rollup-openharmony-arm64": 4.60.0
+      "@rollup/rollup-win32-arm64-msvc": 4.60.0
+      "@rollup/rollup-win32-ia32-msvc": 4.60.0
+      "@rollup/rollup-win32-x64-gnu": 4.60.0
+      "@rollup/rollup-win32-x64-msvc": 4.60.0
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
 
@@ -332,6 +1579,12 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   string-argv@0.3.2: {}
 
@@ -350,7 +1603,118 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.4: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite-node@3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - "@types/node"
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rollup: 4.60.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      "@types/node": 22.19.15
+      fsevents: 2.3.3
+      tsx: 4.21.0
+      yaml: 2.8.3
+
+  vitest@3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      "@types/chai": 5.2.3
+      "@vitest/expect": 3.2.4
+      "@vitest/mocker": 3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3))
+      "@vitest/pretty-format": 3.2.4
+      "@vitest/runner": 3.2.4
+      "@vitest/snapshot": 3.2.4
+      "@vitest/spy": 3.2.4
+      "@vitest/utils": 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      "@types/node": 22.19.15
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@9.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "api"
+  - "web"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./api" }]
+}


### PR DESCRIPTION
## Background (Why)

Implements the backend portion of #2. Users need a way to browse their Claude Code conversation history. This PR sets up the monorepo foundation and delivers the API layer that reads and serves conversation data from `~/.claude/`.

## Approach (How)

- **Monorepo**: pnpm workspaces with `api/` and `web/` packages. Root scripts delegate to workspaces via `pnpm -r run`.
- **Claude Data Parser**: Reads `history.jsonl` for the session index and scans `projects/` subdirectories for session files by ID. Defensive parsing with defaults for missing fields. Filters out noise (progress, snapshots, system, meta, sidechain).
- **API**: Hono app factory accepts `claudeDir` parameter for testability. Two endpoints serve session list and conversation messages.
- **TDD**: All code written test-first with vertical slices (RED→GREEN per behavior).

## Changes (What)

- [x] pnpm workspaces monorepo (`api/` + `web/`)
- [x] Pre-commit hooks: Husky + lint-staged (Prettier) + typecheck + test
- [x] Claude Data Parser: `listSessions()`, `getSessionMessages()`, `findSessionFile()`
- [x] `GET /api/sessions` — returns session list from `history.jsonl`
- [x] `GET /api/sessions/:id` — returns filtered conversation messages
- [x] 12 tests (9 parser unit/integration + 3 API integration)

### Test Verification

- [x] `listSessions` correctly groups by sessionId, derives title from first non-command message
- [x] Missing fields default gracefully (empty string, 0, "Untitled")
- [x] Missing history file returns empty array
- [x] `getSessionMessages` filters out progress/snapshot/system/meta/sidechain entries
- [x] Content block types (text, thinking, tool_use, tool_result) preserved correctly
- [x] `findSessionFile` scans project subdirectories by sessionId
- [x] API returns 404 for nonexistent session

## Additional Notes

- Frontend (three-column UI, dark theme, markdown rendering) will be a separate PR
- `index.ts` uses `@hono/node-server` for production; tests use Hono's built-in `app.request()`

## Related Links

- Issue: #2