### PR TITLE
feat(archive): scaffold archive.db schema, migrations, and repository

### DIFF
--- a/api/drizzle.archive.config.ts
+++ b/api/drizzle.archive.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "sqlite",
+  schema: "./src/archive/schema.ts",
+  out: "./drizzle/archive",
+});

--- a/api/drizzle/archive/0000_first_gateway.sql
+++ b/api/drizzle/archive/0000_first_gateway.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `archive_meta` (
+	`id` integer PRIMARY KEY NOT NULL,
+	`archive_uuid` text NOT NULL,
+	`created_at` integer NOT NULL
+);

--- a/api/drizzle/archive/0001_gigantic_dracula.sql
+++ b/api/drizzle/archive/0001_gigantic_dracula.sql
@@ -1,0 +1,4 @@
+CREATE TABLE `schema_version` (
+	`version` integer PRIMARY KEY NOT NULL,
+	`applied_at` integer NOT NULL
+);

--- a/api/drizzle/archive/0002_fast_cloak.sql
+++ b/api/drizzle/archive/0002_fast_cloak.sql
@@ -1,0 +1,46 @@
+CREATE TABLE `ingestion_events` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`agent` text NOT NULL,
+	`session_id` text NOT NULL,
+	`source_path` text NOT NULL,
+	`event_type` text NOT NULL,
+	`detail` text NOT NULL,
+	`observed_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `messages` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`agent` text NOT NULL,
+	`session_id` text NOT NULL,
+	`message_id` text NOT NULL,
+	`role` text NOT NULL,
+	`ts` integer NOT NULL,
+	`text` text NOT NULL,
+	`blocks` text NOT NULL,
+	`raw_id` integer NOT NULL,
+	FOREIGN KEY (`raw_id`) REFERENCES `raw_messages`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `messages_canonical_idx` ON `messages` (`agent`,`session_id`,`message_id`);--> statement-breakpoint
+CREATE TABLE `raw_messages` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`agent` text NOT NULL,
+	`session_id` text NOT NULL,
+	`source_path` text NOT NULL,
+	`source_locator` text NOT NULL,
+	`raw_payload` text NOT NULL,
+	`payload_hash` text NOT NULL,
+	`ingested_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `raw_messages_idem_idx` ON `raw_messages` (`agent`,`session_id`,`payload_hash`);--> statement-breakpoint
+CREATE TABLE `sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`short_code` text NOT NULL,
+	`agent` text NOT NULL,
+	`source_session_id` text NOT NULL,
+	`first_seen_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `sessions_short_code_unique` ON `sessions` (`short_code`);--> statement-breakpoint
+CREATE UNIQUE INDEX `sessions_agent_source_idx` ON `sessions` (`agent`,`source_session_id`);

--- a/api/drizzle/archive/meta/0000_snapshot.json
+++ b/api/drizzle/archive/meta/0000_snapshot.json
@@ -1,0 +1,49 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d3a95e23-e94b-48eb-b47f-93125fb0c649",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "archive_meta": {
+      "name": "archive_meta",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archive_uuid": {
+          "name": "archive_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/api/drizzle/archive/meta/0001_snapshot.json
+++ b/api/drizzle/archive/meta/0001_snapshot.json
@@ -1,0 +1,73 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "037731f6-9a27-4a72-b757-9ac3c4cedf65",
+  "prevId": "d3a95e23-e94b-48eb-b47f-93125fb0c649",
+  "tables": {
+    "archive_meta": {
+      "name": "archive_meta",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archive_uuid": {
+          "name": "archive_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schema_version": {
+      "name": "schema_version",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/api/drizzle/archive/meta/0002_snapshot.json
+++ b/api/drizzle/archive/meta/0002_snapshot.json
@@ -1,0 +1,349 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cc9ed3dd-09fe-4c34-aef4-b1c07daabe89",
+  "prevId": "037731f6-9a27-4a72-b757-9ac3c4cedf65",
+  "tables": {
+    "archive_meta": {
+      "name": "archive_meta",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archive_uuid": {
+          "name": "archive_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ingestion_events": {
+      "name": "ingestion_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_id": {
+          "name": "raw_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "messages_canonical_idx": {
+          "name": "messages_canonical_idx",
+          "columns": ["agent", "session_id", "message_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "messages_raw_id_raw_messages_id_fk": {
+          "name": "messages_raw_id_raw_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "raw_messages",
+          "columnsFrom": ["raw_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "raw_messages": {
+      "name": "raw_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_locator": {
+          "name": "source_locator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "raw_messages_idem_idx": {
+          "name": "raw_messages_idem_idx",
+          "columns": ["agent", "session_id", "payload_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schema_version": {
+      "name": "schema_version",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_short_code_unique": {
+          "name": "sessions_short_code_unique",
+          "columns": ["short_code"],
+          "isUnique": true
+        },
+        "sessions_agent_source_idx": {
+          "name": "sessions_agent_source_idx",
+          "columns": ["agent", "source_session_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/api/drizzle/archive/meta/_journal.json
+++ b/api/drizzle/archive/meta/_journal.json
@@ -1,0 +1,27 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1778652457969,
+      "tag": "0000_first_gateway",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1778652620486,
+      "tag": "0001_gigantic_dracula",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1778652698986,
+      "tag": "0002_fast_cloak",
+      "breakpoints": true
+    }
+  ]
+}

--- a/api/package.json
+++ b/api/package.json
@@ -8,7 +8,8 @@
     "build": "tsup",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "db:generate": "drizzle-kit generate"
+    "db:generate": "drizzle-kit generate",
+    "db:generate:archive": "drizzle-kit generate --config drizzle.archive.config.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.11",

--- a/api/src/archive/repository.test.ts
+++ b/api/src/archive/repository.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createArchiveRepository } from "./repository.js";
+import { CROCKFORD_ALPHABET } from "./short-code.js";
+import { sessions } from "./schema.js";
+
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-archive-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("ArchiveRepository", () => {
+  it("creates archive.db and stores a single archive_meta row with a UUID v4 on first run", () => {
+    const repo = createArchiveRepository({ dataDir });
+
+    expect(fs.existsSync(path.join(dataDir, "archive.db"))).toBe(true);
+    expect(repo.getArchiveUuid()).toMatch(UUID_V4);
+
+    repo.close();
+  });
+
+  it("records applied migrations in schema_version", () => {
+    const repo = createArchiveRepository({ dataDir });
+
+    const applied = repo.getAppliedMigrations();
+    expect(applied.length).toBeGreaterThan(0);
+    for (const entry of applied) {
+      expect(entry.version).toBeTypeOf("number");
+      expect(entry.appliedAt).toBeInstanceOf(Date);
+    }
+
+    repo.close();
+  });
+
+  it("generateShortCode avoids existing sessions.short_code values", () => {
+    const repo = createArchiveRepository({ dataDir });
+    const allowed = new Set(CROCKFORD_ALPHABET);
+
+    const first = repo.generateShortCode();
+    expect(first).toHaveLength(6);
+    for (const ch of first) expect(allowed.has(ch)).toBe(true);
+
+    repo.db
+      .insert(sessions)
+      .values({
+        id: "id-1",
+        shortCode: first,
+        agent: "claude-code",
+        sourceSessionId: "a",
+        firstSeenAt: new Date(),
+      })
+      .run();
+
+    for (let i = 0; i < 20; i++) {
+      expect(repo.generateShortCode()).not.toBe(first);
+    }
+
+    repo.close();
+  });
+
+  it("preserves archive_uuid across repository instances", () => {
+    const first = createArchiveRepository({ dataDir });
+    const original = first.getArchiveUuid();
+    first.close();
+
+    const second = createArchiveRepository({ dataDir });
+    expect(second.getArchiveUuid()).toBe(original);
+    second.close();
+  });
+});

--- a/api/src/archive/repository.ts
+++ b/api/src/archive/repository.ts
@@ -1,0 +1,112 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import {
+  drizzle,
+  type BetterSQLite3Database,
+} from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { eq } from "drizzle-orm";
+import * as schema from "./schema.js";
+import { archiveMeta, schemaVersion, sessions } from "./schema.js";
+import { generateShortCode } from "./short-code.js";
+
+export type ArchiveDb = BetterSQLite3Database<typeof schema>;
+
+function resolveMigrationsFolder(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(here, "../../drizzle/archive"),
+    path.join(here, "./drizzle/archive"),
+  ];
+  const found = candidates.find((p) => fs.existsSync(p));
+  if (!found) {
+    throw new Error("Could not locate archive drizzle migrations folder");
+  }
+  return found;
+}
+
+export interface AppliedMigration {
+  version: number;
+  appliedAt: Date;
+}
+
+export interface ArchiveRepository {
+  readonly db: ArchiveDb;
+  getArchiveUuid(): string;
+  getAppliedMigrations(): AppliedMigration[];
+  generateShortCode(): string;
+  close(): void;
+}
+
+interface DrizzleMigrationRow {
+  id: number;
+  created_at: number;
+}
+
+interface RepositoryOptions {
+  dataDir: string;
+}
+
+export function createArchiveRepository({
+  dataDir,
+}: RepositoryOptions): ArchiveRepository {
+  fs.mkdirSync(dataDir, { recursive: true });
+  const sqlite = new Database(path.join(dataDir, "archive.db"));
+  const db: ArchiveDb = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: resolveMigrationsFolder() });
+
+  const drizzleMigrations = sqlite
+    .prepare("SELECT id, created_at FROM __drizzle_migrations ORDER BY id ASC")
+    .all() as DrizzleMigrationRow[];
+  for (const m of drizzleMigrations) {
+    db.insert(schemaVersion)
+      .values({ version: m.id, appliedAt: new Date(m.created_at) })
+      .onConflictDoNothing()
+      .run();
+  }
+
+  const existing = db.select().from(archiveMeta).get();
+  if (!existing) {
+    db.insert(archiveMeta)
+      .values({
+        id: 1,
+        archiveUuid: crypto.randomUUID(),
+        createdAt: new Date(),
+      })
+      .run();
+  }
+
+  return {
+    db,
+    getArchiveUuid() {
+      const row = db.select().from(archiveMeta).get();
+      if (!row) {
+        throw new Error("archive_meta row missing after initialization");
+      }
+      return row.archiveUuid;
+    },
+    getAppliedMigrations() {
+      return db
+        .select()
+        .from(schemaVersion)
+        .all()
+        .map((r) => ({ version: r.version, appliedAt: r.appliedAt }));
+    },
+    generateShortCode() {
+      return generateShortCode({
+        isTaken: (candidate) =>
+          db
+            .select({ id: sessions.id })
+            .from(sessions)
+            .where(eq(sessions.shortCode, candidate))
+            .get() !== undefined,
+      });
+    },
+    close() {
+      sqlite.close();
+    },
+  };
+}

--- a/api/src/archive/schema.test.ts
+++ b/api/src/archive/schema.test.ts
@@ -1,0 +1,236 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createArchiveRepository,
+  type ArchiveRepository,
+} from "./repository.js";
+import { ingestionEvents, messages, rawMessages, sessions } from "./schema.js";
+
+let dataDir: string;
+let repo: ArchiveRepository;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-archive-"));
+  repo = createArchiveRepository({ dataDir });
+});
+
+afterEach(() => {
+  repo.close();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("sessions table", () => {
+  it("round-trips a session row", () => {
+    const now = new Date();
+    repo.db
+      .insert(sessions)
+      .values({
+        id: "11111111-1111-4111-8111-111111111111",
+        shortCode: "abc234",
+        agent: "claude-code",
+        sourceSessionId: "src-1",
+        firstSeenAt: now,
+      })
+      .run();
+
+    const row = repo.db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.id, "11111111-1111-4111-8111-111111111111"))
+      .get();
+
+    expect(row).toMatchObject({
+      id: "11111111-1111-4111-8111-111111111111",
+      shortCode: "abc234",
+      agent: "claude-code",
+      sourceSessionId: "src-1",
+    });
+    expect(row?.firstSeenAt).toBeInstanceOf(Date);
+  });
+
+  it("rejects duplicate (agent, source_session_id)", () => {
+    const base = {
+      agent: "claude-code",
+      sourceSessionId: "dup",
+      firstSeenAt: new Date(),
+    };
+    repo.db
+      .insert(sessions)
+      .values({ ...base, id: "id-1", shortCode: "aaa111" })
+      .run();
+
+    expect(() =>
+      repo.db
+        .insert(sessions)
+        .values({ ...base, id: "id-2", shortCode: "bbb222" })
+        .run()
+    ).toThrow();
+  });
+
+  it("rejects duplicate short_code", () => {
+    const now = new Date();
+    repo.db
+      .insert(sessions)
+      .values({
+        id: "id-1",
+        shortCode: "same11",
+        agent: "claude-code",
+        sourceSessionId: "a",
+        firstSeenAt: now,
+      })
+      .run();
+
+    expect(() =>
+      repo.db
+        .insert(sessions)
+        .values({
+          id: "id-2",
+          shortCode: "same11",
+          agent: "claude-code",
+          sourceSessionId: "b",
+          firstSeenAt: now,
+        })
+        .run()
+    ).toThrow();
+  });
+});
+
+describe("raw_messages table", () => {
+  it("round-trips a raw_messages row", () => {
+    const now = new Date();
+    const inserted = repo.db
+      .insert(rawMessages)
+      .values({
+        agent: "claude-code",
+        sessionId: "src-1",
+        sourcePath: "/tmp/sess.jsonl",
+        sourceLocator: "line:42",
+        rawPayload: '{"role":"user","content":"hi"}',
+        payloadHash: "deadbeef",
+        ingestedAt: now,
+      })
+      .returning()
+      .get();
+
+    expect(inserted).toMatchObject({
+      agent: "claude-code",
+      sessionId: "src-1",
+      rawPayload: '{"role":"user","content":"hi"}',
+      payloadHash: "deadbeef",
+    });
+    expect(inserted.id).toBeTypeOf("number");
+  });
+
+  it("rejects duplicate (agent, session_id, payload_hash)", () => {
+    const base = {
+      agent: "claude-code",
+      sessionId: "src-1",
+      sourcePath: "/tmp/sess.jsonl",
+      sourceLocator: "line:42",
+      rawPayload: "{}",
+      payloadHash: "h1",
+      ingestedAt: new Date(),
+    };
+    repo.db.insert(rawMessages).values(base).run();
+
+    expect(() => repo.db.insert(rawMessages).values(base).run()).toThrow();
+  });
+});
+
+describe("messages table", () => {
+  it("round-trips a messages row referencing raw_messages", () => {
+    const raw = repo.db
+      .insert(rawMessages)
+      .values({
+        agent: "claude-code",
+        sessionId: "src-1",
+        sourcePath: "/tmp/sess.jsonl",
+        sourceLocator: "line:1",
+        rawPayload: "{}",
+        payloadHash: "h-1",
+        ingestedAt: new Date(),
+      })
+      .returning()
+      .get();
+
+    const ts = new Date();
+    repo.db
+      .insert(messages)
+      .values({
+        agent: "claude-code",
+        sessionId: "src-1",
+        messageId: "m-1",
+        role: "user",
+        ts,
+        text: "hello",
+        blocks: [{ type: "text", text: "hello" }],
+        rawId: raw.id,
+      })
+      .run();
+
+    const row = repo.db.select().from(messages).get();
+    expect(row).toMatchObject({
+      messageId: "m-1",
+      role: "user",
+      text: "hello",
+      rawId: raw.id,
+    });
+    expect(row?.blocks).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("rejects duplicate (agent, session_id, message_id)", () => {
+    const raw = repo.db
+      .insert(rawMessages)
+      .values({
+        agent: "claude-code",
+        sessionId: "src-1",
+        sourcePath: "/tmp/sess.jsonl",
+        sourceLocator: "line:1",
+        rawPayload: "{}",
+        payloadHash: "h-1",
+        ingestedAt: new Date(),
+      })
+      .returning()
+      .get();
+
+    const base = {
+      agent: "claude-code",
+      sessionId: "src-1",
+      messageId: "m-1",
+      role: "user",
+      ts: new Date(),
+      text: "x",
+      blocks: [],
+      rawId: raw.id,
+    };
+    repo.db.insert(messages).values(base).run();
+
+    expect(() => repo.db.insert(messages).values(base).run()).toThrow();
+  });
+});
+
+describe("ingestion_events table", () => {
+  it("round-trips an ingestion_events row", () => {
+    repo.db
+      .insert(ingestionEvents)
+      .values({
+        agent: "claude-code",
+        sessionId: "src-1",
+        sourcePath: "/tmp/sess.jsonl",
+        eventType: "unlinked",
+        detail: { reason: "file_removed" },
+        observedAt: new Date(),
+      })
+      .run();
+
+    const row = repo.db.select().from(ingestionEvents).get();
+    expect(row).toMatchObject({
+      agent: "claude-code",
+      eventType: "unlinked",
+    });
+    expect(row?.detail).toEqual({ reason: "file_removed" });
+  });
+});

--- a/api/src/archive/schema.ts
+++ b/api/src/archive/schema.ts
@@ -1,0 +1,82 @@
+import {
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+export const archiveMeta = sqliteTable("archive_meta", {
+  id: integer("id").primaryKey(),
+  archiveUuid: text("archive_uuid").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+});
+
+export const schemaVersion = sqliteTable("schema_version", {
+  version: integer("version").primaryKey(),
+  appliedAt: integer("applied_at", { mode: "timestamp_ms" }).notNull(),
+});
+
+export const sessions = sqliteTable(
+  "sessions",
+  {
+    id: text("id").primaryKey(),
+    shortCode: text("short_code").notNull().unique(),
+    agent: text("agent").notNull(),
+    sourceSessionId: text("source_session_id").notNull(),
+    firstSeenAt: integer("first_seen_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (t) => [
+    uniqueIndex("sessions_agent_source_idx").on(t.agent, t.sourceSessionId),
+  ]
+);
+
+export const rawMessages = sqliteTable(
+  "raw_messages",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    agent: text("agent").notNull(),
+    sessionId: text("session_id").notNull(),
+    sourcePath: text("source_path").notNull(),
+    sourceLocator: text("source_locator").notNull(),
+    rawPayload: text("raw_payload").notNull(),
+    payloadHash: text("payload_hash").notNull(),
+    ingestedAt: integer("ingested_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (t) => [
+    uniqueIndex("raw_messages_idem_idx").on(
+      t.agent,
+      t.sessionId,
+      t.payloadHash
+    ),
+  ]
+);
+
+export const messages = sqliteTable(
+  "messages",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    agent: text("agent").notNull(),
+    sessionId: text("session_id").notNull(),
+    messageId: text("message_id").notNull(),
+    role: text("role").notNull(),
+    ts: integer("ts", { mode: "timestamp_ms" }).notNull(),
+    text: text("text").notNull(),
+    blocks: text("blocks", { mode: "json" }).notNull(),
+    rawId: integer("raw_id")
+      .notNull()
+      .references(() => rawMessages.id),
+  },
+  (t) => [
+    uniqueIndex("messages_canonical_idx").on(t.agent, t.sessionId, t.messageId),
+  ]
+);
+
+export const ingestionEvents = sqliteTable("ingestion_events", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  agent: text("agent").notNull(),
+  sessionId: text("session_id").notNull(),
+  sourcePath: text("source_path").notNull(),
+  eventType: text("event_type").notNull(),
+  detail: text("detail", { mode: "json" }).notNull(),
+  observedAt: integer("observed_at", { mode: "timestamp_ms" }).notNull(),
+});

--- a/api/src/archive/short-code.test.ts
+++ b/api/src/archive/short-code.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { CROCKFORD_ALPHABET, generateShortCode } from "./short-code.js";
+
+const ALLOWED = new Set(CROCKFORD_ALPHABET);
+
+describe("generateShortCode", () => {
+  it("returns a 6-character string using only Crockford alphabet", () => {
+    for (let i = 0; i < 100; i++) {
+      const code = generateShortCode({ isTaken: () => false });
+      expect(code).toHaveLength(6);
+      for (const ch of code) {
+        expect(ALLOWED.has(ch)).toBe(true);
+      }
+    }
+  });
+
+  it("retries when isTaken reports a collision, returning the first free code", () => {
+    const sequences = [
+      [0, 0, 0, 0, 0, 0], // → "000000"
+      [1, 1, 1, 1, 1, 1], // → "111111"
+      [2, 2, 2, 2, 2, 2], // → "222222"
+    ];
+    let cursor = 0;
+    const randomIndex = (): number => {
+      const seq = sequences[Math.floor(cursor / 6)]!;
+      const value = seq[cursor % 6]!;
+      cursor++;
+      return value;
+    };
+    const taken = new Set(["000000", "111111"]);
+
+    const code = generateShortCode({
+      isTaken: (c) => taken.has(c),
+      randomIndex,
+    });
+
+    expect(code).toBe("222222");
+  });
+
+  it("throws when every retry collides", () => {
+    expect(() =>
+      generateShortCode({
+        isTaken: () => true,
+        randomIndex: () => 0,
+      })
+    ).toThrow(/short_code/);
+  });
+
+  it("excludes i, l, o, u from the alphabet", () => {
+    for (const banned of ["i", "l", "o", "u"]) {
+      expect(ALLOWED.has(banned)).toBe(false);
+    }
+    expect(CROCKFORD_ALPHABET).toHaveLength(32);
+  });
+});

--- a/api/src/archive/short-code.ts
+++ b/api/src/archive/short-code.ts
@@ -1,0 +1,29 @@
+import crypto from "node:crypto";
+
+export const CROCKFORD_ALPHABET = "0123456789abcdefghjkmnpqrstvwxyz";
+
+const SHORT_CODE_LENGTH = 6;
+const MAX_RETRIES = 5;
+
+export interface GenerateShortCodeOptions {
+  isTaken: (candidate: string) => boolean;
+  randomIndex?: () => number;
+}
+
+export function generateShortCode({
+  isTaken,
+  randomIndex = () => crypto.randomInt(CROCKFORD_ALPHABET.length),
+}: GenerateShortCodeOptions): string {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    let code = "";
+    for (let i = 0; i < SHORT_CODE_LENGTH; i++) {
+      code += CROCKFORD_ALPHABET[randomIndex()];
+    }
+    if (!isTaken(code)) {
+      return code;
+    }
+  }
+  throw new Error(
+    `Failed to generate unique short_code after ${MAX_RETRIES + 1} attempts`
+  );
+}


### PR DESCRIPTION
## Background (Why)

First PR in the Archive architecture milestone (#40). Lands the place future ingestion will write to and future reads will read from. No user-visible change until #45 flips the read path — this PR is pure scaffolding for that arc.

## Approach (How)

- Six Drizzle tables: `archive_meta`, `schema_version`, `sessions`, `raw_messages`, `messages`, `ingestion_events`, including UNIQUE constraints and the `messages → raw_messages` FK.
- `createArchiveRepository` opens `~/.chat-logbook/archive.db`, runs migrations, seeds a single `archive_meta` row with a UUID v4 on first run, and mirrors Drizzle's internal migration log into the public `schema_version` table.
- `generateShortCode` is a pure function (`api/src/archive/short-code.ts`) producing 6-char Crockford base32 codes; injected `isTaken` lets the repository retry against live `sessions.short_code` uniqueness.
- Archive uses a separate `drizzle.archive.config.ts` and `drizzle/archive/` migrations folder so it evolves independently from `data.db`.
- TDD: built slice-by-slice (RED→GREEN per behavior), no horizontal slicing. 16 new tests, 39 total passing.

## Changes (What)

- [x] `api/src/archive/schema.ts` — six tables with UNIQUE / FK
- [x] `api/src/archive/repository.ts` — migration runner, UUID seed, `schema_version` mirror, `generateShortCode` wired to the live sessions table
- [x] `api/src/archive/short-code.ts` — pure Crockford base32 generator with injectable randomness and 5-retry collision cap
- [x] `api/src/archive/{repository,schema,short-code}.test.ts` — 16 tests covering UUID init/persistence, migration bookkeeping, schema round-trips, UNIQUE enforcement, alphabet validity, retry behavior
- [x] `api/drizzle.archive.config.ts` + `api/drizzle/archive/000{0,1,2}_*.sql` — separate migration track from `data.db`
- [x] `api/package.json` — `db:generate:archive` script

## Test plan

- [x] `pnpm test` — 39/39 green (api 28, web 42 unchanged)
- [x] `pnpm typecheck` — clean
- [x] First-run behavior: `archive.db` is created, single `archive_meta` row holds a UUID v4
- [x] Second-run behavior: existing `archive_uuid` is preserved
- [x] UNIQUE constraints reject duplicates on `sessions(agent, source_session_id)`, `sessions(short_code)`, `raw_messages(agent, session_id, payload_hash)`, `messages(agent, session_id, message_id)`
- [x] `generateShortCode` avoids existing `sessions.short_code` values

## Notes

- No app wiring yet — `createArchiveRepository` is not called from `api/src/index.ts`. Next PR (#42) starts using it.
- Closes #40.