### PR TITLE
ci: add GitHub Actions pipeline for PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,6 @@ jobs:
 
       - run: pnpm run test
 
-      - run: npx playwright install chromium
+      - run: pnpm --filter web exec playwright install chromium
 
       - run: pnpm --filter web run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm run typecheck
+
+      - run: pnpm run test
+
+      - run: npx playwright install chromium
+
+      - run: pnpm --filter web run test:e2e


### PR DESCRIPTION
## Background (Why)

The project has unit/integration tests (Vitest) and E2E tests (Playwright), but they only run locally. Without automated checks on PRs, broken code can be merged if someone forgets to run tests.

## Approach (How)

Add a single-job GitHub Actions workflow that runs on PRs to `main`. Since total test time is under 10 seconds, a single job is sufficient — no need to parallelize.

## Changes (What)

- [x] Add `.github/workflows/ci.yml` with steps: `pnpm install` → `typecheck` → `unit tests` → install Chromium → `E2E tests`
- [x] Use Node 22 (current LTS) with pnpm cache

### Test Verification

- [x] Pre-commit hooks pass (prettier, typecheck, all tests)
- [x] CI workflow runs successfully on this PR

## Additional Notes

- Revisit single-job structure if E2E test suite grows beyond ~1 minute
- Revisit Node version matrix if the project becomes a library consumed by others

## Related Links

- Closes #19