### PR TITLE
fix: declare better-sqlite3 as runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     ]
   },
   "dependencies": {
+    "better-sqlite3": "^12.9.0",
     "update-notifier": "^7.3.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      better-sqlite3:
+        specifier: ^12.9.0
+        version: 12.9.0
       update-notifier:
         specifier: ^7.3.1
         version: 7.3.1


### PR DESCRIPTION
## Background (Why)

v0.3.0 was published to npm but `npm install -g chat-logbook` followed by running `chat-log` fails immediately:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'better-sqlite3'
  imported from .../chat-logbook/api/dist/index.js
```

`api/tsup.config.ts` marks `better-sqlite3` as external (it's a native module that cannot be bundled), so the published package needs to declare it as a runtime dependency. The root `package.json` only listed `update-notifier`, so npm never installed `better-sqlite3` for end users.

## Approach (How)

Add `better-sqlite3` to the root `package.json` `dependencies`. The version is pinned to `^12.9.0` to match the version already in `api/package.json` and the resolved tree.

## Changes (What)

- [x] Add `better-sqlite3@^12.9.0` to root `dependencies`
- [x] Refresh `pnpm-lock.yaml`

### Test Verification

- [x] `pnpm run test` — all 65 tests pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm build && npm pack && npm install -g ./chat-logbook-0.3.0.tgz` — `chat-log` now starts successfully on http://localhost:3100

## Additional Notes

After this lands, cut v0.3.1 and `npm deprecate chat-logbook@0.3.0` with a message pointing users at the fixed release.