### PR TITLE
feat(metadata): rekey sessions_meta to internal UUID and add custom_title

### DIFF
--- a/api/drizzle/0001_rekey_sessions_meta.sql
+++ b/api/drizzle/0001_rekey_sessions_meta.sql
@@ -1,0 +1,18 @@
+PRAGMA foreign_keys=OFF;
+--> statement-breakpoint
+CREATE TABLE `__new_sessions_meta` (
+	`id` text PRIMARY KEY NOT NULL,
+	`is_deleted` integer DEFAULT false NOT NULL,
+	`custom_title` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_sessions_meta`("id", "is_deleted", "created_at", "updated_at")
+SELECT `session_id`, `is_deleted`, `created_at`, `updated_at` FROM `sessions_meta`;
+--> statement-breakpoint
+DROP TABLE `sessions_meta`;
+--> statement-breakpoint
+ALTER TABLE `__new_sessions_meta` RENAME TO `sessions_meta`;
+--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777980160883,
       "tag": "0000_safe_slapstick",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1778025600000,
+      "tag": "0001_rekey_sessions_meta",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/metadata/repository.test.ts
+++ b/api/src/metadata/repository.test.ts
@@ -44,4 +44,78 @@ describe("MetadataRepository", () => {
 
     expect(second.isDeleted("session-1")).toBe(true);
   });
+
+  it("returns null for custom title before it is set, and the stored value after", () => {
+    const repo = createMetadataRepository({ dataDir });
+
+    expect(repo.getCustomTitle("session-1")).toBeNull();
+
+    repo.setCustomTitle("session-1", "My renamed chat");
+
+    expect(repo.getCustomTitle("session-1")).toBe("My renamed chat");
+  });
+
+  it("rekeys legacy vendor-keyed rows to internal ids when archive lookup is provided", () => {
+    const legacy = createMetadataRepository({ dataDir });
+    legacy.softDelete("vendor-abc");
+    expect(legacy.isDeleted("vendor-abc")).toBe(true);
+
+    const reopened = createMetadataRepository({
+      dataDir,
+      lookupInternalId: (agent, sourceSessionId) =>
+        agent === "claude-code" && sourceSessionId === "vendor-abc"
+          ? "internal-xyz"
+          : null,
+      ensureSession: () => {
+        throw new Error("ensureSession should not be called when lookup hits");
+      },
+    });
+
+    expect(reopened.isDeleted("internal-xyz")).toBe(true);
+    expect(reopened.isDeleted("vendor-abc")).toBe(false);
+  });
+
+  it("creates a fresh archive session for legacy rows the archive does not know about", () => {
+    const legacy = createMetadataRepository({ dataDir });
+    legacy.softDelete("vendor-orphan");
+
+    const ensured: Array<{ agent: string; sourceSessionId: string }> = [];
+    const reopened = createMetadataRepository({
+      dataDir,
+      lookupInternalId: () => null,
+      ensureSession: (agent, sourceSessionId) => {
+        ensured.push({ agent, sourceSessionId });
+        return "internal-newly-created";
+      },
+    });
+
+    expect(ensured).toEqual([
+      { agent: "claude-code", sourceSessionId: "vendor-orphan" },
+    ]);
+    expect(reopened.isDeleted("internal-newly-created")).toBe(true);
+    expect(reopened.isDeleted("vendor-orphan")).toBe(false);
+  });
+
+  it("only runs the rekey migration once across multiple startups", () => {
+    const legacy = createMetadataRepository({ dataDir });
+    legacy.softDelete("vendor-x");
+
+    let ensureCalls = 0;
+    const reopen = () =>
+      createMetadataRepository({
+        dataDir,
+        lookupInternalId: (_agent, src) =>
+          src === "vendor-x" ? "internal-x" : null,
+        ensureSession: (_agent, src) => {
+          ensureCalls++;
+          return `ensured-${src}`;
+        },
+      });
+
+    reopen();
+    const third = reopen();
+
+    expect(ensureCalls).toBe(0);
+    expect(third.isDeleted("internal-x")).toBe(true);
+  });
 });

--- a/api/src/metadata/repository.ts
+++ b/api/src/metadata/repository.ts
@@ -24,65 +24,137 @@ function resolveMigrationsFolder(): string {
 }
 
 export interface MetadataRepository {
-  softDelete(sessionId: string): void;
-  restore(sessionId: string): void;
-  isDeleted(sessionId: string): boolean;
+  softDelete(internalId: string): void;
+  restore(internalId: string): void;
+  isDeleted(internalId: string): boolean;
   listDeletedIds(): string[];
+  getCustomTitle(internalId: string): string | null;
+  setCustomTitle(internalId: string, title: string | null): void;
 }
+
+export type LookupInternalId = (
+  agent: string,
+  sourceSessionId: string
+) => string | null;
+
+export type EnsureSession = (agent: string, sourceSessionId: string) => string;
 
 interface RepositoryOptions {
   dataDir: string;
+  lookupInternalId?: LookupInternalId;
+  ensureSession?: EnsureSession;
 }
+
+const CLAUDE_CODE_AGENT = "claude-code";
 
 export function createMetadataRepository({
   dataDir,
+  lookupInternalId,
+  ensureSession,
 }: RepositoryOptions): MetadataRepository {
   fs.mkdirSync(dataDir, { recursive: true });
   const sqlite = new Database(path.join(dataDir, "data.db"));
   const db: BetterSQLite3Database = drizzle(sqlite);
   migrate(db, { migrationsFolder: resolveMigrationsFolder() });
 
+  if (lookupInternalId) {
+    rekeyLegacyRows(sqlite, db, lookupInternalId, ensureSession);
+  }
+
   return {
-    softDelete(sessionId) {
+    softDelete(internalId) {
       const now = new Date();
       db.insert(sessionsMeta)
         .values({
-          sessionId,
+          id: internalId,
           isDeleted: true,
           createdAt: now,
           updatedAt: now,
         })
         .onConflictDoUpdate({
-          target: sessionsMeta.sessionId,
+          target: sessionsMeta.id,
           set: { isDeleted: true, updatedAt: now },
         })
         .run();
     },
 
-    restore(sessionId) {
+    restore(internalId) {
       const now = new Date();
       db.update(sessionsMeta)
         .set({ isDeleted: false, updatedAt: now })
-        .where(eq(sessionsMeta.sessionId, sessionId))
+        .where(eq(sessionsMeta.id, internalId))
         .run();
     },
 
-    isDeleted(sessionId) {
+    isDeleted(internalId) {
       const row = db
         .select({ isDeleted: sessionsMeta.isDeleted })
         .from(sessionsMeta)
-        .where(eq(sessionsMeta.sessionId, sessionId))
+        .where(eq(sessionsMeta.id, internalId))
         .get();
       return row?.isDeleted ?? false;
     },
 
     listDeletedIds() {
       const rows = db
-        .select({ sessionId: sessionsMeta.sessionId })
+        .select({ id: sessionsMeta.id })
         .from(sessionsMeta)
         .where(eq(sessionsMeta.isDeleted, true))
         .all();
-      return rows.map((r) => r.sessionId);
+      return rows.map((r) => r.id);
+    },
+
+    getCustomTitle(internalId) {
+      const row = db
+        .select({ customTitle: sessionsMeta.customTitle })
+        .from(sessionsMeta)
+        .where(eq(sessionsMeta.id, internalId))
+        .get();
+      return row?.customTitle ?? null;
+    },
+
+    setCustomTitle(internalId, title) {
+      const now = new Date();
+      db.insert(sessionsMeta)
+        .values({
+          id: internalId,
+          customTitle: title,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: sessionsMeta.id,
+          set: { customTitle: title, updatedAt: now },
+        })
+        .run();
     },
   };
+}
+
+const REKEY_USER_VERSION = 4;
+
+function rekeyLegacyRows(
+  sqlite: Database.Database,
+  db: BetterSQLite3Database,
+  lookupInternalId: LookupInternalId,
+  ensureSession: EnsureSession | undefined
+): void {
+  const current = sqlite.pragma("user_version", { simple: true }) as number;
+  if (current >= REKEY_USER_VERSION) return;
+
+  const rows = db.select({ id: sessionsMeta.id }).from(sessionsMeta).all();
+  for (const row of rows) {
+    let target = lookupInternalId(CLAUDE_CODE_AGENT, row.id);
+    if (target === null) {
+      if (!ensureSession) continue;
+      target = ensureSession(CLAUDE_CODE_AGENT, row.id);
+    }
+    if (target === row.id) continue;
+    db.update(sessionsMeta)
+      .set({ id: target, updatedAt: new Date() })
+      .where(eq(sessionsMeta.id, row.id))
+      .run();
+  }
+
+  sqlite.pragma(`user_version = ${REKEY_USER_VERSION}`);
 }

--- a/api/src/metadata/schema.ts
+++ b/api/src/metadata/schema.ts
@@ -1,10 +1,11 @@
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 export const sessionsMeta = sqliteTable("sessions_meta", {
-  sessionId: text("session_id").primaryKey(),
+  id: text("id").primaryKey(),
   isDeleted: integer("is_deleted", { mode: "boolean" })
     .notNull()
     .default(false),
+  customTitle: text("custom_title"),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
 });


### PR DESCRIPTION
## Background (Why)

Second PR in the Archive architecture milestone (#42), building on #40. We wants `data.db` keys against chat-logbook's internal session id (owned by `archive.db.sessions.id`), not the vendor's source session id — but today `data.db.sessions_meta` is still keyed by the vendor UUID, a holdover from before the archive existed. This PR brings the two stores into agreement and adds the `custom_title` column the rename-chat feature will sit on.

No user-visible change until #45 flips the read path — this is internal schema alignment to unblock #44 (ingestion) and #45 (read switch).

## Approach (How)

- Drizzle schema renames the PK from `session_id` to `id` and adds `custom_title TEXT NULL`. Migration `0001_rekey_sessions_meta.sql` uses the standard SQLite table-rebuild dance (`CREATE __new` → `INSERT ... SELECT` → `DROP` → `RENAME`) so existing rows survive the rebuild with their old vendor id values temporarily carried into the new `id` column.
- A separate JS-level rekey runs once on `createMetadataRepository` init when archive lookup callbacks are injected: for each surviving legacy row, `lookupInternalId('claude-code', row.id)` resolves to the chat-logbook internal id; a miss falls back to `ensureSession`, which lets the caller create the matching `archive.db.sessions` row. The row's PK is then updated in place.
- Idempotency is anchored on `PRAGMA user_version = 4`. After the rekey completes once the marker is set; subsequent startups short-circuit, which prevents drift in the steady-state (where row ids are internal UUIDs that wouldn't resolve via `lookupInternalId`).
- Repository interface renames the `sessionId` parameter to `internalId` (semantic, not just cosmetic — the contract is now "chat-logbook id, not vendor id") and grows `getCustomTitle` / `setCustomTitle`.
- TDD: 4 vertical RED→GREEN slices (custom title round-trip, rekey on lookup hit, rekey via `ensureSession` on lookup miss, idempotency across startups). 7 tests in `repository.test.ts`; 43 total api tests passing.

## Changes (What)

- [x] `api/src/metadata/schema.ts` — PK renamed `id`, added nullable `customTitle`
- [x] `api/src/metadata/repository.ts` — interface renamed to `internalId`, new `getCustomTitle`/`setCustomTitle`, injectable `lookupInternalId`/`ensureSession`, one-shot rekey guarded by `PRAGMA user_version`
- [x] `api/src/metadata/repository.test.ts` — 4 new tests covering custom title, rekey on hit, rekey on miss, idempotency
- [x] `api/drizzle/0001_rekey_sessions_meta.sql` — SQLite table-rebuild preserving existing rows
- [x] `api/drizzle/meta/_journal.json` — registers the new migration

### Test Verification

- [x] `pnpm -r test` — 85/85 green (api 43, web 42)
- [x] `pnpm -r typecheck` — clean
- [x] Fresh DB: repo init runs migrations cleanly with zero rows; no-op rekey
- [x] Populated DB, archive hit: legacy `vendor-x` row becomes `internal-x`; `isDeleted` state preserved
- [x] Populated DB, archive miss: `ensureSession` is called exactly once per orphan row; row rekeys to the returned id
- [x] Two consecutive startups: `ensureSession` is not re-invoked; `user_version` pins the migration

## Additional Notes

- **App layer is intentionally untouched.** `api/src/app.ts` still passes vendor ids straight through to the repository, because the `/api/sessions/:id/*` routes don't yet have an `archive.db` handle to bridge from vendor → internal. Wiring `createArchiveRepository` into app startup and switching the routes to internal ids lands with #44/#45, where the read path is rewritten anyway.
- **`drizzle-kit generate` was not run for this migration.** drizzle-kit needs an interactive TTY to disambiguate the `session_id → id` rename from a drop+add. The `.sql` file and `_journal.json` entry were hand-written; the runtime migrator (`migrate()`) only consumes those two, so this is functionally complete. A `meta/0001_snapshot.json` should be regenerated next time `pnpm db:generate` is run interactively, so future generates can diff cleanly.
- **No release from this PR.** Per the milestone plan, v0.4 ships once #45 flips the read path; #40–#44 are internal scaffolding.

## Related Links

- Closes #42