### PR TITLE
feat: soft delete and restore

### DIFF
--- a/api/drizzle.config.ts
+++ b/api/drizzle.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "sqlite",
+  schema: "./src/metadata/schema.ts",
+  out: "./drizzle",
+});

--- a/api/drizzle/0000_safe_slapstick.sql
+++ b/api/drizzle/0000_safe_slapstick.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `sessions_meta` (
+	`session_id` text PRIMARY KEY NOT NULL,
+	`is_deleted` integer DEFAULT false NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);

--- a/api/drizzle/meta/0000_snapshot.json
+++ b/api/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,57 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bc9f920f-c5a0-4f4f-b813-9ea2c69e0f7e",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "sessions_meta": {
+      "name": "sessions_meta",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1777980160883,
+      "tag": "0000_safe_slapstick",
+      "breakpoints": true
+    }
+  ]
+}

--- a/api/package.json
+++ b/api/package.json
@@ -11,12 +11,16 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.11",
+    "better-sqlite3": "^12.9.0",
+    "drizzle-orm": "^0.45.2",
     "hono": "^4.7.0",
     "update-notifier": "^7.3.1"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
     "@types/update-notifier": "^6.0.8",
+    "drizzle-kit": "^0.31.10",
     "tsup": "^8.5.1",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",

--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,8 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsup",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "db:generate": "drizzle-kit generate"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.11",

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -1,13 +1,25 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { createApp } from "./app.js";
 import type { Session, Message } from "./parser.js";
 
 const fixturesDir = path.join(import.meta.dirname, "__fixtures__");
 
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-app-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
 describe("GET /api/sessions", () => {
   it("returns a list of sessions", async () => {
-    const app = createApp({ claudeDir: fixturesDir });
+    const app = createApp({ claudeDir: fixturesDir, dataDir });
     const res = await app.request("/api/sessions");
 
     expect(res.status).toBe(200);
@@ -22,7 +34,7 @@ describe("GET /api/sessions", () => {
   });
 
   it("excludes sessions that have no conversation file", async () => {
-    const app = createApp({ claudeDir: fixturesDir });
+    const app = createApp({ claudeDir: fixturesDir, dataDir });
     const res = await app.request("/api/sessions");
     const body = (await res.json()) as { sessions: Session[] };
 
@@ -34,9 +46,106 @@ describe("GET /api/sessions", () => {
   });
 });
 
+describe("GET /api/sessions?includeDeleted=true", () => {
+  it("returns deleted sessions with isDeleted flag", async () => {
+    const app = createApp({ claudeDir: fixturesDir, dataDir });
+
+    await app.request("/api/sessions/session-1", { method: "DELETE" });
+
+    const res = await app.request("/api/sessions?includeDeleted=true");
+    const body = (await res.json()) as {
+      sessions: (Session & { isDeleted?: boolean })[];
+    };
+
+    const session1 = body.sessions.find((s) => s.id === "session-1");
+    expect(session1).toBeDefined();
+    expect(session1!.isDeleted).toBe(true);
+  });
+});
+
+describe("DELETE /api/sessions/:id", () => {
+  it("hides the session from GET /api/sessions after soft delete", async () => {
+    const app = createApp({ claudeDir: fixturesDir, dataDir });
+
+    const del = await app.request("/api/sessions/session-1", {
+      method: "DELETE",
+    });
+    expect(del.status).toBe(204);
+
+    const list = await app.request("/api/sessions");
+    const body = (await list.json()) as { sessions: Session[] };
+    const ids = body.sessions.map((s) => s.id);
+    expect(ids).not.toContain("session-1");
+  });
+});
+
+describe("POST /api/sessions/:id/restore", () => {
+  it("makes a previously deleted session reappear in GET /api/sessions", async () => {
+    const app = createApp({ claudeDir: fixturesDir, dataDir });
+
+    await app.request("/api/sessions/session-1", { method: "DELETE" });
+
+    const restore = await app.request("/api/sessions/session-1/restore", {
+      method: "POST",
+    });
+    expect(restore.status).toBe(204);
+
+    const list = await app.request("/api/sessions");
+    const body = (await list.json()) as { sessions: Session[] };
+    const ids = body.sessions.map((s) => s.id);
+    expect(ids).toContain("session-1");
+  });
+});
+
+describe("DELETE / restore idempotency", () => {
+  it("returns 404 when deleting a session that does not exist in the source", async () => {
+    const app = createApp({ claudeDir: fixturesDir, dataDir });
+
+    const res = await app.request("/api/sessions/nonexistent", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when restoring a session that does not exist in the source", async () => {
+    const app = createApp({ claudeDir: fixturesDir, dataDir });
+
+    const res = await app.request("/api/sessions/nonexistent/restore", {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 204 when deleting an already-deleted session", async () => {
+    const app = createApp({ claudeDir: fixturesDir, dataDir });
+
+    const first = await app.request("/api/sessions/session-1", {
+      method: "DELETE",
+    });
+    expect(first.status).toBe(204);
+
+    const second = await app.request("/api/sessions/session-1", {
+      method: "DELETE",
+    });
+    expect(second.status).toBe(204);
+  });
+
+  it("returns 204 when restoring a session that was never deleted", async () => {
+    const app = createApp({ claudeDir: fixturesDir, dataDir });
+
+    const res = await app.request("/api/sessions/session-1/restore", {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(204);
+  });
+});
+
 describe("GET /api/sessions/:id", () => {
   it("returns messages for an existing session", async () => {
-    const app = createApp({ claudeDir: fixturesDir });
+    const app = createApp({ claudeDir: fixturesDir, dataDir });
     const res = await app.request("/api/sessions/session-1");
 
     expect(res.status).toBe(200);
@@ -51,7 +160,7 @@ describe("GET /api/sessions/:id", () => {
   });
 
   it("returns 404 for a nonexistent session", async () => {
-    const app = createApp({ claudeDir: fixturesDir });
+    const app = createApp({ claudeDir: fixturesDir, dataDir });
     const res = await app.request("/api/sessions/nonexistent");
 
     expect(res.status).toBe(404);

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,20 +1,46 @@
 import { Hono } from "hono";
 import { serveStatic } from "@hono/node-server/serve-static";
+import { createMetadataRepository } from "./metadata/repository.js";
 import { listSessions, findSessionFile, getSessionMessages } from "./parser.js";
 
 interface AppOptions {
   claudeDir: string;
+  dataDir: string;
   webDistDir?: string;
 }
 
-export function createApp({ claudeDir, webDistDir }: AppOptions) {
+export function createApp({ claudeDir, dataDir, webDistDir }: AppOptions) {
   const app = new Hono();
+  const metadata = createMetadataRepository({ dataDir });
 
   app.get("/api/sessions", (c) => {
-    const sessions = listSessions(claudeDir).filter(
-      (session) => findSessionFile(claudeDir, session.id) !== null
-    );
+    const includeDeleted = c.req.query("includeDeleted") === "true";
+    const deleted = new Set(metadata.listDeletedIds());
+    const sessions = listSessions(claudeDir)
+      .filter((session) => findSessionFile(claudeDir, session.id) !== null)
+      .filter((session) => includeDeleted || !deleted.has(session.id))
+      .map((session) =>
+        deleted.has(session.id) ? { ...session, isDeleted: true } : session
+      );
     return c.json({ sessions });
+  });
+
+  app.delete("/api/sessions/:id", (c) => {
+    const sessionId = c.req.param("id");
+    if (findSessionFile(claudeDir, sessionId) === null) {
+      return c.json({ error: "Session not found" }, 404);
+    }
+    metadata.softDelete(sessionId);
+    return c.body(null, 204);
+  });
+
+  app.post("/api/sessions/:id/restore", (c) => {
+    const sessionId = c.req.param("id");
+    if (findSessionFile(claudeDir, sessionId) === null) {
+      return c.json({ error: "Session not found" }, 404);
+    }
+    metadata.restore(sessionId);
+    return c.body(null, 204);
   });
 
   app.get("/api/sessions/:id", (c) => {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -17,8 +17,9 @@ const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as {
 updateNotifier({ pkg }).notify();
 
 const claudeDir = path.join(os.homedir(), ".claude");
+const dataDir = path.join(os.homedir(), ".chat-logbook");
 const webDistDir = path.join(__dirname, "../../web/dist");
-const app = createApp({ claudeDir, webDistDir });
+const app = createApp({ claudeDir, dataDir, webDistDir });
 const port = Number(process.env.PORT) || 3100;
 
 function openBrowser(url: string): void {

--- a/api/src/metadata/repository.test.ts
+++ b/api/src/metadata/repository.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createMetadataRepository } from "./repository.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("MetadataRepository", () => {
+  it("marks a session as deleted after softDelete", () => {
+    const repo = createMetadataRepository({ dataDir });
+
+    expect(repo.isDeleted("session-1")).toBe(false);
+
+    repo.softDelete("session-1");
+
+    expect(repo.isDeleted("session-1")).toBe(true);
+  });
+
+  it("clears the deleted flag after restore", () => {
+    const repo = createMetadataRepository({ dataDir });
+
+    repo.softDelete("session-1");
+    expect(repo.isDeleted("session-1")).toBe(true);
+
+    repo.restore("session-1");
+
+    expect(repo.isDeleted("session-1")).toBe(false);
+  });
+
+  it("persists deleted state across repository instances", () => {
+    const first = createMetadataRepository({ dataDir });
+    first.softDelete("session-1");
+
+    const second = createMetadataRepository({ dataDir });
+
+    expect(second.isDeleted("session-1")).toBe(true);
+  });
+});

--- a/api/src/metadata/repository.ts
+++ b/api/src/metadata/repository.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { eq } from "drizzle-orm";
+import {
+  drizzle,
+  type BetterSQLite3Database,
+} from "drizzle-orm/better-sqlite3";
+import { sessionsMeta } from "./schema.js";
+
+export interface MetadataRepository {
+  softDelete(sessionId: string): void;
+  restore(sessionId: string): void;
+  isDeleted(sessionId: string): boolean;
+  listDeletedIds(): string[];
+}
+
+interface RepositoryOptions {
+  dataDir: string;
+}
+
+export function createMetadataRepository({
+  dataDir,
+}: RepositoryOptions): MetadataRepository {
+  fs.mkdirSync(dataDir, { recursive: true });
+  const sqlite = new Database(path.join(dataDir, "data.db"));
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS sessions_meta (
+      session_id TEXT PRIMARY KEY,
+      is_deleted INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+
+  const db: BetterSQLite3Database = drizzle(sqlite);
+
+  return {
+    softDelete(sessionId) {
+      const now = new Date();
+      db.insert(sessionsMeta)
+        .values({
+          sessionId,
+          isDeleted: true,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: sessionsMeta.sessionId,
+          set: { isDeleted: true, updatedAt: now },
+        })
+        .run();
+    },
+
+    restore(sessionId) {
+      const now = new Date();
+      db.update(sessionsMeta)
+        .set({ isDeleted: false, updatedAt: now })
+        .where(eq(sessionsMeta.sessionId, sessionId))
+        .run();
+    },
+
+    isDeleted(sessionId) {
+      const row = db
+        .select({ isDeleted: sessionsMeta.isDeleted })
+        .from(sessionsMeta)
+        .where(eq(sessionsMeta.sessionId, sessionId))
+        .get();
+      return row?.isDeleted ?? false;
+    },
+
+    listDeletedIds() {
+      const rows = db
+        .select({ sessionId: sessionsMeta.sessionId })
+        .from(sessionsMeta)
+        .where(eq(sessionsMeta.isDeleted, true))
+        .all();
+      return rows.map((r) => r.sessionId);
+    },
+  };
+}

--- a/api/src/metadata/repository.ts
+++ b/api/src/metadata/repository.ts
@@ -1,12 +1,27 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 import { eq } from "drizzle-orm";
 import {
   drizzle,
   type BetterSQLite3Database,
 } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { sessionsMeta } from "./schema.js";
+
+function resolveMigrationsFolder(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(here, "../../drizzle"),
+    path.join(here, "./drizzle"),
+  ];
+  const found = candidates.find((p) => fs.existsSync(p));
+  if (!found) {
+    throw new Error("Could not locate drizzle migrations folder");
+  }
+  return found;
+}
 
 export interface MetadataRepository {
   softDelete(sessionId: string): void;
@@ -24,16 +39,8 @@ export function createMetadataRepository({
 }: RepositoryOptions): MetadataRepository {
   fs.mkdirSync(dataDir, { recursive: true });
   const sqlite = new Database(path.join(dataDir, "data.db"));
-  sqlite.exec(`
-    CREATE TABLE IF NOT EXISTS sessions_meta (
-      session_id TEXT PRIMARY KEY,
-      is_deleted INTEGER NOT NULL DEFAULT 0,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    );
-  `);
-
   const db: BetterSQLite3Database = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolveMigrationsFolder() });
 
   return {
     softDelete(sessionId) {

--- a/api/src/metadata/schema.ts
+++ b/api/src/metadata/schema.ts
@@ -1,0 +1,10 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const sessionsMeta = sqliteTable("sessions_meta", {
+  sessionId: text("session_id").primaryKey(),
+  isDeleted: integer("is_deleted", { mode: "boolean" })
+    .notNull()
+    .default(false),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+});

--- a/api/tsup.config.ts
+++ b/api/tsup.config.ts
@@ -1,8 +1,15 @@
+import fs from "node:fs";
+import path from "node:path";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
   clean: true,
-  noExternal: [/^(?!update-notifier).*/],
+  noExternal: [/^(?!(update-notifier|better-sqlite3)).*/],
+  async onSuccess() {
+    const src = path.resolve("drizzle");
+    const dest = path.resolve("dist/drizzle");
+    fs.cpSync(src, dest, { recursive: true });
+  },
 });

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "packageManager": "pnpm@10.32.1",
   "pnpm": {
     "onlyBuiltDependencies": [
+      "better-sqlite3",
       "esbuild",
       "msw"
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       "@hono/node-server":
         specifier: ^1.19.11
         version: 1.19.11(hono@4.12.9)
+      better-sqlite3:
+        specifier: ^12.9.0
+        version: 12.9.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)
       hono:
         specifier: ^4.7.0
         version: 4.12.9
@@ -33,12 +39,18 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1
     devDependencies:
+      "@types/better-sqlite3":
+        specifier: ^7.6.13
+        version: 7.6.13
       "@types/node":
         specifier: ^22.0.0
         version: 22.19.15
       "@types/update-notifier":
         specifier: ^6.0.8
         version: 6.0.8
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
@@ -509,6 +521,12 @@ packages:
       }
     hasBin: true
 
+  "@drizzle-team/brocli@0.10.2":
+    resolution:
+      {
+        integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==,
+      }
+
   "@ecies/ciphers@0.2.5":
     resolution:
       {
@@ -536,6 +554,29 @@ packages:
         integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==,
       }
 
+  "@esbuild-kit/core-utils@3.3.2":
+    resolution:
+      {
+        integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==,
+      }
+    deprecated: "Merged into tsx: https://tsx.is"
+
+  "@esbuild-kit/esm-loader@2.6.5":
+    resolution:
+      {
+        integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==,
+      }
+    deprecated: "Merged into tsx: https://tsx.is"
+
+  "@esbuild/aix-ppc64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [aix]
+
   "@esbuild/aix-ppc64@0.27.4":
     resolution:
       {
@@ -545,6 +586,24 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  "@esbuild/android-arm64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==,
+      }
+    engines: { node: ">=12" }
+    cpu: [arm64]
+    os: [android]
+
+  "@esbuild/android-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [android]
+
   "@esbuild/android-arm64@0.27.4":
     resolution:
       {
@@ -552,6 +611,24 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
+    os: [android]
+
+  "@esbuild/android-arm@0.18.20":
+    resolution:
+      {
+        integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==,
+      }
+    engines: { node: ">=12" }
+    cpu: [arm]
+    os: [android]
+
+  "@esbuild/android-arm@0.25.12":
+    resolution:
+      {
+        integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
     os: [android]
 
   "@esbuild/android-arm@0.27.4":
@@ -563,6 +640,24 @@ packages:
     cpu: [arm]
     os: [android]
 
+  "@esbuild/android-x64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==,
+      }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [android]
+
+  "@esbuild/android-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [android]
+
   "@esbuild/android-x64@0.27.4":
     resolution:
       {
@@ -572,6 +667,24 @@ packages:
     cpu: [x64]
     os: [android]
 
+  "@esbuild/darwin-arm64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==,
+      }
+    engines: { node: ">=12" }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@esbuild/darwin-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [darwin]
+
   "@esbuild/darwin-arm64@0.27.4":
     resolution:
       {
@@ -579,6 +692,24 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
+    os: [darwin]
+
+  "@esbuild/darwin-x64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==,
+      }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@esbuild/darwin-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
     os: [darwin]
 
   "@esbuild/darwin-x64@0.27.4":
@@ -590,6 +721,24 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  "@esbuild/freebsd-arm64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==,
+      }
+    engines: { node: ">=12" }
+    cpu: [arm64]
+    os: [freebsd]
+
+  "@esbuild/freebsd-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [freebsd]
+
   "@esbuild/freebsd-arm64@0.27.4":
     resolution:
       {
@@ -597,6 +746,24 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
+    os: [freebsd]
+
+  "@esbuild/freebsd-x64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==,
+      }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@esbuild/freebsd-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
     os: [freebsd]
 
   "@esbuild/freebsd-x64@0.27.4":
@@ -608,6 +775,24 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  "@esbuild/linux-arm64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==,
+      }
+    engines: { node: ">=12" }
+    cpu: [arm64]
+    os: [linux]
+
+  "@esbuild/linux-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [linux]
+
   "@esbuild/linux-arm64@0.27.4":
     resolution:
       {
@@ -615,6 +800,24 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
+    os: [linux]
+
+  "@esbuild/linux-arm@0.18.20":
+    resolution:
+      {
+        integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==,
+      }
+    engines: { node: ">=12" }
+    cpu: [arm]
+    os: [linux]
+
+  "@esbuild/linux-arm@0.25.12":
+    resolution:
+      {
+        integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
     os: [linux]
 
   "@esbuild/linux-arm@0.27.4":
@@ -626,6 +829,24 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  "@esbuild/linux-ia32@0.18.20":
+    resolution:
+      {
+        integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==,
+      }
+    engines: { node: ">=12" }
+    cpu: [ia32]
+    os: [linux]
+
+  "@esbuild/linux-ia32@0.25.12":
+    resolution:
+      {
+        integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [linux]
+
   "@esbuild/linux-ia32@0.27.4":
     resolution:
       {
@@ -633,6 +854,24 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ia32]
+    os: [linux]
+
+  "@esbuild/linux-loong64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==,
+      }
+    engines: { node: ">=12" }
+    cpu: [loong64]
+    os: [linux]
+
+  "@esbuild/linux-loong64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
+      }
+    engines: { node: ">=18" }
+    cpu: [loong64]
     os: [linux]
 
   "@esbuild/linux-loong64@0.27.4":
@@ -644,6 +883,24 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  "@esbuild/linux-mips64el@0.18.20":
+    resolution:
+      {
+        integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==,
+      }
+    engines: { node: ">=12" }
+    cpu: [mips64el]
+    os: [linux]
+
+  "@esbuild/linux-mips64el@0.25.12":
+    resolution:
+      {
+        integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [mips64el]
+    os: [linux]
+
   "@esbuild/linux-mips64el@0.27.4":
     resolution:
       {
@@ -651,6 +908,24 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [mips64el]
+    os: [linux]
+
+  "@esbuild/linux-ppc64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==,
+      }
+    engines: { node: ">=12" }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@esbuild/linux-ppc64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
     os: [linux]
 
   "@esbuild/linux-ppc64@0.27.4":
@@ -662,6 +937,24 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  "@esbuild/linux-riscv64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==,
+      }
+    engines: { node: ">=12" }
+    cpu: [riscv64]
+    os: [linux]
+
+  "@esbuild/linux-riscv64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [riscv64]
+    os: [linux]
+
   "@esbuild/linux-riscv64@0.27.4":
     resolution:
       {
@@ -669,6 +962,24 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [riscv64]
+    os: [linux]
+
+  "@esbuild/linux-s390x@0.18.20":
+    resolution:
+      {
+        integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==,
+      }
+    engines: { node: ">=12" }
+    cpu: [s390x]
+    os: [linux]
+
+  "@esbuild/linux-s390x@0.25.12":
+    resolution:
+      {
+        integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [s390x]
     os: [linux]
 
   "@esbuild/linux-s390x@0.27.4":
@@ -680,6 +991,24 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  "@esbuild/linux-x64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==,
+      }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [linux]
+
+  "@esbuild/linux-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [linux]
+
   "@esbuild/linux-x64@0.27.4":
     resolution:
       {
@@ -689,6 +1018,15 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  "@esbuild/netbsd-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [netbsd]
+
   "@esbuild/netbsd-arm64@0.27.4":
     resolution:
       {
@@ -696,6 +1034,24 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
+    os: [netbsd]
+
+  "@esbuild/netbsd-x64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==,
+      }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [netbsd]
+
+  "@esbuild/netbsd-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
     os: [netbsd]
 
   "@esbuild/netbsd-x64@0.27.4":
@@ -707,6 +1063,15 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  "@esbuild/openbsd-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openbsd]
+
   "@esbuild/openbsd-arm64@0.27.4":
     resolution:
       {
@@ -714,6 +1079,24 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
+    os: [openbsd]
+
+  "@esbuild/openbsd-x64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==,
+      }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [openbsd]
+
+  "@esbuild/openbsd-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
     os: [openbsd]
 
   "@esbuild/openbsd-x64@0.27.4":
@@ -725,6 +1108,15 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  "@esbuild/openharmony-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openharmony]
+
   "@esbuild/openharmony-arm64@0.27.4":
     resolution:
       {
@@ -733,6 +1125,24 @@ packages:
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
+
+  "@esbuild/sunos-x64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==,
+      }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [sunos]
+
+  "@esbuild/sunos-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [sunos]
 
   "@esbuild/sunos-x64@0.27.4":
     resolution:
@@ -743,6 +1153,24 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  "@esbuild/win32-arm64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==,
+      }
+    engines: { node: ">=12" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@esbuild/win32-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [win32]
+
   "@esbuild/win32-arm64@0.27.4":
     resolution:
       {
@@ -752,6 +1180,24 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  "@esbuild/win32-ia32@0.18.20":
+    resolution:
+      {
+        integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==,
+      }
+    engines: { node: ">=12" }
+    cpu: [ia32]
+    os: [win32]
+
+  "@esbuild/win32-ia32@0.25.12":
+    resolution:
+      {
+        integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [win32]
+
   "@esbuild/win32-ia32@0.27.4":
     resolution:
       {
@@ -759,6 +1205,24 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ia32]
+    os: [win32]
+
+  "@esbuild/win32-x64@0.18.20":
+    resolution:
+      {
+        integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==,
+      }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [win32]
+
+  "@esbuild/win32-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
     os: [win32]
 
   "@esbuild/win32-x64@0.27.4":
@@ -1710,6 +2174,12 @@ packages:
         integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==,
       }
 
+  "@types/better-sqlite3@7.6.13":
+    resolution:
+      {
+        integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==,
+      }
+
   "@types/chai@5.2.3":
     resolution:
       {
@@ -2152,6 +2622,12 @@ packages:
       }
     engines: { node: 18 || 20 || >=22 }
 
+  base64-js@1.5.1:
+    resolution:
+      {
+        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
+      }
+
   baseline-browser-mapping@2.10.11:
     resolution:
       {
@@ -2160,10 +2636,29 @@ packages:
     engines: { node: ">=6.0.0" }
     hasBin: true
 
+  better-sqlite3@12.9.0:
+    resolution:
+      {
+        integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==,
+      }
+    engines: { node: 20.x || 22.x || 23.x || 24.x || 25.x }
+
   bidi-js@1.0.3:
     resolution:
       {
         integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==,
+      }
+
+  bindings@1.5.0:
+    resolution:
+      {
+        integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==,
+      }
+
+  bl@4.1.0:
+    resolution:
+      {
+        integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
       }
 
   body-parser@2.2.2:
@@ -2214,6 +2709,18 @@ packages:
       }
     engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
+
+  buffer-from@1.1.2:
+    resolution:
+      {
+        integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
+      }
+
+  buffer@5.7.1:
+    resolution:
+      {
+        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
+      }
 
   bundle-name@4.1.0:
     resolution:
@@ -2350,6 +2857,12 @@ packages:
         integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
       }
     engines: { node: ">= 14.16.0" }
+
+  chownr@1.1.4:
+    resolution:
+      {
+        integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==,
+      }
 
   class-variance-authority@0.7.1:
     resolution:
@@ -2622,6 +3135,13 @@ packages:
         integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==,
       }
 
+  decompress-response@6.0.0:
+    resolution:
+      {
+        integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==,
+      }
+    engines: { node: ">=10" }
+
   dedent@1.7.2:
     resolution:
       {
@@ -2741,6 +3261,108 @@ packages:
       }
     engines: { node: ">=12" }
 
+  drizzle-kit@0.31.10:
+    resolution:
+      {
+        integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==,
+      }
+    hasBin: true
+
+  drizzle-orm@0.45.2:
+    resolution:
+      {
+        integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==,
+      }
+    peerDependencies:
+      "@aws-sdk/client-rds-data": ">=3"
+      "@cloudflare/workers-types": ">=4"
+      "@electric-sql/pglite": ">=0.2.0"
+      "@libsql/client": ">=0.10.0"
+      "@libsql/client-wasm": ">=0.10.0"
+      "@neondatabase/serverless": ">=0.10.0"
+      "@op-engineering/op-sqlite": ">=2"
+      "@opentelemetry/api": ^1.4.1
+      "@planetscale/database": ">=1.13"
+      "@prisma/client": "*"
+      "@tidbcloud/serverless": "*"
+      "@types/better-sqlite3": "*"
+      "@types/pg": "*"
+      "@types/sql.js": "*"
+      "@upstash/redis": ">=1.34.7"
+      "@vercel/postgres": ">=0.8.0"
+      "@xata.io/client": "*"
+      better-sqlite3: ">=7"
+      bun-types: "*"
+      expo-sqlite: ">=14.0.0"
+      gel: ">=2"
+      knex: "*"
+      kysely: "*"
+      mysql2: ">=2"
+      pg: ">=8"
+      postgres: ">=3"
+      prisma: "*"
+      sql.js: ">=1"
+      sqlite3: ">=5"
+    peerDependenciesMeta:
+      "@aws-sdk/client-rds-data":
+        optional: true
+      "@cloudflare/workers-types":
+        optional: true
+      "@electric-sql/pglite":
+        optional: true
+      "@libsql/client":
+        optional: true
+      "@libsql/client-wasm":
+        optional: true
+      "@neondatabase/serverless":
+        optional: true
+      "@op-engineering/op-sqlite":
+        optional: true
+      "@opentelemetry/api":
+        optional: true
+      "@planetscale/database":
+        optional: true
+      "@prisma/client":
+        optional: true
+      "@tidbcloud/serverless":
+        optional: true
+      "@types/better-sqlite3":
+        optional: true
+      "@types/pg":
+        optional: true
+      "@types/sql.js":
+        optional: true
+      "@upstash/redis":
+        optional: true
+      "@vercel/postgres":
+        optional: true
+      "@xata.io/client":
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution:
       {
@@ -2797,6 +3419,12 @@ packages:
         integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==,
       }
     engines: { node: ">= 0.8" }
+
+  end-of-stream@1.4.5:
+    resolution:
+      {
+        integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
+      }
 
   enhanced-resolve@5.20.1:
     resolution:
@@ -2858,6 +3486,22 @@ packages:
         integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==,
       }
     engines: { node: ">= 0.4" }
+
+  esbuild@0.18.20:
+    resolution:
+      {
+        integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==,
+      }
+    engines: { node: ">=12" }
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution:
+      {
+        integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
 
   esbuild@0.27.4:
     resolution:
@@ -3055,6 +3699,13 @@ packages:
       }
     engines: { node: ^18.19.0 || >=20.5.0 }
 
+  expand-template@2.0.3:
+    resolution:
+      {
+        integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==,
+      }
+    engines: { node: ">=6" }
+
   expect-type@1.3.0:
     resolution:
       {
@@ -3154,6 +3805,12 @@ packages:
       }
     engines: { node: ">=16.0.0" }
 
+  file-uri-to-path@1.0.0:
+    resolution:
+      {
+        integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==,
+      }
+
   fill-range@7.1.1:
     resolution:
       {
@@ -3214,6 +3871,12 @@ packages:
         integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==,
       }
     engines: { node: ">= 0.8" }
+
+  fs-constants@1.0.0:
+    resolution:
+      {
+        integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==,
+      }
 
   fs-extra@11.3.4:
     resolution:
@@ -3310,6 +3973,12 @@ packages:
     resolution:
       {
         integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==,
+      }
+
+  github-from-package@0.0.0:
+    resolution:
+      {
+        integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==,
       }
 
   glob-parent@5.1.2:
@@ -3505,6 +4174,12 @@ packages:
         integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==,
       }
     engines: { node: ">=0.10.0" }
+
+  ieee754@1.2.1:
+    resolution:
+      {
+        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
+      }
 
   ignore@5.3.2:
     resolution:
@@ -4504,6 +5179,13 @@ packages:
       }
     engines: { node: ">=18" }
 
+  mimic-response@3.1.0:
+    resolution:
+      {
+        integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==,
+      }
+    engines: { node: ">=10" }
+
   min-indent@1.0.1:
     resolution:
       {
@@ -4528,6 +5210,12 @@ packages:
     resolution:
       {
         integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
+      }
+
+  mkdirp-classic@0.5.3:
+    resolution:
+      {
+        integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==,
       }
 
   mlly@1.8.2:
@@ -4576,6 +5264,12 @@ packages:
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution:
+      {
+        integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==,
+      }
+
   natural-compare@1.4.0:
     resolution:
       {
@@ -4588,6 +5282,13 @@ packages:
         integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==,
       }
     engines: { node: ">= 0.6" }
+
+  node-abi@3.90.0:
+    resolution:
+      {
+        integrity: sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==,
+      }
+    engines: { node: ">=10" }
 
   node-domexception@1.0.0:
     resolution:
@@ -4910,6 +5611,15 @@ packages:
       }
     engines: { node: ">=20" }
 
+  prebuild-install@7.1.3:
+    resolution:
+      {
+        integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==,
+      }
+    engines: { node: ">=10" }
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution:
       {
@@ -4964,6 +5674,12 @@ packages:
         integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==,
       }
     engines: { node: ">= 0.10" }
+
+  pump@3.0.4:
+    resolution:
+      {
+        integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==,
+      }
 
   punycode@2.3.1:
     resolution:
@@ -5051,6 +5767,13 @@ packages:
         integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==,
       }
     engines: { node: ">=0.10.0" }
+
+  readable-stream@3.6.2:
+    resolution:
+      {
+        integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
+      }
+    engines: { node: ">= 6" }
 
   readdirp@4.1.2:
     resolution:
@@ -5219,6 +5942,12 @@ packages:
         integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
       }
 
+  safe-buffer@5.2.1:
+    resolution:
+      {
+        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+      }
+
   safer-buffer@2.1.2:
     resolution:
       {
@@ -5341,6 +6070,18 @@ packages:
       }
     engines: { node: ">=14" }
 
+  simple-concat@1.0.1:
+    resolution:
+      {
+        integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==,
+      }
+
+  simple-get@4.0.1:
+    resolution:
+      {
+        integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==,
+      }
+
   sisteransi@1.0.5:
     resolution:
       {
@@ -5367,6 +6108,12 @@ packages:
         integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
       }
     engines: { node: ">=0.10.0" }
+
+  source-map-support@0.5.21:
+    resolution:
+      {
+        integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==,
+      }
 
   source-map@0.6.1:
     resolution:
@@ -5454,6 +6201,12 @@ packages:
         integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==,
       }
     engines: { node: ">=20" }
+
+  string_decoder@1.3.0:
+    resolution:
+      {
+        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
+      }
 
   stringify-entities@4.0.4:
     resolution:
@@ -5604,6 +6357,19 @@ packages:
     resolution:
       {
         integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==,
+      }
+    engines: { node: ">=6" }
+
+  tar-fs@2.1.4:
+    resolution:
+      {
+        integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==,
+      }
+
+  tar-stream@2.2.0:
+    resolution:
+      {
+        integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==,
       }
     engines: { node: ">=6" }
 
@@ -5796,6 +6562,12 @@ packages:
       }
     engines: { node: ">=18.0.0" }
     hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution:
+      {
+        integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
+      }
 
   tw-animate-css@1.4.0:
     resolution:
@@ -6651,6 +7423,8 @@ snapshots:
       picomatch: 4.0.4
       which: 4.0.0
 
+  "@drizzle-team/brocli@0.10.2": {}
+
   "@ecies/ciphers@0.2.5(@noble/ciphers@1.3.0)":
     dependencies:
       "@noble/ciphers": 1.3.0
@@ -6671,79 +7445,233 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  "@esbuild-kit/core-utils@3.3.2":
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  "@esbuild-kit/esm-loader@2.6.5":
+    dependencies:
+      "@esbuild-kit/core-utils": 3.3.2
+      get-tsconfig: 4.13.7
+
+  "@esbuild/aix-ppc64@0.25.12":
+    optional: true
+
   "@esbuild/aix-ppc64@0.27.4":
+    optional: true
+
+  "@esbuild/android-arm64@0.18.20":
+    optional: true
+
+  "@esbuild/android-arm64@0.25.12":
     optional: true
 
   "@esbuild/android-arm64@0.27.4":
     optional: true
 
+  "@esbuild/android-arm@0.18.20":
+    optional: true
+
+  "@esbuild/android-arm@0.25.12":
+    optional: true
+
   "@esbuild/android-arm@0.27.4":
+    optional: true
+
+  "@esbuild/android-x64@0.18.20":
+    optional: true
+
+  "@esbuild/android-x64@0.25.12":
     optional: true
 
   "@esbuild/android-x64@0.27.4":
     optional: true
 
+  "@esbuild/darwin-arm64@0.18.20":
+    optional: true
+
+  "@esbuild/darwin-arm64@0.25.12":
+    optional: true
+
   "@esbuild/darwin-arm64@0.27.4":
+    optional: true
+
+  "@esbuild/darwin-x64@0.18.20":
+    optional: true
+
+  "@esbuild/darwin-x64@0.25.12":
     optional: true
 
   "@esbuild/darwin-x64@0.27.4":
     optional: true
 
+  "@esbuild/freebsd-arm64@0.18.20":
+    optional: true
+
+  "@esbuild/freebsd-arm64@0.25.12":
+    optional: true
+
   "@esbuild/freebsd-arm64@0.27.4":
+    optional: true
+
+  "@esbuild/freebsd-x64@0.18.20":
+    optional: true
+
+  "@esbuild/freebsd-x64@0.25.12":
     optional: true
 
   "@esbuild/freebsd-x64@0.27.4":
     optional: true
 
+  "@esbuild/linux-arm64@0.18.20":
+    optional: true
+
+  "@esbuild/linux-arm64@0.25.12":
+    optional: true
+
   "@esbuild/linux-arm64@0.27.4":
+    optional: true
+
+  "@esbuild/linux-arm@0.18.20":
+    optional: true
+
+  "@esbuild/linux-arm@0.25.12":
     optional: true
 
   "@esbuild/linux-arm@0.27.4":
     optional: true
 
+  "@esbuild/linux-ia32@0.18.20":
+    optional: true
+
+  "@esbuild/linux-ia32@0.25.12":
+    optional: true
+
   "@esbuild/linux-ia32@0.27.4":
+    optional: true
+
+  "@esbuild/linux-loong64@0.18.20":
+    optional: true
+
+  "@esbuild/linux-loong64@0.25.12":
     optional: true
 
   "@esbuild/linux-loong64@0.27.4":
     optional: true
 
+  "@esbuild/linux-mips64el@0.18.20":
+    optional: true
+
+  "@esbuild/linux-mips64el@0.25.12":
+    optional: true
+
   "@esbuild/linux-mips64el@0.27.4":
+    optional: true
+
+  "@esbuild/linux-ppc64@0.18.20":
+    optional: true
+
+  "@esbuild/linux-ppc64@0.25.12":
     optional: true
 
   "@esbuild/linux-ppc64@0.27.4":
     optional: true
 
+  "@esbuild/linux-riscv64@0.18.20":
+    optional: true
+
+  "@esbuild/linux-riscv64@0.25.12":
+    optional: true
+
   "@esbuild/linux-riscv64@0.27.4":
+    optional: true
+
+  "@esbuild/linux-s390x@0.18.20":
+    optional: true
+
+  "@esbuild/linux-s390x@0.25.12":
     optional: true
 
   "@esbuild/linux-s390x@0.27.4":
     optional: true
 
+  "@esbuild/linux-x64@0.18.20":
+    optional: true
+
+  "@esbuild/linux-x64@0.25.12":
+    optional: true
+
   "@esbuild/linux-x64@0.27.4":
+    optional: true
+
+  "@esbuild/netbsd-arm64@0.25.12":
     optional: true
 
   "@esbuild/netbsd-arm64@0.27.4":
     optional: true
 
+  "@esbuild/netbsd-x64@0.18.20":
+    optional: true
+
+  "@esbuild/netbsd-x64@0.25.12":
+    optional: true
+
   "@esbuild/netbsd-x64@0.27.4":
+    optional: true
+
+  "@esbuild/openbsd-arm64@0.25.12":
     optional: true
 
   "@esbuild/openbsd-arm64@0.27.4":
     optional: true
 
+  "@esbuild/openbsd-x64@0.18.20":
+    optional: true
+
+  "@esbuild/openbsd-x64@0.25.12":
+    optional: true
+
   "@esbuild/openbsd-x64@0.27.4":
+    optional: true
+
+  "@esbuild/openharmony-arm64@0.25.12":
     optional: true
 
   "@esbuild/openharmony-arm64@0.27.4":
     optional: true
 
+  "@esbuild/sunos-x64@0.18.20":
+    optional: true
+
+  "@esbuild/sunos-x64@0.25.12":
+    optional: true
+
   "@esbuild/sunos-x64@0.27.4":
+    optional: true
+
+  "@esbuild/win32-arm64@0.18.20":
+    optional: true
+
+  "@esbuild/win32-arm64@0.25.12":
     optional: true
 
   "@esbuild/win32-arm64@0.27.4":
     optional: true
 
+  "@esbuild/win32-ia32@0.18.20":
+    optional: true
+
+  "@esbuild/win32-ia32@0.25.12":
+    optional: true
+
   "@esbuild/win32-ia32@0.27.4":
+    optional: true
+
+  "@esbuild/win32-x64@0.18.20":
+    optional: true
+
+  "@esbuild/win32-x64@0.25.12":
     optional: true
 
   "@esbuild/win32-x64@0.27.4":
@@ -7245,6 +8173,10 @@ snapshots:
 
   "@types/aria-query@5.0.4": {}
 
+  "@types/better-sqlite3@7.6.13":
+    dependencies:
+      "@types/node": 24.12.0
+
   "@types/chai@5.2.3":
     dependencies:
       "@types/deep-eql": 4.0.2
@@ -7533,11 +8465,28 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.11: {}
+
+  better-sqlite3@12.9.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
 
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   body-parser@2.2.2:
     dependencies:
@@ -7595,6 +8544,13 @@ snapshots:
       electron-to-chromium: 1.5.328
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-name@4.1.0:
     dependencies:
@@ -7657,6 +8613,8 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  chownr@1.1.4: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -7783,6 +8741,10 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   dedent@1.7.2: {}
 
   deep-eql@5.0.2: {}
@@ -7824,6 +8786,18 @@ snapshots:
 
   dotenv@17.3.1: {}
 
+  drizzle-kit@0.31.10:
+    dependencies:
+      "@drizzle-team/brocli": 0.10.2
+      "@esbuild-kit/esm-loader": 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.21.0
+
+  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0):
+    optionalDependencies:
+      "@types/better-sqlite3": 7.6.13
+      better-sqlite3: 12.9.0
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -7851,6 +8825,10 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -7875,6 +8853,60 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      "@esbuild/android-arm": 0.18.20
+      "@esbuild/android-arm64": 0.18.20
+      "@esbuild/android-x64": 0.18.20
+      "@esbuild/darwin-arm64": 0.18.20
+      "@esbuild/darwin-x64": 0.18.20
+      "@esbuild/freebsd-arm64": 0.18.20
+      "@esbuild/freebsd-x64": 0.18.20
+      "@esbuild/linux-arm": 0.18.20
+      "@esbuild/linux-arm64": 0.18.20
+      "@esbuild/linux-ia32": 0.18.20
+      "@esbuild/linux-loong64": 0.18.20
+      "@esbuild/linux-mips64el": 0.18.20
+      "@esbuild/linux-ppc64": 0.18.20
+      "@esbuild/linux-riscv64": 0.18.20
+      "@esbuild/linux-s390x": 0.18.20
+      "@esbuild/linux-x64": 0.18.20
+      "@esbuild/netbsd-x64": 0.18.20
+      "@esbuild/openbsd-x64": 0.18.20
+      "@esbuild/sunos-x64": 0.18.20
+      "@esbuild/win32-arm64": 0.18.20
+      "@esbuild/win32-ia32": 0.18.20
+      "@esbuild/win32-x64": 0.18.20
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      "@esbuild/aix-ppc64": 0.25.12
+      "@esbuild/android-arm": 0.25.12
+      "@esbuild/android-arm64": 0.25.12
+      "@esbuild/android-x64": 0.25.12
+      "@esbuild/darwin-arm64": 0.25.12
+      "@esbuild/darwin-x64": 0.25.12
+      "@esbuild/freebsd-arm64": 0.25.12
+      "@esbuild/freebsd-x64": 0.25.12
+      "@esbuild/linux-arm": 0.25.12
+      "@esbuild/linux-arm64": 0.25.12
+      "@esbuild/linux-ia32": 0.25.12
+      "@esbuild/linux-loong64": 0.25.12
+      "@esbuild/linux-mips64el": 0.25.12
+      "@esbuild/linux-ppc64": 0.25.12
+      "@esbuild/linux-riscv64": 0.25.12
+      "@esbuild/linux-s390x": 0.25.12
+      "@esbuild/linux-x64": 0.25.12
+      "@esbuild/netbsd-arm64": 0.25.12
+      "@esbuild/netbsd-x64": 0.25.12
+      "@esbuild/openbsd-arm64": 0.25.12
+      "@esbuild/openbsd-x64": 0.25.12
+      "@esbuild/openharmony-arm64": 0.25.12
+      "@esbuild/sunos-x64": 0.25.12
+      "@esbuild/win32-arm64": 0.25.12
+      "@esbuild/win32-ia32": 0.25.12
+      "@esbuild/win32-x64": 0.25.12
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -8045,6 +9077,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   express-rate-limit@8.3.1(express@5.2.1):
@@ -8124,6 +9158,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -8164,6 +9200,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  fs-constants@1.0.0: {}
 
   fs-extra@11.3.4:
     dependencies:
@@ -8217,6 +9255,8 @@ snapshots:
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -8329,6 +9369,8 @@ snapshots:
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -9003,6 +10045,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.4:
@@ -9014,6 +10058,8 @@ snapshots:
       brace-expansion: 1.1.12
 
   minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.2:
     dependencies:
@@ -9085,9 +10131,15 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  node-abi@3.90.0:
+    dependencies:
+      semver: 7.7.4
 
   node-domexception@1.0.0: {}
 
@@ -9268,6 +10320,21 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.90.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
@@ -9295,6 +10362,11 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -9355,6 +10427,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -9512,6 +10590,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -9634,6 +10714,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   sisteransi@1.0.5: {}
 
   slice-ansi@7.1.2:
@@ -9647,6 +10735,11 @@ snapshots:
       is-fullwidth-code-point: 5.1.0
 
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
 
   source-map@0.6.1: {}
 
@@ -9688,6 +10781,10 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   stringify-entities@4.0.4:
     dependencies:
@@ -9765,6 +10862,21 @@ snapshots:
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   thenify-all@1.6.0:
     dependencies:
@@ -9872,6 +10984,10 @@ snapshots:
       get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   tw-animate-css@1.4.0: {}
 

--- a/web/e2e/virtual-scrolling.spec.ts
+++ b/web/e2e/virtual-scrolling.spec.ts
@@ -18,7 +18,7 @@ test.describe("Virtual scrolling", () => {
     page,
   }) => {
     // Intercept API calls with fake data
-    await page.route("**/api/sessions", (route) =>
+    await page.route(/\/api\/sessions(\?|$)/, (route) =>
       route.fulfill({
         json: {
           sessions: [

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
 import App from "./App";
@@ -27,8 +27,10 @@ describe("Session list", () => {
     await screen.findByText("Fix database migration");
 
     const list = screen.getByTestId("session-list");
-    const listItems = within(list).getAllByRole("button");
-    const titles = listItems.map((item) => item.textContent);
+    const rowButtons = within(list)
+      .getAllByRole("button")
+      .filter((el) => !el.getAttribute("aria-label")?.startsWith("Delete"));
+    const titles = rowButtons.map((item) => item.textContent);
 
     // session-2 has updatedAt 1700000300000 (newer)
     // session-1 has updatedAt 1700000200000 (older)
@@ -59,6 +61,123 @@ describe("Trash link in filter panel", () => {
     const trashLink = await screen.findByTestId("trash-link");
     expect(within(trashLink).getByText(/trash/i)).toBeInTheDocument();
     expect(within(trashLink).getByText("1")).toBeInTheDocument();
+  });
+});
+
+describe("Soft delete from session list", () => {
+  it("removes the session from the list and increments trash count", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Fix database migration");
+
+    // Find the session row by title, then its delete button
+    const row = screen.getByText("Fix database migration").closest("button");
+    if (!row) throw new Error("Session row not found");
+
+    const deleteButton = within(row.parentElement!).getByRole("button", {
+      name: /delete session: fix database migration/i,
+    });
+    await user.click(deleteButton);
+
+    // Session should disappear from main list
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Fix database migration")
+      ).not.toBeInTheDocument();
+    });
+
+    // Trash count: 1 → 2
+    const trashLink = screen.getByTestId("trash-link");
+    expect(within(trashLink).getByText("2")).toBeInTheDocument();
+  });
+});
+
+describe("Auto-select next after delete", () => {
+  it("auto-selects the next session after deleting the selected one", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Select "Build a login page" (2nd in sorted main list)
+    await user.click(await screen.findByText("Build a login page"));
+
+    const header = screen.getByTestId("conversation-header");
+    expect(within(header).getByText("Build a login page")).toBeInTheDocument();
+
+    // Delete it via hover button
+    const list = screen.getByTestId("session-list");
+    const deleteBtn = within(list).getByRole("button", {
+      name: /delete session: build a login page/i,
+    });
+    await user.click(deleteBtn);
+
+    // Next session ("Refactor utils") should be auto-selected
+    await waitFor(() => {
+      expect(within(header).getByText("Refactor utils")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("Undo toast on delete", () => {
+  it("shows Undo toast after delete; clicking Undo restores the session", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Fix database migration");
+
+    const list = screen.getByTestId("session-list");
+    const deleteBtn = within(list).getByRole("button", {
+      name: /delete session: fix database migration/i,
+    });
+    await user.click(deleteBtn);
+
+    const toast = await screen.findByTestId("toast");
+    expect(within(toast).getByText(/session deleted/i)).toBeInTheDocument();
+
+    await user.click(within(toast).getByRole("button", { name: /undo/i }));
+
+    await waitFor(() => {
+      expect(
+        within(list).getByText("Fix database migration")
+      ).toBeInTheDocument();
+    });
+
+    const trashLink = screen.getByTestId("trash-link");
+    expect(within(trashLink).getByText("1")).toBeInTheDocument();
+  });
+});
+
+describe("Keyboard shortcuts: delete and undo", () => {
+  it("deletes the selected session when Backspace is pressed", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+
+    await user.keyboard("{Backspace}");
+
+    const list = screen.getByTestId("session-list");
+    await waitFor(() => {
+      expect(
+        within(list).queryByText("Build a login page")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("undoes the last delete when Cmd+Z is pressed", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+    await user.keyboard("{Backspace}");
+
+    await screen.findByTestId("toast");
+
+    await user.keyboard("{Meta>}z{/Meta}");
+
+    await waitFor(() => {
+      expect(screen.getByText("Build a login page")).toBeInTheDocument();
+    });
   });
 });
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,7 +1,15 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
 import { describe, it, expect } from "vitest";
 import App from "./App";
+import { server } from "./test/server";
 
 describe("Session list", () => {
   it("displays session titles fetched from the API", async () => {
@@ -178,6 +186,240 @@ describe("Keyboard shortcuts: delete and undo", () => {
     await waitFor(() => {
       expect(screen.getByText("Build a login page")).toBeInTheDocument();
     });
+  });
+});
+
+describe("Enter Trash mode", () => {
+  it("clicking Trash link replaces the session list with deleted sessions", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+
+    await user.click(screen.getByTestId("trash-link"));
+
+    const list = screen.getByTestId("session-list");
+    expect(within(list).getByText(/trash \(1\)/i)).toBeInTheDocument();
+    expect(within(list).getByText("Old prototype")).toBeInTheDocument();
+    expect(
+      within(list).queryByText("Build a login page")
+    ).not.toBeInTheDocument();
+    expect(
+      within(list).getByRole("button", { name: /back/i })
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Deleted banner in Trash mode", () => {
+  it("shows a Deleted banner with a Restore button when viewing a deleted session", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+
+    await user.click(screen.getByText("Old prototype"));
+
+    expect(
+      await screen.findByText(/this session is deleted/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^restore$/i })
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Restore from Trash banner", () => {
+  it("clicking Restore removes the session from Trash and shows a Restore toast", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+    await user.click(screen.getByText("Old prototype"));
+
+    await user.click(screen.getByRole("button", { name: /^restore$/i }));
+
+    const list = screen.getByTestId("session-list");
+    await waitFor(() => {
+      expect(within(list).queryByText("Old prototype")).not.toBeInTheDocument();
+    });
+
+    const toast = await screen.findByTestId("toast");
+    expect(within(toast).getByText(/session restored/i)).toBeInTheDocument();
+    expect(
+      within(toast).getByRole("button", { name: /view/i })
+    ).toBeInTheDocument();
+  });
+
+  it("clicking View in the restore toast exits Trash and selects the restored session", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+    await user.click(screen.getByText("Old prototype"));
+    await user.click(screen.getByRole("button", { name: /^restore$/i }));
+
+    const toast = await screen.findByTestId("toast");
+    await user.click(within(toast).getByRole("button", { name: /view/i }));
+
+    // Back in main mode — Sessions header visible
+    const list = screen.getByTestId("session-list");
+    expect(within(list).getByText("Sessions")).toBeInTheDocument();
+
+    // Restored session selected and shown in conv header
+    const header = screen.getByTestId("conversation-header");
+    expect(within(header).getByText("Old prototype")).toBeInTheDocument();
+  });
+});
+
+describe("Trash mode triggers: hover button, Backspace, Esc", () => {
+  it("clicking the hover restore button on a Trash row restores the session", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+
+    const list = screen.getByTestId("session-list");
+    const restoreBtn = within(list).getByRole("button", {
+      name: /restore session: old prototype/i,
+    });
+    await user.click(restoreBtn);
+
+    await waitFor(() => {
+      expect(within(list).queryByText("Old prototype")).not.toBeInTheDocument();
+    });
+  });
+
+  it("pressing Backspace in Trash mode restores the selected session", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+    await user.click(screen.getByText("Old prototype"));
+
+    await user.keyboard("{Backspace}");
+
+    const list = screen.getByTestId("session-list");
+    await waitFor(() => {
+      expect(within(list).queryByText("Old prototype")).not.toBeInTheDocument();
+    });
+  });
+
+  it("pressing Esc exits Trash mode and returns to the main session list", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+
+    const list = screen.getByTestId("session-list");
+    expect(within(list).getByText(/trash/i)).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    expect(within(list).getByText("Sessions")).toBeInTheDocument();
+    expect(within(list).getByText("Build a login page")).toBeInTheDocument();
+  });
+});
+
+describe("Right-click context menu", () => {
+  it("right-clicking a session row in main mode shows a Delete item", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const row = await screen.findByText("Build a login page");
+    fireEvent.contextMenu(row);
+
+    const menu = await screen.findByRole("menu");
+    const deleteItem = within(menu).getByRole("menuitem", {
+      name: /delete session/i,
+    });
+
+    await user.click(deleteItem);
+
+    const list = screen.getByTestId("session-list");
+    await waitFor(() => {
+      expect(
+        within(list).queryByText("Build a login page")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("right-clicking a Trash row shows a Restore item", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+
+    const row = screen.getByText("Old prototype");
+    fireEvent.contextMenu(row);
+
+    const menu = await screen.findByRole("menu");
+    expect(
+      within(menu).getByRole("menuitem", { name: /restore session/i })
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Empty states", () => {
+  it("shows a Trash empty-state message when no sessions are deleted", async () => {
+    server.use(
+      http.get("/api/sessions", () =>
+        HttpResponse.json({
+          sessions: [
+            {
+              id: "session-1",
+              title: "Build a login page",
+              project: "/Users/test/my-web-app",
+              createdAt: 1700000000000,
+              updatedAt: 1700000200000,
+            },
+          ],
+        })
+      )
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+
+    expect(screen.getByText(/trash is empty/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/deleted sessions appear here/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows a 'No sessions' hint pointing to Trash when the main list is empty", async () => {
+    server.use(
+      http.get("/api/sessions", () =>
+        HttpResponse.json({
+          sessions: [
+            {
+              id: "session-deleted-only",
+              title: "Only deleted",
+              project: "/Users/test/p",
+              createdAt: 1,
+              updatedAt: 2,
+              isDeleted: true,
+            },
+          ],
+        })
+      )
+    );
+
+    render(<App />);
+
+    expect(await screen.findByText(/no sessions/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^trash \(1\)$/i })
+    ).toBeInTheDocument();
   });
 });
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
 import App from "./App";
@@ -26,13 +26,39 @@ describe("Session list", () => {
 
     await screen.findByText("Fix database migration");
 
-    const listItems = screen.getAllByRole("button");
+    const list = screen.getByTestId("session-list");
+    const listItems = within(list).getAllByRole("button");
     const titles = listItems.map((item) => item.textContent);
 
     // session-2 has updatedAt 1700000300000 (newer)
     // session-1 has updatedAt 1700000200000 (older)
     expect(titles[0]).toContain("Fix database migration");
     expect(titles[1]).toContain("Build a login page");
+  });
+});
+
+describe("Conversation header", () => {
+  it("shows the session title and project after selecting a session", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+
+    const header = await screen.findByTestId("conversation-header");
+    expect(within(header).getByText("Build a login page")).toBeInTheDocument();
+    expect(within(header).getByText(/my-web-app/)).toBeInTheDocument();
+  });
+});
+
+describe("Trash link in filter panel", () => {
+  it("shows the count of deleted sessions in a Trash link", async () => {
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+
+    const trashLink = await screen.findByTestId("trash-link");
+    expect(within(trashLink).getByText(/trash/i)).toBeInTheDocument();
+    expect(within(trashLink).getByText("1")).toBeInTheDocument();
   });
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,24 +14,31 @@ function App() {
   const { sessions } = useSessions();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const { messages, error } = useMessages(selectedId);
+  const mainSessions = sessions.filter((s) => !s.isDeleted);
+  const deletedSessions = sessions.filter((s) => s.isDeleted);
+  const selectedSession = sessions.find((s) => s.id === selectedId) ?? null;
 
   return (
     <div className="h-screen bg-background text-foreground">
       <ResizablePanelGroup orientation="horizontal">
         <ResizablePanel defaultSize={15} minSize={10}>
-          <FilterPanel />
+          <FilterPanel deletedCount={deletedSessions.length} />
         </ResizablePanel>
         <ResizableHandle />
         <ResizablePanel defaultSize={25} minSize={15}>
           <SessionList
-            sessions={sessions}
+            sessions={mainSessions}
             selectedId={selectedId}
             onSelect={setSelectedId}
           />
         </ResizablePanel>
         <ResizableHandle />
         <ResizablePanel defaultSize={60} minSize={30}>
-          <ConversationView messages={messages} error={error} />
+          <ConversationView
+            session={selectedSession}
+            messages={messages}
+            error={error}
+          />
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,11 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSessions } from "@/hooks/useSessions";
 import { useMessages } from "@/hooks/useMessages";
+import { useToast } from "@/hooks/useToast";
 import { FilterPanel } from "@/components/FilterPanel";
 import { SessionList } from "@/components/SessionList";
 import { ConversationView } from "@/components/ConversationView";
+import { Toast } from "@/components/Toast";
 import {
   ResizablePanelGroup,
   ResizablePanel,
@@ -11,12 +13,53 @@ import {
 } from "@/components/ui/resizable";
 
 function App() {
-  const { sessions } = useSessions();
+  const { sessions, softDelete, restore } = useSessions();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const { messages, error } = useMessages(selectedId);
+  const { toast, showToast, dismissToast } = useToast();
   const mainSessions = sessions.filter((s) => !s.isDeleted);
   const deletedSessions = sessions.filter((s) => s.isDeleted);
   const selectedSession = sessions.find((s) => s.id === selectedId) ?? null;
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const isEditable =
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable === true;
+      if (isEditable) return;
+
+      if (e.key === "Backspace" && selectedId) {
+        e.preventDefault();
+        handleDelete(selectedId);
+        return;
+      }
+
+      if ((e.metaKey || e.ctrlKey) && e.key === "z" && toast?.onAction) {
+        e.preventDefault();
+        toast.onAction();
+        dismissToast();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  });
+
+  const handleDelete = (id: string) => {
+    if (id === selectedId) {
+      const idx = mainSessions.findIndex((s) => s.id === id);
+      const remaining = mainSessions.filter((_, i) => i !== idx);
+      const next = remaining[idx] ?? remaining[idx - 1] ?? null;
+      setSelectedId(next?.id ?? null);
+    }
+    void softDelete(id);
+    showToast({
+      message: "Session deleted.",
+      actionLabel: "Undo",
+      onAction: () => void restore(id),
+    });
+  };
 
   return (
     <div className="h-screen bg-background text-foreground">
@@ -30,6 +73,7 @@ function App() {
             sessions={mainSessions}
             selectedId={selectedId}
             onSelect={setSelectedId}
+            onDelete={handleDelete}
           />
         </ResizablePanel>
         <ResizableHandle />
@@ -41,6 +85,7 @@ function App() {
           />
         </ResizablePanel>
       </ResizablePanelGroup>
+      <Toast toast={toast} onDismiss={dismissToast} />
     </div>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,10 +15,12 @@ import {
 function App() {
   const { sessions, softDelete, restore } = useSessions();
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [mode, setMode] = useState<"main" | "trash">("main");
   const { messages, error } = useMessages(selectedId);
   const { toast, showToast, dismissToast } = useToast();
   const mainSessions = sessions.filter((s) => !s.isDeleted);
   const deletedSessions = sessions.filter((s) => s.isDeleted);
+  const visibleSessions = mode === "trash" ? deletedSessions : mainSessions;
   const selectedSession = sessions.find((s) => s.id === selectedId) ?? null;
 
   useEffect(() => {
@@ -30,9 +32,19 @@ function App() {
         target?.isContentEditable === true;
       if (isEditable) return;
 
+      if (e.key === "Escape" && mode === "trash") {
+        e.preventDefault();
+        setMode("main");
+        return;
+      }
+
       if (e.key === "Backspace" && selectedId) {
         e.preventDefault();
-        handleDelete(selectedId);
+        if (mode === "trash") {
+          handleRestore(selectedId);
+        } else {
+          handleDelete(selectedId);
+        }
         return;
       }
 
@@ -45,6 +57,24 @@ function App() {
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   });
+
+  const handleRestore = (id: string) => {
+    if (id === selectedId) {
+      const idx = deletedSessions.findIndex((s) => s.id === id);
+      const remaining = deletedSessions.filter((_, i) => i !== idx);
+      const next = remaining[idx] ?? remaining[idx - 1] ?? null;
+      setSelectedId(next?.id ?? null);
+    }
+    void restore(id);
+    showToast({
+      message: "Session restored.",
+      actionLabel: "View",
+      onAction: () => {
+        setMode("main");
+        setSelectedId(id);
+      },
+    });
+  };
 
   const handleDelete = (id: string) => {
     if (id === selectedId) {
@@ -65,15 +95,23 @@ function App() {
     <div className="h-screen bg-background text-foreground">
       <ResizablePanelGroup orientation="horizontal">
         <ResizablePanel defaultSize={15} minSize={10}>
-          <FilterPanel deletedCount={deletedSessions.length} />
+          <FilterPanel
+            deletedCount={deletedSessions.length}
+            onOpenTrash={() => setMode("trash")}
+          />
         </ResizablePanel>
         <ResizableHandle />
         <ResizablePanel defaultSize={25} minSize={15}>
           <SessionList
-            sessions={mainSessions}
+            mode={mode}
+            sessions={visibleSessions}
             selectedId={selectedId}
             onSelect={setSelectedId}
             onDelete={handleDelete}
+            onRestore={handleRestore}
+            onBack={() => setMode("main")}
+            deletedCount={deletedSessions.length}
+            onOpenTrash={() => setMode("trash")}
           />
         </ResizablePanel>
         <ResizableHandle />
@@ -82,6 +120,7 @@ function App() {
             session={selectedSession}
             messages={messages}
             error={error}
+            onRestore={handleRestore}
           />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/web/src/components/ConversationView.tsx
+++ b/web/src/components/ConversationView.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { RotateCcw } from "lucide-react";
 import Markdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
@@ -11,6 +12,32 @@ interface ConversationViewProps {
   session: Session | null;
   messages: Message[];
   error?: string | null;
+  onRestore?: (id: string) => void;
+}
+
+function DeletedBanner({
+  sessionId,
+  onRestore,
+}: {
+  sessionId: string;
+  onRestore: (id: string) => void;
+}) {
+  return (
+    <div className="mx-5 mt-3 flex items-center justify-between gap-3 rounded-md border border-[#a13836] bg-[#3a1d23] px-4 py-2.5 text-sm">
+      <span className="text-foreground">
+        <strong className="text-destructive">This session is deleted.</strong>{" "}
+        It won't appear in your main list until restored.
+      </span>
+      <button
+        type="button"
+        onClick={() => onRestore(sessionId)}
+        className="flex shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+      >
+        <RotateCcw size={14} aria-hidden="true" />
+        Restore
+      </button>
+    </div>
+  );
 }
 
 function getProjectName(projectPath: string): string {
@@ -108,6 +135,7 @@ export function ConversationView({
   session,
   messages,
   error,
+  onRestore,
 }: ConversationViewProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -121,6 +149,9 @@ export function ConversationView({
   return (
     <div className="flex h-full flex-col">
       <ConversationHeader session={session} />
+      {session?.isDeleted && onRestore && (
+        <DeletedBanner sessionId={session.id} onRestore={onRestore} />
+      )}
       {error ? (
         <div
           data-testid="conversation-panel"

--- a/web/src/components/ConversationView.tsx
+++ b/web/src/components/ConversationView.tsx
@@ -3,13 +3,54 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import Markdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
-import type { Message, ContentBlock } from "@/types";
+import type { Message, ContentBlock, Session } from "@/types";
 import { CollapsibleThinking } from "./CollapsibleThinking";
 import { CollapsibleToolCall } from "./CollapsibleToolCall";
 
 interface ConversationViewProps {
+  session: Session | null;
   messages: Message[];
   error?: string | null;
+}
+
+function getProjectName(projectPath: string): string {
+  const segments = projectPath.split("/").filter(Boolean);
+  return segments[segments.length - 1] ?? projectPath;
+}
+
+function getRelativeTime(timestamp: number): string {
+  const now = Date.now();
+  const diffMs = now - timestamp;
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffDays > 0) return `${diffDays}d ago`;
+  if (diffHours > 0) return `${diffHours}h ago`;
+  if (diffMinutes > 0) return `${diffMinutes}m ago`;
+  return "just now";
+}
+
+function ConversationHeader({ session }: { session: Session | null }) {
+  return (
+    <div
+      data-testid="conversation-header"
+      className="flex h-12 shrink-0 items-center gap-4 border-b border-border px-5"
+    >
+      {session && (
+        <>
+          <div className="min-w-0 flex-1 truncate text-sm font-semibold text-accent-foreground">
+            {session.title}
+          </div>
+          <div className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
+            {getProjectName(session.project)} ·{" "}
+            {getRelativeTime(session.updatedAt)}
+          </div>
+        </>
+      )}
+    </div>
+  );
 }
 
 function MarkdownText({ children }: { children: string }) {
@@ -63,7 +104,11 @@ function MessageBubble({ message }: { message: Message }) {
   );
 }
 
-export function ConversationView({ messages, error }: ConversationViewProps) {
+export function ConversationView({
+  session,
+  messages,
+  error,
+}: ConversationViewProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const virtualizer = useVirtualizer({
@@ -73,50 +118,47 @@ export function ConversationView({ messages, error }: ConversationViewProps) {
     initialRect: { width: 800, height: 600 },
   });
 
-  if (error) {
-    return (
-      <div
-        data-testid="conversation-panel"
-        className="flex h-full items-center justify-center text-sm text-destructive"
-      >
-        {error}
-      </div>
-    );
-  }
-
-  if (messages.length === 0) {
-    return (
-      <div
-        data-testid="conversation-panel"
-        className="flex h-full items-center justify-center text-sm text-muted-foreground"
-      >
-        Select a session to view the conversation
-      </div>
-    );
-  }
-
   return (
-    <div
-      data-testid="conversation-panel"
-      ref={scrollContainerRef}
-      className="h-full overflow-y-auto p-6"
-    >
-      <div
-        className="relative flex flex-col"
-        style={{ height: `${virtualizer.getTotalSize()}px` }}
-      >
-        {virtualizer.getVirtualItems().map((virtualItem) => (
+    <div className="flex h-full flex-col">
+      <ConversationHeader session={session} />
+      {error ? (
+        <div
+          data-testid="conversation-panel"
+          className="flex flex-1 items-center justify-center text-sm text-destructive"
+        >
+          {error}
+        </div>
+      ) : messages.length === 0 ? (
+        <div
+          data-testid="conversation-panel"
+          className="flex flex-1 items-center justify-center text-sm text-muted-foreground"
+        >
+          Select a session to view the conversation
+        </div>
+      ) : (
+        <div
+          data-testid="conversation-panel"
+          ref={scrollContainerRef}
+          className="flex-1 overflow-y-auto p-6"
+        >
           <div
-            key={virtualItem.index}
-            data-index={virtualItem.index}
-            ref={virtualizer.measureElement}
-            className="absolute left-0 right-0 flex flex-col pb-4"
-            style={{ transform: `translateY(${virtualItem.start}px)` }}
+            className="relative flex flex-col"
+            style={{ height: `${virtualizer.getTotalSize()}px` }}
           >
-            <MessageBubble message={messages[virtualItem.index]} />
+            {virtualizer.getVirtualItems().map((virtualItem) => (
+              <div
+                key={virtualItem.index}
+                data-index={virtualItem.index}
+                ref={virtualizer.measureElement}
+                className="absolute left-0 right-0 flex flex-col pb-4"
+                style={{ transform: `translateY(${virtualItem.start}px)` }}
+              >
+                <MessageBubble message={messages[virtualItem.index]} />
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/FilterPanel.tsx
+++ b/web/src/components/FilterPanel.tsx
@@ -2,9 +2,10 @@ import { Trash } from "lucide-react";
 
 interface FilterPanelProps {
   deletedCount: number;
+  onOpenTrash: () => void;
 }
 
-export function FilterPanel({ deletedCount }: FilterPanelProps) {
+export function FilterPanel({ deletedCount, onOpenTrash }: FilterPanelProps) {
   return (
     <div data-testid="filter-panel" className="flex h-full flex-col">
       <div className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4 text-sm font-semibold text-foreground">
@@ -19,6 +20,7 @@ export function FilterPanel({ deletedCount }: FilterPanelProps) {
         <button
           type="button"
           data-testid="trash-link"
+          onClick={onOpenTrash}
           className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-card"
         >
           <span className="flex items-center gap-2">

--- a/web/src/components/FilterPanel.tsx
+++ b/web/src/components/FilterPanel.tsx
@@ -1,13 +1,34 @@
-export function FilterPanel() {
+import { Trash } from "lucide-react";
+
+interface FilterPanelProps {
+  deletedCount: number;
+}
+
+export function FilterPanel({ deletedCount }: FilterPanelProps) {
   return (
-    <div data-testid="filter-panel" className="flex h-full flex-col p-4">
-      <div className="flex items-center gap-2 text-base font-bold text-foreground">
-        <div className="h-5 w-5 rounded bg-primary" />
+    <div data-testid="filter-panel" className="flex h-full flex-col">
+      <div className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4 text-sm font-semibold text-foreground">
+        <div className="h-4 w-4 rounded bg-primary" />
         Chat Logbook
       </div>
-      <div className="mt-8 text-center text-sm text-muted-foreground">
+      <div className="flex-1 px-4 pt-8 text-center text-sm text-muted-foreground">
         Filters coming soon
         <div className="mt-1 text-xs">Projects, tags, search</div>
+      </div>
+      <div className="flex h-12 shrink-0 items-center border-t border-border px-2">
+        <button
+          type="button"
+          data-testid="trash-link"
+          className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-card"
+        >
+          <span className="flex items-center gap-2">
+            <Trash size={14} aria-hidden="true" />
+            Trash
+          </span>
+          <span className="rounded-full bg-card px-2 text-xs font-semibold tabular-nums text-muted-foreground">
+            {deletedCount}
+          </span>
+        </button>
       </div>
     </div>
   );

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,11 +1,17 @@
-import { Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { ArrowLeft, RotateCcw, Trash2 } from "lucide-react";
 import type { Session } from "@/types";
 
 interface SessionListProps {
+  mode?: "main" | "trash";
   sessions: Session[];
   selectedId: string | null;
   onSelect: (id: string) => void;
   onDelete: (id: string) => void;
+  onRestore?: (id: string) => void;
+  onBack?: () => void;
+  deletedCount?: number;
+  onOpenTrash?: () => void;
 }
 
 function getProjectName(projectPath: string): string {
@@ -27,52 +33,187 @@ function getRelativeTime(timestamp: number): string {
   return "just now";
 }
 
+interface ContextMenuState {
+  sessionId: string;
+  x: number;
+  y: number;
+}
+
 export function SessionList({
+  mode = "main",
   sessions,
   selectedId,
   onSelect,
   onDelete,
+  onRestore,
+  onBack,
+  deletedCount = 0,
+  onOpenTrash,
 }: SessionListProps) {
+  const isTrash = mode === "trash";
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+
+  useEffect(() => {
+    if (!contextMenu) return;
+    const close = () => setContextMenu(null);
+    document.addEventListener("click", close);
+    document.addEventListener("contextmenu", close);
+    return () => {
+      document.removeEventListener("click", close);
+      document.removeEventListener("contextmenu", close);
+    };
+  }, [contextMenu]);
+
+  const handleContextMenu = (e: React.MouseEvent, sessionId: string) => {
+    e.preventDefault();
+    setContextMenu({ sessionId, x: e.clientX, y: e.clientY });
+  };
+
   return (
     <div data-testid="session-list" className="flex h-full flex-col">
       <div className="flex h-12 shrink-0 items-center justify-between gap-3 border-b border-border px-4 text-sm">
-        <span className="font-semibold text-accent-foreground">Sessions</span>
-        <span className="text-xs text-muted-foreground">{sessions.length}</span>
-      </div>
-      <div className="flex-1 overflow-y-auto">
-        {sessions.map((session) => (
-          <div key={session.id} className="group relative">
-            <button
-              onClick={() => onSelect(session.id)}
-              className={`flex w-full flex-col gap-1 border-b border-border px-4 py-3 text-left transition-colors hover:bg-card ${
-                session.id === selectedId
-                  ? "border-l-2 border-l-primary bg-card"
-                  : "border-l-2 border-l-transparent"
-              }`}
-            >
-              <span className="truncate text-sm font-medium text-accent-foreground">
-                {session.title}
-              </span>
-              <span className="flex items-center justify-between text-xs text-muted-foreground">
-                <span className="truncate">
-                  {getProjectName(session.project)}
-                </span>
-                <span className="ml-2 shrink-0">
-                  {getRelativeTime(session.updatedAt)}
-                </span>
-              </span>
-            </button>
+        {isTrash ? (
+          <>
             <button
               type="button"
-              aria-label={`Delete session: ${session.title}`}
-              onClick={() => onDelete(session.id)}
-              className="absolute top-2 right-2 rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground opacity-0 shadow-sm transition-all hover:border-[#a13836] hover:bg-[#3a1d23] hover:text-destructive group-hover:opacity-100 focus:opacity-100"
+              onClick={onBack}
+              className="flex items-center gap-1 text-xs text-primary transition-colors hover:text-primary/80"
+            >
+              <ArrowLeft size={14} aria-hidden="true" />
+              Back
+            </button>
+            <span className="font-semibold text-accent-foreground">
+              Trash ({sessions.length})
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="font-semibold text-accent-foreground">
+              Sessions
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {sessions.length}
+            </span>
+          </>
+        )}
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {sessions.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center px-6 text-center text-sm text-muted-foreground">
+            {isTrash ? (
+              <>
+                <div className="font-medium text-foreground">
+                  Trash is empty
+                </div>
+                <div className="mt-1 text-xs">
+                  Deleted sessions appear here. They stay until you restore
+                  them.
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="font-medium text-foreground">No sessions</div>
+                {deletedCount > 0 && onOpenTrash && (
+                  <div className="mt-1 text-xs">
+                    Check{" "}
+                    <button
+                      type="button"
+                      onClick={onOpenTrash}
+                      className="text-primary hover:underline"
+                    >
+                      Trash ({deletedCount})
+                    </button>{" "}
+                    to restore deleted ones.
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        ) : (
+          sessions.map((session) => (
+            <div
+              key={session.id}
+              className="group relative"
+              onContextMenu={(e) => handleContextMenu(e, session.id)}
+            >
+              <button
+                onClick={() => onSelect(session.id)}
+                className={`flex w-full flex-col gap-1 border-b border-border px-4 py-3 text-left transition-colors hover:bg-card ${
+                  session.id === selectedId
+                    ? "border-l-2 border-l-primary bg-card"
+                    : "border-l-2 border-l-transparent"
+                }`}
+              >
+                <span className="truncate text-sm font-medium text-accent-foreground">
+                  {session.title}
+                </span>
+                <span className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span className="truncate">
+                    {getProjectName(session.project)}
+                  </span>
+                  <span className="ml-2 shrink-0">
+                    {getRelativeTime(session.updatedAt)}
+                  </span>
+                </span>
+              </button>
+              {isTrash && onRestore ? (
+                <button
+                  type="button"
+                  aria-label={`Restore session: ${session.title}`}
+                  onClick={() => onRestore(session.id)}
+                  className="absolute top-2 right-2 rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground opacity-0 shadow-sm transition-all hover:border-[#5f7a26] hover:bg-[#1f2e15] hover:text-[#859900] group-hover:opacity-100 focus:opacity-100"
+                >
+                  <RotateCcw size={14} aria-hidden="true" />
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  aria-label={`Delete session: ${session.title}`}
+                  onClick={() => onDelete(session.id)}
+                  className="absolute top-2 right-2 rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground opacity-0 shadow-sm transition-all hover:border-[#a13836] hover:bg-[#3a1d23] hover:text-destructive group-hover:opacity-100 focus:opacity-100"
+                >
+                  <Trash2 size={14} aria-hidden="true" />
+                </button>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+      {contextMenu && (
+        <div
+          role="menu"
+          className="fixed z-50 min-w-[180px] rounded-md border border-border bg-card py-1 text-sm shadow-lg"
+          style={{ top: contextMenu.y, left: contextMenu.x }}
+        >
+          {isTrash && onRestore ? (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                onRestore(contextMenu.sessionId);
+                setContextMenu(null);
+              }}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-accent"
+            >
+              <RotateCcw size={14} aria-hidden="true" />
+              Restore session
+            </button>
+          ) : (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                onDelete(contextMenu.sessionId);
+                setContextMenu(null);
+              }}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-destructive transition-colors hover:bg-[#3a1d23]"
             >
               <Trash2 size={14} aria-hidden="true" />
+              Delete session
             </button>
-          </div>
-        ))}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -31,34 +31,36 @@ export function SessionList({
   onSelect,
 }: SessionListProps) {
   return (
-    <div
-      data-testid="session-list"
-      className="flex h-full flex-col overflow-y-auto"
-    >
-      <div className="border-b border-border px-4 py-3 text-sm font-medium text-muted-foreground">
-        {sessions.length} sessions
+    <div data-testid="session-list" className="flex h-full flex-col">
+      <div className="flex h-12 shrink-0 items-center justify-between gap-3 border-b border-border px-4 text-sm">
+        <span className="font-semibold text-accent-foreground">Sessions</span>
+        <span className="text-xs text-muted-foreground">{sessions.length}</span>
       </div>
-      {sessions.map((session) => (
-        <button
-          key={session.id}
-          onClick={() => onSelect(session.id)}
-          className={`flex flex-col gap-1 border-b border-border px-4 py-3 text-left transition-colors hover:bg-card ${
-            session.id === selectedId
-              ? "border-l-2 border-l-primary bg-card"
-              : "border-l-2 border-l-transparent"
-          }`}
-        >
-          <span className="truncate text-sm font-medium text-accent-foreground">
-            {session.title}
-          </span>
-          <span className="flex items-center justify-between text-xs text-muted-foreground">
-            <span className="truncate">{getProjectName(session.project)}</span>
-            <span className="ml-2 shrink-0">
-              {getRelativeTime(session.updatedAt)}
+      <div className="flex-1 overflow-y-auto">
+        {sessions.map((session) => (
+          <button
+            key={session.id}
+            onClick={() => onSelect(session.id)}
+            className={`flex w-full flex-col gap-1 border-b border-border px-4 py-3 text-left transition-colors hover:bg-card ${
+              session.id === selectedId
+                ? "border-l-2 border-l-primary bg-card"
+                : "border-l-2 border-l-transparent"
+            }`}
+          >
+            <span className="truncate text-sm font-medium text-accent-foreground">
+              {session.title}
             </span>
-          </span>
-        </button>
-      ))}
+            <span className="flex items-center justify-between text-xs text-muted-foreground">
+              <span className="truncate">
+                {getProjectName(session.project)}
+              </span>
+              <span className="ml-2 shrink-0">
+                {getRelativeTime(session.updatedAt)}
+              </span>
+            </span>
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,9 +1,11 @@
+import { Trash2 } from "lucide-react";
 import type { Session } from "@/types";
 
 interface SessionListProps {
   sessions: Session[];
   selectedId: string | null;
   onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
 }
 
 function getProjectName(projectPath: string): string {
@@ -29,6 +31,7 @@ export function SessionList({
   sessions,
   selectedId,
   onSelect,
+  onDelete,
 }: SessionListProps) {
   return (
     <div data-testid="session-list" className="flex h-full flex-col">
@@ -38,27 +41,36 @@ export function SessionList({
       </div>
       <div className="flex-1 overflow-y-auto">
         {sessions.map((session) => (
-          <button
-            key={session.id}
-            onClick={() => onSelect(session.id)}
-            className={`flex w-full flex-col gap-1 border-b border-border px-4 py-3 text-left transition-colors hover:bg-card ${
-              session.id === selectedId
-                ? "border-l-2 border-l-primary bg-card"
-                : "border-l-2 border-l-transparent"
-            }`}
-          >
-            <span className="truncate text-sm font-medium text-accent-foreground">
-              {session.title}
-            </span>
-            <span className="flex items-center justify-between text-xs text-muted-foreground">
-              <span className="truncate">
-                {getProjectName(session.project)}
+          <div key={session.id} className="group relative">
+            <button
+              onClick={() => onSelect(session.id)}
+              className={`flex w-full flex-col gap-1 border-b border-border px-4 py-3 text-left transition-colors hover:bg-card ${
+                session.id === selectedId
+                  ? "border-l-2 border-l-primary bg-card"
+                  : "border-l-2 border-l-transparent"
+              }`}
+            >
+              <span className="truncate text-sm font-medium text-accent-foreground">
+                {session.title}
               </span>
-              <span className="ml-2 shrink-0">
-                {getRelativeTime(session.updatedAt)}
+              <span className="flex items-center justify-between text-xs text-muted-foreground">
+                <span className="truncate">
+                  {getProjectName(session.project)}
+                </span>
+                <span className="ml-2 shrink-0">
+                  {getRelativeTime(session.updatedAt)}
+                </span>
               </span>
-            </span>
-          </button>
+            </button>
+            <button
+              type="button"
+              aria-label={`Delete session: ${session.title}`}
+              onClick={() => onDelete(session.id)}
+              className="absolute top-2 right-2 rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground opacity-0 shadow-sm transition-all hover:border-[#a13836] hover:bg-[#3a1d23] hover:text-destructive group-hover:opacity-100 focus:opacity-100"
+            >
+              <Trash2 size={14} aria-hidden="true" />
+            </button>
+          </div>
         ))}
       </div>
     </div>

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,0 +1,34 @@
+import type { ToastState } from "@/hooks/useToast";
+
+interface ToastProps {
+  toast: ToastState | null;
+  onDismiss: () => void;
+}
+
+export function Toast({ toast, onDismiss }: ToastProps) {
+  if (!toast) return null;
+
+  const handleAction = () => {
+    toast.onAction?.();
+    onDismiss();
+  };
+
+  return (
+    <div
+      data-testid="toast"
+      role="status"
+      className="fixed top-4 left-1/2 z-50 flex -translate-x-1/2 items-center gap-4 rounded-md border border-border bg-card px-4 py-2.5 text-sm text-foreground shadow-lg"
+    >
+      <span>{toast.message}</span>
+      {toast.actionLabel && toast.onAction && (
+        <button
+          type="button"
+          onClick={handleAction}
+          className="text-xs font-semibold uppercase tracking-wide text-primary transition-colors hover:text-primary/80"
+        >
+          {toast.actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -1,7 +1,14 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Session } from "@/types";
 
-export function useSessions(): { sessions: Session[]; loading: boolean } {
+interface UseSessionsResult {
+  sessions: Session[];
+  loading: boolean;
+  softDelete: (id: string) => Promise<void>;
+  restore: (id: string) => Promise<void>;
+}
+
+export function useSessions(): UseSessionsResult {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -20,5 +27,23 @@ export function useSessions(): { sessions: Session[]; loading: boolean } {
       });
   }, []);
 
-  return { sessions, loading };
+  const softDelete = useCallback(async (id: string) => {
+    setSessions((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, isDeleted: true } : s))
+    );
+    await fetch(`/api/sessions/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    });
+  }, []);
+
+  const restore = useCallback(async (id: string) => {
+    setSessions((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, isDeleted: false } : s))
+    );
+    await fetch(`/api/sessions/${encodeURIComponent(id)}/restore`, {
+      method: "POST",
+    });
+  }, []);
+
+  return { sessions, loading, softDelete, restore };
 }

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -6,7 +6,7 @@ export function useSessions(): { sessions: Session[]; loading: boolean } {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("/api/sessions")
+    fetch("/api/sessions?includeDeleted=true")
       .then((res) => res.json())
       .then((data: { sessions: Session[] }) => {
         const sorted = [...data.sessions].sort(

--- a/web/src/hooks/useToast.ts
+++ b/web/src/hooks/useToast.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface ToastState {
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+interface UseToastResult {
+  toast: ToastState | null;
+  showToast: (toast: ToastState) => void;
+  dismissToast: () => void;
+}
+
+const TOAST_TIMEOUT_MS = 5000;
+
+export function useToast(): UseToastResult {
+  const [toast, setToast] = useState<ToastState | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const showToast = useCallback(
+    (next: ToastState) => {
+      clearTimer();
+      setToast(next);
+      timerRef.current = setTimeout(() => setToast(null), TOAST_TIMEOUT_MS);
+    },
+    [clearTimer]
+  );
+
+  const dismissToast = useCallback(() => {
+    clearTimer();
+    setToast(null);
+  }, [clearTimer]);
+
+  useEffect(() => clearTimer, [clearTimer]);
+
+  return { toast, showToast, dismissToast };
+}

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -9,7 +9,7 @@ type FakeSession = {
   isDeleted?: boolean;
 };
 
-export const fakeSessions: FakeSession[] = [
+const initialFakeSessions: FakeSession[] = [
   {
     id: "session-1",
     title: "Build a login page",
@@ -47,6 +47,12 @@ export const fakeSessions: FakeSession[] = [
     isDeleted: true,
   },
 ];
+
+export let fakeSessions: FakeSession[] = structuredClone(initialFakeSessions);
+
+export function resetFakeSessions(): void {
+  fakeSessions = structuredClone(initialFakeSessions);
+}
 
 export const fakeMessages = {
   "session-1": [
@@ -130,5 +136,23 @@ export const handlers = [
       return HttpResponse.json({ error: "Session not found" }, { status: 404 });
     }
     return HttpResponse.json({ messages });
+  }),
+  http.delete("/api/sessions/:id", ({ params }) => {
+    const id = params.id as string;
+    const session = fakeSessions.find((s) => s.id === id);
+    if (!session) {
+      return HttpResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+    session.isDeleted = true;
+    return new HttpResponse(null, { status: 204 });
+  }),
+  http.post("/api/sessions/:id/restore", ({ params }) => {
+    const id = params.id as string;
+    const session = fakeSessions.find((s) => s.id === id);
+    if (!session) {
+      return HttpResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+    session.isDeleted = false;
+    return new HttpResponse(null, { status: 204 });
   }),
 ];

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -1,6 +1,15 @@
 import { http, HttpResponse } from "msw";
 
-export const fakeSessions = [
+type FakeSession = {
+  id: string;
+  title: string;
+  project: string;
+  createdAt: number;
+  updatedAt: number;
+  isDeleted?: boolean;
+};
+
+export const fakeSessions: FakeSession[] = [
   {
     id: "session-1",
     title: "Build a login page",
@@ -28,6 +37,14 @@ export const fakeSessions = [
     project: "/Users/test/some-project",
     createdAt: 1699999900000,
     updatedAt: 1699999900000,
+  },
+  {
+    id: "session-deleted-1",
+    title: "Old prototype",
+    project: "/Users/test/my-web-app",
+    createdAt: 1699999000000,
+    updatedAt: 1699999500000,
+    isDeleted: true,
   },
 ];
 
@@ -98,8 +115,13 @@ export const fakeMessages = {
 };
 
 export const handlers = [
-  http.get("/api/sessions", () => {
-    return HttpResponse.json({ sessions: fakeSessions });
+  http.get("/api/sessions", ({ request }) => {
+    const url = new URL(request.url);
+    const includeDeleted = url.searchParams.get("includeDeleted") === "true";
+    const sessions = includeDeleted
+      ? fakeSessions
+      : fakeSessions.filter((s) => !s.isDeleted);
+    return HttpResponse.json({ sessions });
   }),
   http.get("/api/sessions/:id", ({ params }) => {
     const id = params.id as string;

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -84,6 +84,13 @@ export const fakeMessages = {
       timestamp: "2024-01-01T00:00:05Z",
     },
   ],
+  "session-deleted-1": [
+    {
+      role: "user",
+      content: "Quick prototype experiment",
+      timestamp: "2024-01-01T00:00:08Z",
+    },
+  ],
   "session-3": [
     {
       role: "user",

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterAll, afterEach, beforeAll } from "vitest";
+import { resetFakeSessions } from "./handlers";
 import { server } from "./server";
 
 // react-resizable-panels and @tanstack/react-virtual require ResizeObserver.
@@ -56,5 +57,6 @@ beforeAll(() => server.listen());
 afterEach(() => {
   cleanup();
   server.resetHandlers();
+  resetFakeSessions();
 });
 afterAll(() => server.close());

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -4,6 +4,7 @@ export interface Session {
   project: string;
   createdAt: number;
   updatedAt: number;
+  isDeleted?: boolean;
 }
 
 export type ContentBlock =


### PR DESCRIPTION
## Background (Why)

Set up the SQLite metadata layer and ship the first write feature — soft-deleting and restoring sessions — without ever touching the read-only `~/.claude/` source directory. Establishes the Drizzle ORM + better-sqlite3 + drizzle-kit migrations foundation that later write features (titles, tags, annotations) will build on.

## Approach (How)

- **Three stores stay separate.** Source files in `~/.claude/` remain read-only. User-owned metadata lives in a new `~/.chat-logbook/data.db` keyed by session ID.
- **Repository pattern** wraps all SQLite access. Drizzle-kit generates migrations from the schema; the app runs `migrate()` on startup so the DB file is created and upgraded automatically.
- **Endpoints follow GitHub/Stripe-style semantics.** `DELETE` / `restore` return 404 when the session ID is unknown to the source, 204 when the operation is a no-op (idempotent on already-deleted / never-deleted).
- **UI delivered TDD-style** as 11 vertical slices, ending with three bundled commits: column headers + Trash sidebar, soft-delete with undo toast and keyboard shortcuts, then full Trash mode with restore flow and empty states.

## Changes (What)

API:

- [x] `sessions_meta` table (drizzle schema + initial migration) at `~/.chat-logbook/data.db`
- [x] `MetadataRepository` interface and better-sqlite3 implementation
- [x] `DELETE /api/sessions/:id`, `POST /api/sessions/:id/restore`, `GET /api/sessions?includeDeleted=true`
- [x] tsup copies `drizzle/` into `dist/` on build; better-sqlite3 is externalized so its native binding is loaded at runtime

UI:

- [x] Equal-height (48px) headers across all three columns; new conversation header showing the selected session's title and project
- [x] Trash link at the bottom of the sidebar with a count badge
- [x] Hover-only delete chip on each row; right-click "Delete session" menu item
- [x] Auto-select next session on delete; top-center "Session deleted. Undo" toast (5s, single instance)
- [x] Backspace deletes the selected session; Cmd+Z undoes within the toast window; editable elements (input/textarea/contentEditable) are exempted
- [x] Trash mode replaces the middle column with deleted sessions sorted by deleted time; Back link returns to the main list; Esc also exits Trash
- [x] Red "This session is deleted." banner with Restore button when viewing a deleted session
- [x] Restore from banner / hover chip / Backspace; "Session restored. View" toast jumps to the restored session in the main list
- [x] Empty-state copy for both modes (Trash empty / no main sessions with hint to Trash)

## Test plan

- [x] `pnpm test` — 23 API tests + 42 web tests
- [x] `pnpm typecheck`
- [x] Manual QA in dev server: delete a session via hover chip, undo via toast, undo via Cmd+Z; enter Trash, restore via banner / row hover / Backspace, click View toast; Esc exits Trash; main empty state shows Trash hint

## Notes for reviewer

- `sessions_meta.updated_at` doubles as the deleted timestamp today. When future write features (tags, titles) start updating this row, we should add an explicit `deleted_at` column.
- UI color tokens for the destructive chip / banner use Solarized-tuned hex literals (`#a13836`, `#3a1d23`) instead of theme tokens. If the app ever supports light mode, these need to move into CSS variables.

## Related Links

- Closes #6