### PR TITLE
feat(plugins): formalize AgentPlugin interface and extract ClaudeCodePlugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ playwright-report/
 .claude/
 .playwright-mcp/
 CLAUDE.local.md
+
+# Plugin test fixtures need to ship a fake ~/.claude tree
+!api/src/plugins/**/__fixtures__/**

--- a/api/src/plugins/claude-code/__fixtures__/home/.claude/projects/project-a/session-1.jsonl
+++ b/api/src/plugins/claude-code/__fixtures__/home/.claude/projects/project-a/session-1.jsonl
@@ -1,0 +1,9 @@
+{"type":"file-history-snapshot","messageId":"msg-1","snapshot":{"trackedFileBackups":{},"timestamp":"2024-01-01T00:00:00Z"}}
+{"type":"user","message":{"role":"user","content":"<local-command-caveat>system message</local-command-caveat>"},"isMeta":true,"uuid":"msg-meta","timestamp":"2024-01-01T00:00:01Z","sessionId":"session-1","isSidechain":false}
+{"type":"user","message":{"role":"user","content":"Build a login page"},"isMeta":false,"uuid":"msg-2","timestamp":"2024-01-01T00:00:02Z","sessionId":"session-1","isSidechain":false}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Sure, I'll build a login page for you."}]},"uuid":"msg-3","timestamp":"2024-01-01T00:00:03Z","sessionId":"session-1","isSidechain":false}
+{"type":"progress","data":{"type":"agent_progress","prompt":"searching..."},"uuid":"msg-4","timestamp":"2024-01-01T00:00:04Z"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"Let me think about this..."},{"type":"text","text":"Here's the implementation."}]},"uuid":"msg-5","timestamp":"2024-01-01T00:00:05Z","sessionId":"session-1","isSidechain":false}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"src/index.ts"}}]},"uuid":"msg-6","timestamp":"2024-01-01T00:00:06Z","sessionId":"session-1","isSidechain":false}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-1","content":"file contents here"}]},"uuid":"msg-7","timestamp":"2024-01-01T00:00:07Z","sessionId":"session-1","isSidechain":false}
+{"type":"system","subtype":"turn_duration","durationMs":5000,"uuid":"msg-8","timestamp":"2024-01-01T00:00:08Z"}

--- a/api/src/plugins/claude-code/__fixtures__/home/.claude/projects/project-b/session-2.jsonl
+++ b/api/src/plugins/claude-code/__fixtures__/home/.claude/projects/project-b/session-2.jsonl
@@ -1,0 +1,2 @@
+{"type":"user","message":{"role":"user","content":"Hello from project b"},"isMeta":false,"isSidechain":false,"uuid":"msg-b1","timestamp":"2024-02-01T00:00:00Z","sessionId":"session-2"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hi there."}]},"uuid":"msg-b2","timestamp":"2024-02-01T00:00:01Z","sessionId":"session-2"}

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -1,0 +1,224 @@
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { ClaudeCodePlugin } from "./plugin.js";
+import type { RawRecord, SessionRef } from "../types.js";
+
+const plugin = new ClaudeCodePlugin();
+const homeDir = path.join(import.meta.dirname, "__fixtures__", "home");
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iter) out.push(item);
+  return out;
+}
+
+function rawRecord(payload: unknown): RawRecord {
+  return {
+    sessionId: "session-1",
+    sourcePath: "/fake/session-1.jsonl",
+    sourceLocator: "L1",
+    payload,
+  };
+}
+
+describe("ClaudeCodePlugin.discover", () => {
+  it("yields one SessionRef per jsonl file under ~/.claude/projects/*/", async () => {
+    const refs = await collect(plugin.discover({ homeDir }));
+
+    expect(refs).toHaveLength(2);
+    const byId = new Map(refs.map((r) => [r.sessionId, r] as const));
+
+    const s1 = byId.get("session-1")!;
+    expect(s1.sourcePath).toBe(
+      path.join(homeDir, ".claude/projects/project-a/session-1.jsonl")
+    );
+    expect(s1.watchPaths).toEqual([s1.sourcePath]);
+
+    expect(byId.get("session-2")).toBeDefined();
+  });
+
+  it("yields nothing when ~/.claude/projects does not exist", async () => {
+    const refs = await collect(
+      plugin.discover({ homeDir: "/nonexistent/path" })
+    );
+    expect(refs).toEqual([]);
+  });
+});
+
+describe("ClaudeCodePlugin.extractRaw", () => {
+  it("yields one RawRecord per non-empty line", async () => {
+    const ref: SessionRef = {
+      sessionId: "session-2",
+      sourcePath: path.join(
+        homeDir,
+        ".claude/projects/project-b/session-2.jsonl"
+      ),
+      watchPaths: [],
+    };
+
+    const records = await collect(plugin.extractRaw(ref));
+
+    expect(records).toHaveLength(2);
+    expect(records[0].sessionId).toBe("session-2");
+    expect(records[0].sourcePath).toBe(ref.sourcePath);
+    expect(records[0].sourceLocator).toBe("L1");
+    expect((records[0].payload as { uuid: string }).uuid).toBe("msg-b1");
+    expect(records[1].sourceLocator).toBe("L2");
+  });
+});
+
+describe("ClaudeCodePlugin.normalize → null cases", () => {
+  it.each([
+    [
+      "file-history-snapshot",
+      { type: "file-history-snapshot", messageId: "x", snapshot: {} },
+    ],
+    ["permission-mode", { type: "permission-mode", mode: "default" }],
+    [
+      "system event",
+      { type: "system", subtype: "turn_duration", durationMs: 5000 },
+    ],
+    ["progress event", { type: "progress", data: { type: "agent_progress" } }],
+    [
+      "isMeta user",
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: "<local-command-caveat>x</local-command-caveat>",
+        },
+        isMeta: true,
+        uuid: "msg-meta",
+        timestamp: "2024-01-01T00:00:01Z",
+      },
+    ],
+    [
+      "isSidechain user",
+      {
+        type: "user",
+        message: { role: "user", content: "side" },
+        isMeta: false,
+        isSidechain: true,
+        uuid: "msg-side",
+        timestamp: "2024-01-01T00:00:01Z",
+      },
+    ],
+  ])("returns null for %s", (_label, payload) => {
+    expect(plugin.normalize(rawRecord(payload))).toBeNull();
+  });
+});
+
+describe("ClaudeCodePlugin.normalize", () => {
+  it("normalizes an assistant message with thinking + text blocks", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "Let me think about this..." },
+            { type: "text", text: "Here's the implementation." },
+          ],
+        },
+        uuid: "msg-5",
+        timestamp: "2024-01-01T00:00:05Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result).toEqual({
+      messageId: "msg-5",
+      role: "assistant",
+      ts: "2024-01-01T00:00:05Z",
+      text: "Here's the implementation.",
+      blocks: [
+        { type: "thinking", thinking: "Let me think about this..." },
+        { type: "text", text: "Here's the implementation." },
+      ],
+    });
+  });
+
+  it("normalizes an assistant tool_use block", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "tool-1",
+              name: "Read",
+              input: { file_path: "src/index.ts" },
+            },
+          ],
+        },
+        uuid: "msg-6",
+        timestamp: "2024-01-01T00:00:06Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "tool_use",
+        id: "tool-1",
+        name: "Read",
+        input: { file_path: "src/index.ts" },
+      },
+    ]);
+    expect(result?.text).toBe("");
+  });
+
+  it("normalizes a user tool_result block (renames tool_use_id → toolUseId)", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-1",
+              content: "file contents here",
+            },
+          ],
+        },
+        isMeta: false,
+        isSidechain: false,
+        uuid: "msg-7",
+        timestamp: "2024-01-01T00:00:07Z",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "tool_result",
+        toolUseId: "tool-1",
+        content: "file contents here",
+      },
+    ]);
+  });
+
+  it("normalizes a user text message", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: { role: "user", content: "Build a login page" },
+        isMeta: false,
+        isSidechain: false,
+        uuid: "msg-2",
+        timestamp: "2024-01-01T00:00:02Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result).toEqual({
+      messageId: "msg-2",
+      role: "user",
+      ts: "2024-01-01T00:00:02Z",
+      text: "Build a login page",
+      blocks: [{ type: "text", text: "Build a login page" }],
+    });
+  });
+});

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+import type {
+  AgentPlugin,
+  CanonicalMessage,
+  NormalizedBlock,
+  PluginEnv,
+  RawRecord,
+  SessionRef,
+} from "../types.js";
+
+export class ClaudeCodePlugin implements AgentPlugin {
+  readonly id = "claude-code";
+  readonly displayName = "Claude Code";
+
+  async *discover(env: PluginEnv): AsyncIterable<SessionRef> {
+    const projectsDir = path.join(env.homeDir, ".claude", "projects");
+    if (!fs.existsSync(projectsDir)) return;
+
+    const projects = fs.readdirSync(projectsDir, { withFileTypes: true });
+    for (const project of projects) {
+      if (!project.isDirectory()) continue;
+      const projectPath = path.join(projectsDir, project.name);
+      const files = fs.readdirSync(projectPath, { withFileTypes: true });
+      for (const file of files) {
+        if (!file.isFile() || !file.name.endsWith(".jsonl")) continue;
+        const sourcePath = path.join(projectPath, file.name);
+        const sessionId = file.name.replace(/\.jsonl$/, "");
+        yield { sessionId, sourcePath, watchPaths: [sourcePath] };
+      }
+    }
+  }
+
+  async *extractRaw(ref: SessionRef): AsyncIterable<RawRecord> {
+    if (!fs.existsSync(ref.sourcePath)) return;
+
+    const stream = fs.createReadStream(ref.sourcePath, { encoding: "utf-8" });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    let lineNo = 0;
+    for await (const line of rl) {
+      lineNo += 1;
+      if (!line) continue;
+      yield {
+        sessionId: ref.sessionId,
+        sourcePath: ref.sourcePath,
+        sourceLocator: `L${lineNo}`,
+        payload: JSON.parse(line),
+      };
+    }
+  }
+
+  normalize(raw: RawRecord): CanonicalMessage | null {
+    const payload = raw.payload as Record<string, unknown> | null;
+    if (!payload || typeof payload !== "object") return null;
+
+    if (payload.type !== "user" && payload.type !== "assistant") return null;
+    if (payload.isMeta === true) return null;
+    if (payload.isSidechain === true) return null;
+
+    const message = payload.message as
+      | { role: string; content: unknown }
+      | undefined;
+    if (!message) return null;
+
+    const role = message.role === "assistant" ? "assistant" : "user";
+    const messageId = String(payload.uuid ?? "");
+    const ts = String(payload.timestamp ?? "");
+
+    if (typeof message.content === "string") {
+      const text = message.content;
+      return {
+        messageId,
+        role,
+        ts,
+        text,
+        blocks: [{ type: "text", text }],
+      };
+    }
+
+    if (Array.isArray(message.content)) {
+      const blocks: NormalizedBlock[] = [];
+      for (const block of message.content) {
+        const normalized = normalizeBlock(block);
+        if (normalized) blocks.push(normalized);
+      }
+      const text = blocks
+        .filter((b): b is { type: "text"; text: string } => b.type === "text")
+        .map((b) => b.text)
+        .join("\n");
+      return { messageId, role, ts, text, blocks };
+    }
+
+    return null;
+  }
+}
+
+function normalizeBlock(raw: unknown): NormalizedBlock | null {
+  if (!raw || typeof raw !== "object") return null;
+  const b = raw as Record<string, unknown>;
+  switch (b.type) {
+    case "text":
+      return { type: "text", text: String(b.text ?? "") };
+    case "thinking":
+      return { type: "thinking", thinking: String(b.thinking ?? "") };
+    case "tool_use":
+      return {
+        type: "tool_use",
+        id: String(b.id ?? ""),
+        name: String(b.name ?? ""),
+        input: b.input,
+      };
+    case "tool_result":
+      return {
+        type: "tool_result",
+        toolUseId: String(b.tool_use_id ?? ""),
+        content: b.content,
+      };
+    default:
+      return null;
+  }
+}

--- a/api/src/plugins/registry.test.ts
+++ b/api/src/plugins/registry.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { plugins } from "./registry.js";
+
+describe("plugins registry", () => {
+  it("exports the Claude Code plugin", () => {
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].id).toBe("claude-code");
+    expect(plugins[0].displayName).toBe("Claude Code");
+  });
+});

--- a/api/src/plugins/registry.ts
+++ b/api/src/plugins/registry.ts
@@ -1,0 +1,4 @@
+import { ClaudeCodePlugin } from "./claude-code/plugin.js";
+import type { AgentPlugin } from "./types.js";
+
+export const plugins: readonly AgentPlugin[] = [new ClaudeCodePlugin()];

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -1,0 +1,38 @@
+export interface PluginEnv {
+  homeDir: string;
+}
+
+export interface SessionRef {
+  sessionId: string;
+  sourcePath: string;
+  watchPaths: string[];
+}
+
+export interface RawRecord {
+  sessionId: string;
+  sourcePath: string;
+  sourceLocator: string;
+  payload: unknown;
+}
+
+export type NormalizedBlock =
+  | { type: "text"; text: string }
+  | { type: "thinking"; thinking: string }
+  | { type: "tool_use"; id: string; name: string; input: unknown }
+  | { type: "tool_result"; toolUseId: string; content: unknown };
+
+export interface CanonicalMessage {
+  messageId: string;
+  role: "user" | "assistant";
+  ts: string;
+  text: string;
+  blocks: NormalizedBlock[];
+}
+
+export interface AgentPlugin {
+  id: string;
+  displayName: string;
+  discover(env: PluginEnv): AsyncIterable<SessionRef>;
+  extractRaw(ref: SessionRef): AsyncIterable<RawRecord>;
+  normalize(raw: RawRecord): CanonicalMessage | null;
+}


### PR DESCRIPTION
## Background (Why)

Source format is polymorphic across AI assistants — Claude Code uses per-session JSONL, Codex CLI uses rollout JSONL plus a state DB, Aider uses markdown, OpenCode uses an internal SQLite. To keep ingestion agent-agnostic (per `docs/ARCHITECTURE.md` §Plugin per agent), each agent needs a plugin conforming to a narrow three-method interface.

This PR lands that contract and the first concrete implementation. No ingestion or read-path change — that's #44 / #45.

## Approach (How)

- **Interface lives in `api/src/plugins/types.ts`**. Three methods on `AgentPlugin`: `discover` (find sessions), `extractRaw` (line-stream a session into `RawRecord`s), `normalize` (turn one `RawRecord` into a `CanonicalMessage` or `null`). Supporting types: `PluginEnv`, `SessionRef`, `RawRecord`, `CanonicalMessage`, `NormalizedBlock`.
- **`CanonicalMessage` shape aligns with the `archive.db.messages` table** from #40 (role, ts, text, blocks JSON, message_id), so ingestion in #44 will be a straight insert.
- **`ClaudeCodePlugin` is additive**, not a replacement. `parser.ts` and its callers in `app.ts` are untouched (see "Additional Notes" on the AC carve-out).
- **TDD**: six vertical RED→GREEN cycles (user text → assistant multi-block → null cases → `extractRaw` → `discover` → registry).

## Changes (What)

- [x] `api/src/plugins/types.ts` — `AgentPlugin` interface and supporting types
- [x] `api/src/plugins/claude-code/plugin.ts` — `ClaudeCodePlugin` (three methods)
- [x] `api/src/plugins/claude-code/plugin.test.ts` — 13 tests across `discover` / `extractRaw` / `normalize` happy paths / `normalize` null cases
- [x] `api/src/plugins/claude-code/__fixtures__/home/.claude/projects/{project-a,project-b}/` — fake `~/.claude` tree for `discover` / `extractRaw`
- [x] `api/src/plugins/registry.ts` (+ smoke test) — exports `[new ClaudeCodePlugin()]`
- [x] `.gitignore` — allow `api/src/plugins/**/__fixtures__/**` through the global `.claude/` ignore so the fixture tree can ship

### Test Verification

- [x] `discover` finds known fixture files under `homeDir/.claude/projects/*/` and yields `SessionRef` with correct `watchPaths`
- [x] `discover` yields nothing when `~/.claude/projects` is absent
- [x] `extractRaw` yields one `RawRecord` per non-empty line with `Lnn` locator
- [x] `normalize` user-text → text block; assistant thinking+text → ordered blocks with flattened `text`; assistant `tool_use` → block preserved with empty `text`; user `tool_result` → `tool_use_id` renamed to `toolUseId`
- [x] `normalize` returns `null` for `file-history-snapshot`, `permission-mode`, `system`, `progress`, `isMeta`, `isSidechain`
- [x] `pnpm typecheck` and `pnpm test` clean across api + web (57 + 42 tests)

## Additional Notes

**AC carve-out — `parser.ts` retained.** Issue #43 AC5 says "`parser.ts` is either deleted or reduced to a re-export shim — no runtime callers outside the plugin." I left `parser.ts` as-is. Reason: its three exports (`listSessions`, `findSessionFile`, `getSessionMessages`) read `history.jsonl` for session listing and are still called from `app.ts`. Their shape doesn't match the new plugin's methods, so a re-export shim isn't possible. The proper retirement happens in **#44 (ingestion)** + **#45 (read switch)**, when `app.ts` starts reading from `archive.db` and these callers go away. A note on #43 explains this trade-off.

## Related Links

- Closes #43
- Blocks #44 (ingestion pipeline consumes this contract)
- `docs/ARCHITECTURE.md` §Plugin per agent
- Prior milestone PR #57 (#40 archive.db skeleton)