### PR TITLE
chore: add build pipeline and npm publish configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules/
 dist/
 *.tsbuildinfo
 .zed/
+.claude/
 wireframe.html

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+node_modules/
+.DS_Store
+.zed/
+.claude/
+wireframe.html
+*.tsbuildinfo
+api/src/
+web/src/

--- a/api/package.json
+++ b/api/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "build": "tsup",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
@@ -14,6 +15,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "tsup": "^8.5.1",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^3.1.0"

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -7,7 +7,7 @@ const fixturesDir = path.join(import.meta.dirname, "__fixtures__");
 
 describe("GET /api/sessions", () => {
   it("returns a list of sessions", async () => {
-    const app = createApp(fixturesDir);
+    const app = createApp({ claudeDir: fixturesDir });
     const res = await app.request("/api/sessions");
 
     expect(res.status).toBe(200);
@@ -22,7 +22,7 @@ describe("GET /api/sessions", () => {
   });
 
   it("excludes sessions that have no conversation file", async () => {
-    const app = createApp(fixturesDir);
+    const app = createApp({ claudeDir: fixturesDir });
     const res = await app.request("/api/sessions");
     const body = (await res.json()) as { sessions: Session[] };
 
@@ -36,7 +36,7 @@ describe("GET /api/sessions", () => {
 
 describe("GET /api/sessions/:id", () => {
   it("returns messages for an existing session", async () => {
-    const app = createApp(fixturesDir);
+    const app = createApp({ claudeDir: fixturesDir });
     const res = await app.request("/api/sessions/session-1");
 
     expect(res.status).toBe(200);
@@ -51,7 +51,7 @@ describe("GET /api/sessions/:id", () => {
   });
 
   it("returns 404 for a nonexistent session", async () => {
-    const app = createApp(fixturesDir);
+    const app = createApp({ claudeDir: fixturesDir });
     const res = await app.request("/api/sessions/nonexistent");
 
     expect(res.status).toBe(404);

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,7 +1,13 @@
 import { Hono } from "hono";
+import { serveStatic } from "@hono/node-server/serve-static";
 import { listSessions, findSessionFile, getSessionMessages } from "./parser.js";
 
-export function createApp(claudeDir: string) {
+interface AppOptions {
+  claudeDir: string;
+  webDistDir?: string;
+}
+
+export function createApp({ claudeDir, webDistDir }: AppOptions) {
   const app = new Hono();
 
   app.get("/api/sessions", (c) => {
@@ -22,6 +28,11 @@ export function createApp(claudeDir: string) {
     const messages = getSessionMessages(sessionPath);
     return c.json({ messages });
   });
+
+  if (webDistDir) {
+    app.use("*", serveStatic({ root: webDistDir }));
+    app.use("*", serveStatic({ root: webDistDir, path: "index.html" }));
+  }
 
   return app;
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,12 +1,25 @@
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { serve } from "@hono/node-server";
 import { createApp } from "./app.js";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const claudeDir = path.join(os.homedir(), ".claude");
-const app = createApp(claudeDir);
-const port = 3000;
+const webDistDir = path.join(__dirname, "../../web/dist");
+const app = createApp({ claudeDir, webDistDir });
+const port = Number(process.env.PORT) || 3100;
 
-serve({ fetch: app.fetch, port }, (info: { port: number }) => {
+const server = serve({ fetch: app.fetch, port }, (info: { port: number }) => {
   console.log(`chat-logbook listening on http://localhost:${info.port}`);
+});
+
+server.on("error", (err: NodeJS.ErrnoException) => {
+  if (err.code === "EADDRINUSE") {
+    console.error(
+      `Port ${port} is already in use. Try a different port:\n\n  PORT=8080 chat-log\n`
+    );
+    process.exit(1);
+  }
+  throw err;
 });

--- a/api/tsup.config.ts
+++ b/api/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  clean: true,
+  noExternal: [/(.*)/],
+});

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import("../api/dist/index.js");

--- a/package.json
+++ b/package.json
@@ -1,11 +1,21 @@
 {
   "name": "chat-logbook",
   "version": "0.1.0",
-  "private": true,
   "description": "A local-first conversation manager for Claude Code",
   "license": "MIT",
+  "type": "module",
+  "bin": {
+    "chat-logbook": "./bin/cli.js",
+    "chat-log": "./bin/cli.js"
+  },
+  "files": [
+    "bin/",
+    "api/dist/",
+    "web/dist/"
+  ],
   "scripts": {
     "dev": "pnpm -r run dev",
+    "build": "pnpm --filter web run build && pnpm --filter @chat-logbook/api run build",
     "test": "pnpm -r run test",
     "typecheck": "pnpm -r run typecheck",
     "prepare": "husky"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       "@types/node":
         specifier: ^22.0.0
         version: 22.19.15
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -2001,6 +2004,12 @@ packages:
       }
     engines: { node: ">=12" }
 
+  any-promise@1.3.0:
+    resolution:
+      {
+        integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==,
+      }
+
   argparse@2.0.1:
     resolution:
       {
@@ -2109,6 +2118,15 @@ packages:
       }
     engines: { node: ">=18" }
 
+  bundle-require@5.1.0:
+    resolution:
+      {
+        integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    peerDependencies:
+      esbuild: ">=0.18"
+
   bytes@3.1.2:
     resolution:
       {
@@ -2208,6 +2226,13 @@ packages:
       }
     engines: { node: ">= 16" }
 
+  chokidar@4.0.3:
+    resolution:
+      {
+        integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
+      }
+    engines: { node: ">= 14.16.0" }
+
   class-variance-authority@0.7.1:
     resolution:
       {
@@ -2301,11 +2326,31 @@ packages:
       }
     engines: { node: ">=20" }
 
+  commander@4.1.1:
+    resolution:
+      {
+        integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==,
+      }
+    engines: { node: ">= 6" }
+
   concat-map@0.0.1:
     resolution:
       {
         integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
       }
+
+  confbox@0.1.8:
+    resolution:
+      {
+        integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==,
+      }
+
+  consola@3.4.2:
+    resolution:
+      {
+        integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
+      }
+    engines: { node: ^14.18.0 || >=16.10.0 }
 
   content-disposition@1.0.1:
     resolution:
@@ -2959,6 +3004,12 @@ packages:
       }
     engines: { node: ">=10" }
 
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution:
+      {
+        integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==,
+      }
+
   flat-cache@4.0.1:
     resolution:
       {
@@ -3500,6 +3551,13 @@ packages:
         integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==,
       }
 
+  joycon@3.1.1:
+    resolution:
+      {
+        integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
+      }
+    engines: { node: ">=10" }
+
   js-tokens@4.0.0:
     resolution:
       {
@@ -3726,6 +3784,13 @@ packages:
       }
     engines: { node: ">= 12.0.0" }
 
+  lilconfig@3.1.3:
+    resolution:
+      {
+        integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==,
+      }
+    engines: { node: ">=14" }
+
   lines-and-columns@1.2.4:
     resolution:
       {
@@ -3746,6 +3811,13 @@ packages:
         integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==,
       }
     engines: { node: ">=20.0.0" }
+
+  load-tsconfig@0.2.5:
+    resolution:
+      {
+        integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   locate-path@6.0.0:
     resolution:
@@ -4185,6 +4257,12 @@ packages:
         integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
       }
 
+  mlly@1.8.2:
+    resolution:
+      {
+        integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==,
+      }
+
   ms@2.1.3:
     resolution:
       {
@@ -4210,6 +4288,12 @@ packages:
         integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==,
       }
     engines: { node: ^18.17.0 || >=20.5.0 }
+
+  mz@2.7.0:
+    resolution:
+      {
+        integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
+      }
 
   nanoid@3.3.11:
     resolution:
@@ -4468,12 +4552,46 @@ packages:
       }
     engines: { node: ">=12" }
 
+  pirates@4.0.7:
+    resolution:
+      {
+        integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==,
+      }
+    engines: { node: ">= 6" }
+
   pkce-challenge@5.0.1:
     resolution:
       {
         integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==,
       }
     engines: { node: ">=16.20.0" }
+
+  pkg-types@1.3.1:
+    resolution:
+      {
+        integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==,
+      }
+
+  postcss-load-config@6.0.1:
+    resolution:
+      {
+        integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==,
+      }
+    engines: { node: ">= 18" }
+    peerDependencies:
+      jiti: ">=1.21.0"
+      postcss: ">=8.0.9"
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss-selector-parser@7.1.1:
     resolution:
@@ -4618,6 +4736,13 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  readdirp@4.1.2:
+    resolution:
+      {
+        integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==,
+      }
+    engines: { node: ">= 14.18.0" }
+
   recast@0.23.11:
     resolution:
       {
@@ -4682,6 +4807,13 @@ packages:
         integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
       }
     engines: { node: ">=4" }
+
+  resolve-from@5.0.0:
+    resolution:
+      {
+        integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
+      }
+    engines: { node: ">=8" }
 
   resolve-pkg-maps@1.0.0:
     resolution:
@@ -4907,6 +5039,13 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  source-map@0.7.6:
+    resolution:
+      {
+        integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==,
+      }
+    engines: { node: ">= 12" }
+
   space-separated-tokens@2.0.2:
     resolution:
       {
@@ -5053,6 +5192,14 @@ packages:
         integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==,
       }
 
+  sucrase@3.35.1:
+    resolution:
+      {
+        integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==,
+      }
+    engines: { node: ">=16 || 14 >=14.17" }
+    hasBin: true
+
   supports-color@7.2.0:
     resolution:
       {
@@ -5097,6 +5244,19 @@ packages:
         integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==,
       }
     engines: { node: ">=6" }
+
+  thenify-all@1.6.0:
+    resolution:
+      {
+        integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==,
+      }
+    engines: { node: ">=0.8" }
+
+  thenify@3.3.1:
+    resolution:
+      {
+        integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
+      }
 
   tiny-invariant@1.3.3:
     resolution:
@@ -5192,6 +5352,13 @@ packages:
       }
     engines: { node: ">=20" }
 
+  tree-kill@1.2.2:
+    resolution:
+      {
+        integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
+      }
+    hasBin: true
+
   trim-lines@3.0.1:
     resolution:
       {
@@ -5213,6 +5380,12 @@ packages:
     peerDependencies:
       typescript: ">=4.8.4"
 
+  ts-interface-checker@0.1.13:
+    resolution:
+      {
+        integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==,
+      }
+
   ts-morph@26.0.0:
     resolution:
       {
@@ -5231,6 +5404,28 @@ packages:
       {
         integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
       }
+
+  tsup@8.5.1:
+    resolution:
+      {
+        integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+    peerDependencies:
+      "@microsoft/api-extractor": ^7.36.0
+      "@swc/core": ^1
+      postcss: ^8.4.12
+      typescript: ">=4.5.0"
+    peerDependenciesMeta:
+      "@microsoft/api-extractor":
+        optional: true
+      "@swc/core":
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tsx@4.21.0:
     resolution:
@@ -5284,6 +5479,12 @@ packages:
       }
     engines: { node: ">=14.17" }
     hasBin: true
+
+  ufo@1.6.3:
+    resolution:
+      {
+        integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==,
+      }
 
   undici-types@6.21.0:
     resolution:
@@ -6847,6 +7048,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  any-promise@1.3.0: {}
+
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -6912,6 +7115,11 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bundle-require@5.1.0(esbuild@0.27.4):
+    dependencies:
+      esbuild: 0.27.4
+      load-tsconfig: 0.2.5
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -6957,6 +7165,10 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -6998,7 +7210,13 @@ snapshots:
 
   commander@14.0.3: {}
 
+  commander@4.1.1: {}
+
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   content-disposition@1.0.1: {}
 
@@ -7411,6 +7629,12 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.60.0
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.4.2
@@ -7659,6 +7883,8 @@ snapshots:
 
   jose@6.2.2: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -7777,6 +8003,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lilconfig@3.1.3: {}
+
   lines-and-columns@1.2.4: {}
 
   lint-staged@16.4.0:
@@ -7796,6 +8024,8 @@ snapshots:
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
+
+  load-tsconfig@0.2.5: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -8221,6 +8451,13 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
   ms@2.1.3: {}
 
   msw@2.12.14(@types/node@22.19.15)(typescript@5.9.3):
@@ -8275,6 +8512,12 @@ snapshots:
       - "@types/node"
 
   mute-stream@2.0.0: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
 
@@ -8414,7 +8657,24 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pirates@4.0.7: {}
+
   pkce-challenge@5.0.1: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.8
+      tsx: 4.21.0
+      yaml: 2.8.3
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -8504,6 +8764,8 @@ snapshots:
 
   react@19.2.4: {}
 
+  readdirp@4.1.2: {}
+
   recast@0.23.11:
     dependencies:
       ast-types: 0.16.1
@@ -8558,6 +8820,8 @@ snapshots:
   reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -8778,6 +9042,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   space-separated-tokens@2.0.2: {}
 
   stackback@0.0.2: {}
@@ -8852,6 +9118,16 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  sucrase@3.35.1:
+    dependencies:
+      "@jridgewell/gen-mapping": 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -8867,6 +9143,14 @@ snapshots:
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   tiny-invariant@1.3.3: {}
 
@@ -8907,6 +9191,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -8914,6 +9200,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-interface-checker@0.1.13: {}
 
   ts-morph@26.0.0:
     dependencies:
@@ -8927,6 +9215,34 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.4)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.4
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3)
+      resolve-from: 5.0.0
+      rollup: 4.60.0
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.8
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsx@4.21.0:
     dependencies:
@@ -8963,6 +9279,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
 
   undici-types@6.21.0: {}
 

--- a/web/.npmignore
+++ b/web/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+src

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      "/api": "http://localhost:3000",
+      "/api": "http://localhost:3100",
     },
   },
   test: {


### PR DESCRIPTION
## Background (Why)

Preparing for the first npm release (v0.1.0). The project had no production build flow — only dev mode worked. Need to be able to `npx chat-logbook` or `npm install -g chat-logbook` and have everything work.

## Approach (How)

- Use Vite for frontend build (already existed) and tsup for API bundling (all dependencies bundled into a single file, zero runtime deps)
- Hono serves the frontend static files in production mode
- CLI entry script (`bin/cli.js`) launches the production server
- Default port changed from 3000 to 3100 to avoid conflicts with common dev tools

## Changes (What)

- [x] Add tsup to bundle API with all dependencies into a single JS file
- [x] Add `bin/cli.js` as CLI entry point (registers both `chat-logbook` and `chat-log` commands)
- [x] Add root `build` script that builds web (vite) then api (tsup)
- [x] Configure root `package.json` for npm publishing (`bin`, `files`, `type`, remove `private`)
- [x] Add `.npmignore` files to control published contents
- [x] Hono serves `web/dist/` static files in production via `serveStatic` middleware
- [x] Default port changed to 3100, configurable via `PORT` env var
- [x] Friendly error message on port conflict (`EADDRINUSE`)
- [x] Add `.claude/` to `.gitignore`

### Test Verification

- [x] `pnpm run build` succeeds (web + api)
- [x] `npm pack --dry-run` shows correct 13 files (bin, api/dist, web/dist)
- [x] Global install from tarball works (`npm install -g ./chat-logbook-0.1.0.tgz`)
- [x] `chat-log` command starts server, API returns sessions, static files serve correctly
- [x] All existing tests pass (13 api + 8 web)
- [x] Typecheck passes

## Additional Notes

- Package size: ~219KB compressed, ~603KB unpacked
- API bundle: ~87KB (all Hono dependencies included)
- No runtime dependencies needed after install
