### PR TITLE
feat(ingestion): on-app-open scan writes to archive.db

### DIFF
--- a/api/drizzle/archive/0003_ordinary_blackheart.sql
+++ b/api/drizzle/archive/0003_ordinary_blackheart.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `session_scan_state` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`agent` text NOT NULL,
+	`session_id` text NOT NULL,
+	`source_path` text NOT NULL,
+	`last_mtime_ms` integer NOT NULL,
+	`last_size_bytes` integer NOT NULL,
+	`last_scanned_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `session_scan_state_idx` ON `session_scan_state` (`agent`,`session_id`);

--- a/api/drizzle/archive/meta/0003_snapshot.json
+++ b/api/drizzle/archive/meta/0003_snapshot.json
@@ -1,0 +1,414 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d01e963b-2adc-4d76-a2d0-972d82eeba69",
+  "prevId": "cc9ed3dd-09fe-4c34-aef4-b1c07daabe89",
+  "tables": {
+    "archive_meta": {
+      "name": "archive_meta",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archive_uuid": {
+          "name": "archive_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ingestion_events": {
+      "name": "ingestion_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_id": {
+          "name": "raw_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "messages_canonical_idx": {
+          "name": "messages_canonical_idx",
+          "columns": ["agent", "session_id", "message_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "messages_raw_id_raw_messages_id_fk": {
+          "name": "messages_raw_id_raw_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "raw_messages",
+          "columnsFrom": ["raw_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "raw_messages": {
+      "name": "raw_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_locator": {
+          "name": "source_locator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "raw_messages_idem_idx": {
+          "name": "raw_messages_idem_idx",
+          "columns": ["agent", "session_id", "payload_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schema_version": {
+      "name": "schema_version",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_scan_state": {
+      "name": "session_scan_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_mtime_ms": {
+          "name": "last_mtime_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_size_bytes": {
+          "name": "last_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_scan_state_idx": {
+          "name": "session_scan_state_idx",
+          "columns": ["agent", "session_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_short_code_unique": {
+          "name": "sessions_short_code_unique",
+          "columns": ["short_code"],
+          "isUnique": true
+        },
+        "sessions_agent_source_idx": {
+          "name": "sessions_agent_source_idx",
+          "columns": ["agent", "source_session_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/api/drizzle/archive/meta/_journal.json
+++ b/api/drizzle/archive/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1778652698986,
       "tag": "0002_fast_cloak",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1778668305874,
+      "tag": "0003_ordinary_blackheart",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/archive/schema.ts
+++ b/api/src/archive/schema.ts
@@ -71,6 +71,22 @@ export const messages = sqliteTable(
   ]
 );
 
+export const sessionScanState = sqliteTable(
+  "session_scan_state",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    agent: text("agent").notNull(),
+    sessionId: text("session_id").notNull(),
+    sourcePath: text("source_path").notNull(),
+    lastMtimeMs: integer("last_mtime_ms").notNull(),
+    lastSizeBytes: integer("last_size_bytes").notNull(),
+    lastScannedAt: integer("last_scanned_at", {
+      mode: "timestamp_ms",
+    }).notNull(),
+  },
+  (t) => [uniqueIndex("session_scan_state_idx").on(t.agent, t.sessionId)]
+);
+
 export const ingestionEvents = sqliteTable("ingestion_events", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   agent: text("agent").notNull(),

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -6,6 +6,9 @@ import { fileURLToPath } from "node:url";
 import { serve } from "@hono/node-server";
 import updateNotifier from "update-notifier";
 import { createApp } from "./app.js";
+import { createArchiveRepository } from "./archive/repository.js";
+import { startIngestionInBackground } from "./ingestion/background.js";
+import { plugins } from "./plugins/registry.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkgPath = path.join(__dirname, "../../package.json");
@@ -21,6 +24,13 @@ const dataDir = path.join(os.homedir(), ".chat-logbook");
 const webDistDir = path.join(__dirname, "../../web/dist");
 const app = createApp({ claudeDir, dataDir, webDistDir });
 const port = Number(process.env.PORT) || 3100;
+
+const archive = createArchiveRepository({ dataDir });
+startIngestionInBackground({
+  plugins,
+  archive,
+  env: { homeDir: os.homedir() },
+});
 
 function openBrowser(url: string): void {
   const cmd =

--- a/api/src/ingestion/background.test.ts
+++ b/api/src/ingestion/background.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { startIngestionInBackground } from "./background.js";
+import type { IngestOptions, IngestResult } from "./ingest.js";
+
+describe("startIngestionInBackground", () => {
+  it("returns synchronously before ingestion finishes and resolves done with the result", async () => {
+    let resolveIngest: (r: IngestResult) => void = () => {};
+    const ingestPromise = new Promise<IngestResult>((res) => {
+      resolveIngest = res;
+    });
+    const runner = vi.fn(() => ingestPromise);
+
+    const start = performance.now();
+    const handle = startIngestionInBackground({} as IngestOptions, { runner });
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(20);
+    expect(runner).toHaveBeenCalledTimes(1);
+
+    resolveIngest({
+      scanned: 1,
+      rawInserted: 2,
+      canonicalUpserted: 3,
+      skippedByMtime: 0,
+    });
+
+    await expect(handle.done).resolves.toMatchObject({ rawInserted: 2 });
+  });
+
+  it("swallows runner rejections via onError instead of unhandled rejection", async () => {
+    const err = new Error("boom");
+    const runner = vi.fn(() => Promise.reject(err));
+    const onError = vi.fn();
+
+    const handle = startIngestionInBackground({} as IngestOptions, {
+      runner,
+      onError,
+    });
+
+    await handle.done;
+    expect(onError).toHaveBeenCalledWith(err);
+  });
+});

--- a/api/src/ingestion/background.ts
+++ b/api/src/ingestion/background.ts
@@ -1,0 +1,35 @@
+import {
+  runIngestion,
+  type IngestOptions,
+  type IngestResult,
+} from "./ingest.js";
+
+export interface BackgroundIngestionHandle {
+  done: Promise<IngestResult | null>;
+}
+
+export interface BackgroundOptions {
+  runner?: (opts: IngestOptions) => Promise<IngestResult>;
+  onError?: (err: unknown) => void;
+}
+
+export function startIngestionInBackground(
+  opts: IngestOptions,
+  bg: BackgroundOptions = {}
+): BackgroundIngestionHandle {
+  const runner = bg.runner ?? runIngestion;
+  const onError =
+    bg.onError ??
+    ((err: unknown) => {
+      console.error("[ingestion] background run failed:", err);
+    });
+
+  const done = runner(opts)
+    .then((r): IngestResult | null => r)
+    .catch((err): IngestResult | null => {
+      onError(err);
+      return null;
+    });
+
+  return { done };
+}

--- a/api/src/ingestion/ingest.test.ts
+++ b/api/src/ingestion/ingest.test.ts
@@ -1,0 +1,300 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createArchiveRepository } from "../archive/repository.js";
+import { messages, rawMessages, sessions } from "../archive/schema.js";
+import { ClaudeCodePlugin } from "../plugins/claude-code/plugin.js";
+import { runIngestion } from "./ingest.js";
+
+const fixturesRoot = path.join(__dirname, "../__fixtures__/projects");
+
+interface Env {
+  dataDir: string;
+  homeDir: string;
+}
+
+function setupEnv(): Env {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-ingest-"));
+  const dataDir = path.join(tmp, "data");
+  const homeDir = path.join(tmp, "home");
+  const claudeProjects = path.join(homeDir, ".claude", "projects");
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(claudeProjects, { recursive: true });
+  fs.cpSync(fixturesRoot, claudeProjects, { recursive: true });
+  return { dataDir, homeDir };
+}
+
+let env: Env;
+
+beforeEach(() => {
+  env = setupEnv();
+});
+
+afterEach(() => {
+  fs.rmSync(path.dirname(env.dataDir), { recursive: true, force: true });
+});
+
+describe("runIngestion", () => {
+  it("populates archive.db sessions, raw_messages, and messages from source on first run", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+
+    const result = await runIngestion({
+      plugins: [new ClaudeCodePlugin()],
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+
+    expect(result.scanned).toBeGreaterThan(0);
+    expect(result.rawInserted).toBeGreaterThan(0);
+    expect(result.canonicalUpserted).toBeGreaterThan(0);
+
+    const sessionRows = archive.db.select().from(sessions).all();
+    const rawRows = archive.db.select().from(rawMessages).all();
+    const msgRows = archive.db.select().from(messages).all();
+
+    expect(sessionRows.length).toBeGreaterThan(0);
+    expect(rawRows.length).toBeGreaterThan(0);
+    expect(msgRows.length).toBeGreaterThan(0);
+    expect(msgRows.length).toBeLessThanOrEqual(rawRows.length);
+
+    for (const s of sessionRows) {
+      expect(s.agent).toBe("claude-code");
+      expect(s.shortCode).toHaveLength(6);
+    }
+
+    archive.close();
+  });
+
+  it("is a no-op on second run: zero new raw rows and row counts unchanged", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const pluginsList = [new ClaudeCodePlugin()];
+
+    const first = await runIngestion({
+      plugins: pluginsList,
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+    const rawBefore = archive.db.select().from(rawMessages).all().length;
+    const msgBefore = archive.db.select().from(messages).all().length;
+    const sessBefore = archive.db.select().from(sessions).all().length;
+
+    const second = await runIngestion({
+      plugins: pluginsList,
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+
+    expect(first.rawInserted).toBeGreaterThan(0);
+    expect(second.rawInserted).toBe(0);
+    expect(archive.db.select().from(rawMessages).all().length).toBe(rawBefore);
+    expect(archive.db.select().from(messages).all().length).toBe(msgBefore);
+    expect(archive.db.select().from(sessions).all().length).toBe(sessBefore);
+
+    archive.close();
+  });
+
+  it("appends a new raw row when source content at the same line changes", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const pluginsList = [new ClaudeCodePlugin()];
+
+    await runIngestion({
+      plugins: pluginsList,
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+    const rawBefore = archive.db.select().from(rawMessages).all();
+
+    // Edit a line in the source: same line number, different payload.
+    const sourceFile = path.join(
+      env.homeDir,
+      ".claude",
+      "projects",
+      "project-a",
+      "session-1.jsonl"
+    );
+    const lines = fs.readFileSync(sourceFile, "utf-8").split("\n");
+    // Find a real user message line and tweak its content.
+    const idx = lines.findIndex(
+      (l) => l.includes('"role":"user"') && l.includes("Build a login page")
+    );
+    expect(idx).toBeGreaterThanOrEqual(0);
+    lines[idx] = lines[idx].replace(
+      "Build a login page",
+      "Build a signup page"
+    );
+    fs.writeFileSync(sourceFile, lines.join("\n"));
+
+    const second = await runIngestion({
+      plugins: pluginsList,
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+
+    const rawAfter = archive.db.select().from(rawMessages).all();
+    expect(second.rawInserted).toBe(1);
+    expect(rawAfter.length).toBe(rawBefore.length + 1);
+
+    // All original raw rows are still present (no overwrite).
+    for (const before of rawBefore) {
+      expect(rawAfter.some((r) => r.id === before.id)).toBe(true);
+    }
+
+    archive.close();
+  });
+
+  it("writes raw for every payload but skips messages when normalize returns null", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+
+    await runIngestion({
+      plugins: [new ClaudeCodePlugin()],
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+
+    const rawRows = archive.db.select().from(rawMessages).all();
+    const msgRows = archive.db.select().from(messages).all();
+
+    // Fixture contains file-history-snapshot, isMeta, and isSidechain rows
+    // that the claude-code plugin skips. They must still appear in raw_messages.
+    const hasMetaRaw = rawRows.some((r) => {
+      const p = JSON.parse(r.rawPayload) as Record<string, unknown>;
+      return p.isMeta === true || p.type === "file-history-snapshot";
+    });
+    expect(hasMetaRaw).toBe(true);
+
+    // No message row should be a meta/snapshot/sidechain payload.
+    const rawById = new Map(rawRows.map((r) => [r.id, r]));
+    for (const m of msgRows) {
+      const raw = rawById.get(m.rawId);
+      expect(raw).toBeDefined();
+      const p = JSON.parse(raw!.rawPayload) as Record<string, unknown>;
+      expect(p.isMeta).not.toBe(true);
+      expect(p.isSidechain).not.toBe(true);
+      expect(p.type === "user" || p.type === "assistant").toBe(true);
+    }
+
+    // Strict inequality: there are skipped raw rows.
+    expect(msgRows.length).toBeLessThan(rawRows.length);
+
+    archive.close();
+  });
+
+  it("mtime fast path: skips files whose mtime and size are unchanged since last scan", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+
+    // First run records scan state.
+    await runIngestion({
+      plugins: [new ClaudeCodePlugin()],
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+
+    // Track which sessions actually opened their source file on the second run.
+    const opened: string[] = [];
+    const observedPlugin = new ClaudeCodePlugin();
+    const originalExtract = observedPlugin.extractRaw.bind(observedPlugin);
+    observedPlugin.extractRaw = async function* (ref) {
+      opened.push(ref.sessionId);
+      yield* originalExtract(ref);
+    };
+
+    const second = await runIngestion({
+      plugins: [observedPlugin],
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+
+    expect(second.skippedByMtime).toBeGreaterThan(0);
+    expect(opened).toEqual([]);
+    expect(second.rawInserted).toBe(0);
+
+    archive.close();
+  });
+
+  it("mtime fast path: re-reads a file when mtime changes", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+
+    await runIngestion({
+      plugins: [new ClaudeCodePlugin()],
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+
+    // Append a new line and bump mtime explicitly to ensure the change is visible.
+    const sourceFile = path.join(
+      env.homeDir,
+      ".claude",
+      "projects",
+      "project-a",
+      "session-1.jsonl"
+    );
+    const newLine = JSON.stringify({
+      type: "user",
+      message: { role: "user", content: "another question" },
+      isMeta: false,
+      uuid: "msg-new",
+      timestamp: "2024-01-02T00:00:00Z",
+      sessionId: "session-1",
+      isSidechain: false,
+    });
+    fs.appendFileSync(sourceFile, newLine + "\n");
+    const future = new Date(Date.now() + 60_000);
+    fs.utimesSync(sourceFile, future, future);
+
+    const second = await runIngestion({
+      plugins: [new ClaudeCodePlugin()],
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+
+    expect(second.rawInserted).toBe(1);
+    expect(second.skippedByMtime).toBe(0);
+
+    archive.close();
+  });
+
+  it("preserves archive rows when source file is shrunk between scans", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+
+    await runIngestion({
+      plugins: [new ClaudeCodePlugin()],
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+    const rawBefore = archive.db.select().from(rawMessages).all();
+    const msgBefore = archive.db.select().from(messages).all();
+    const sessBefore = archive.db.select().from(sessions).all();
+    expect(rawBefore.length).toBeGreaterThan(1);
+
+    // Truncate source file to a single line (simulate vendor pruning).
+    const sourceFile = path.join(
+      env.homeDir,
+      ".claude",
+      "projects",
+      "project-a",
+      "session-1.jsonl"
+    );
+    const lines = fs.readFileSync(sourceFile, "utf-8").split("\n");
+    fs.writeFileSync(sourceFile, (lines[0] ?? "") + "\n");
+    const future = new Date(Date.now() + 60_000);
+    fs.utimesSync(sourceFile, future, future);
+
+    await runIngestion({
+      plugins: [new ClaudeCodePlugin()],
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+
+    const rawAfter = archive.db.select().from(rawMessages).all();
+    const msgAfter = archive.db.select().from(messages).all();
+    const sessAfter = archive.db.select().from(sessions).all();
+
+    expect(rawAfter.length).toBeGreaterThanOrEqual(rawBefore.length);
+    expect(msgAfter.length).toBeGreaterThanOrEqual(msgBefore.length);
+    expect(sessAfter.length).toBe(sessBefore.length);
+    for (const r of rawBefore) {
+      expect(rawAfter.some((a) => a.id === r.id)).toBe(true);
+    }
+  });
+});

--- a/api/src/ingestion/ingest.ts
+++ b/api/src/ingestion/ingest.ts
@@ -1,0 +1,283 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import { and, eq } from "drizzle-orm";
+import type { ArchiveRepository } from "../archive/repository.js";
+import {
+  messages,
+  rawMessages,
+  sessions,
+  sessionScanState,
+} from "../archive/schema.js";
+import type {
+  AgentPlugin,
+  CanonicalMessage,
+  PluginEnv,
+} from "../plugins/types.js";
+
+export interface IngestOptions {
+  plugins: readonly AgentPlugin[];
+  archive: ArchiveRepository;
+  env: PluginEnv;
+  now?: () => Date;
+}
+
+export interface IngestResult {
+  scanned: number;
+  rawInserted: number;
+  canonicalUpserted: number;
+  skippedByMtime: number;
+}
+
+export async function runIngestion(opts: IngestOptions): Promise<IngestResult> {
+  const now = opts.now ?? (() => new Date());
+  const result: IngestResult = {
+    scanned: 0,
+    rawInserted: 0,
+    canonicalUpserted: 0,
+    skippedByMtime: 0,
+  };
+
+  for (const plugin of opts.plugins) {
+    for await (const ref of plugin.discover(opts.env)) {
+      result.scanned += 1;
+
+      const stat = safeStat(ref.sourcePath);
+      const prior = opts.archive.db
+        .select()
+        .from(sessionScanState)
+        .where(
+          and(
+            eq(sessionScanState.agent, plugin.id),
+            eq(sessionScanState.sessionId, ref.sessionId)
+          )
+        )
+        .get();
+
+      if (
+        stat &&
+        prior &&
+        prior.lastMtimeMs === stat.mtimeMs &&
+        prior.lastSizeBytes === stat.size
+      ) {
+        result.skippedByMtime += 1;
+        continue;
+      }
+
+      ensureSession(opts.archive, plugin.id, ref.sessionId, now());
+
+      for await (const raw of plugin.extractRaw(ref)) {
+        const payloadJson = JSON.stringify(raw.payload);
+        const payloadHash = crypto
+          .createHash("sha256")
+          .update(payloadJson)
+          .digest("hex");
+
+        const existing = opts.archive.db
+          .select({ id: rawMessages.id })
+          .from(rawMessages)
+          .where(
+            and(
+              eq(rawMessages.agent, plugin.id),
+              eq(rawMessages.sessionId, ref.sessionId),
+              eq(rawMessages.payloadHash, payloadHash)
+            )
+          )
+          .get();
+
+        let rawId: number;
+        if (existing) {
+          rawId = existing.id;
+        } else {
+          const inserted = opts.archive.db
+            .insert(rawMessages)
+            .values({
+              agent: plugin.id,
+              sessionId: ref.sessionId,
+              sourcePath: raw.sourcePath,
+              sourceLocator: raw.sourceLocator,
+              rawPayload: payloadJson,
+              payloadHash,
+              ingestedAt: now(),
+            })
+            .returning({ id: rawMessages.id })
+            .get();
+          rawId = inserted.id;
+          result.rawInserted += 1;
+        }
+
+        const canonical = plugin.normalize(raw);
+        if (!canonical) continue;
+
+        const upserted = upsertCanonical(
+          opts.archive,
+          plugin.id,
+          ref.sessionId,
+          canonical,
+          rawId
+        );
+        if (upserted) result.canonicalUpserted += 1;
+      }
+
+      if (stat) {
+        recordScanState(
+          opts.archive,
+          plugin.id,
+          ref.sessionId,
+          ref.sourcePath,
+          stat,
+          now()
+        );
+      }
+    }
+  }
+
+  return result;
+}
+
+function safeStat(p: string): fs.Stats | null {
+  try {
+    return fs.statSync(p);
+  } catch {
+    return null;
+  }
+}
+
+function recordScanState(
+  archive: ArchiveRepository,
+  agent: string,
+  sessionId: string,
+  sourcePath: string,
+  stat: fs.Stats,
+  scannedAt: Date
+): void {
+  const existing = archive.db
+    .select({ id: sessionScanState.id })
+    .from(sessionScanState)
+    .where(
+      and(
+        eq(sessionScanState.agent, agent),
+        eq(sessionScanState.sessionId, sessionId)
+      )
+    )
+    .get();
+
+  if (existing) {
+    archive.db
+      .update(sessionScanState)
+      .set({
+        sourcePath,
+        lastMtimeMs: stat.mtimeMs,
+        lastSizeBytes: stat.size,
+        lastScannedAt: scannedAt,
+      })
+      .where(eq(sessionScanState.id, existing.id))
+      .run();
+  } else {
+    archive.db
+      .insert(sessionScanState)
+      .values({
+        agent,
+        sessionId,
+        sourcePath,
+        lastMtimeMs: stat.mtimeMs,
+        lastSizeBytes: stat.size,
+        lastScannedAt: scannedAt,
+      })
+      .run();
+  }
+}
+
+function ensureSession(
+  archive: ArchiveRepository,
+  agent: string,
+  sourceSessionId: string,
+  firstSeenAt: Date
+): string {
+  const existing = archive.db
+    .select()
+    .from(sessions)
+    .where(
+      and(
+        eq(sessions.agent, agent),
+        eq(sessions.sourceSessionId, sourceSessionId)
+      )
+    )
+    .get();
+  if (existing) return existing.id;
+
+  const id = crypto.randomUUID();
+  const shortCode = archive.generateShortCode();
+  archive.db
+    .insert(sessions)
+    .values({
+      id,
+      shortCode,
+      agent,
+      sourceSessionId,
+      firstSeenAt,
+    })
+    .run();
+  return id;
+}
+
+function upsertCanonical(
+  archive: ArchiveRepository,
+  agent: string,
+  sessionId: string,
+  msg: CanonicalMessage,
+  rawId: number
+): boolean {
+  const existing = archive.db
+    .select()
+    .from(messages)
+    .where(
+      and(
+        eq(messages.agent, agent),
+        eq(messages.sessionId, sessionId),
+        eq(messages.messageId, msg.messageId)
+      )
+    )
+    .get();
+
+  const ts = parseTs(msg.ts);
+
+  if (!existing) {
+    archive.db
+      .insert(messages)
+      .values({
+        agent,
+        sessionId,
+        messageId: msg.messageId,
+        role: msg.role,
+        ts,
+        text: msg.text,
+        blocks: msg.blocks,
+        rawId,
+      })
+      .run();
+    return true;
+  }
+
+  if (ts.getTime() >= existing.ts.getTime()) {
+    archive.db
+      .update(messages)
+      .set({
+        role: msg.role,
+        ts,
+        text: msg.text,
+        blocks: msg.blocks,
+        rawId,
+      })
+      .where(eq(messages.id, existing.id))
+      .run();
+    return true;
+  }
+
+  return false;
+}
+
+function parseTs(ts: string): Date {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return new Date(0);
+  return d;
+}


### PR DESCRIPTION
## Background (Why)

Part of the Archive architecture milestone — specifically PR 4 of the planned sequence #40→#43→**#44**→#45→(#46, #47). On its own this PR is **invisible to users**: the read path still serves from source JSONL. Its job is to start populating `archive.db` so that #45 can flip the read switch and deliver the product promise ("your history survives even when the vendor prunes its own store").

Per `docs/ARCHITECTURE.md` and PRD §8, the on-app-open scan is one of two ingestion modes (the other, chokidar watcher, lands in #46).

## Approach (How)

Implemented the pipeline shape from the issue, with two design decisions worth calling out:

1. **Watermark in its own table, not in `ingestion_events`.** `ingestion_events` is an append-only audit log per the archive contract; reusing it as a mutable KV store would mix audit history with state. Added `session_scan_state(agent, session_id, source_path, last_mtime_ms, last_size_bytes, last_scanned_at)` — the standard checkpoint pattern from incremental ETL (Airbyte, Debezium). Schema change is additive, consistent with the "forward-only, additive" migration policy.

2. **Background supervisor, not a floating promise.** `startIngestionInBackground` wraps `runIngestion` with centralized error logging and exposes a `done` promise. Keeps `index.ts` as pure wiring and makes server-start non-blocking observable / testable rather than implicit.

Idempotency strategy follows the issue's pseudocode exactly:
- Hash payload with SHA-256, dedupe on `(agent, session_id,
  payload_hash)` — matches the existing `raw_messages_idem_idx`.
- Source-side edits append a new raw row; old rows are never
  overwritten.
- Canonical layer is last-write-wins by `ts`.
- mtime + size fast path skips unchanged files before opening them.

Hard rule from `CLAUDE.md` honoured: **no archive row is ever deleted in response to source changes** (covered by a dedicated test).

## Changes (What)

- [x] `session_scan_state` table + drizzle migration `0003`
- [x] `api/src/ingestion/ingest.ts` — `runIngestion(opts): IngestResult`
- [x] `api/src/ingestion/background.ts` — `startIngestionInBackground`
- [x] `api/src/index.ts` wires background ingestion into startup
- [x] Tests: tracer ingest, idempotency, hash-collision append, normalize-null skip, mtime skip / re-read, source-shrunk archive preservation, background non-blocking + error handling

### Test Verification

- [x] First run on a populated `~/.claude/` writes sessions, raw_messages, and messages (tracer test using existing JSONL fixtures)
- [x] Second run on the same data is a no-op (`rawInserted === 0`, row counts unchanged)
- [x] Edit a line in place → new raw row appended, original raw rows preserved
- [x] Meta / sidechain / `file-history-snapshot` payloads land in `raw_messages` but not in `messages` (normalize returns null)
- [x] Unchanged mtime + size → file is never opened on the next scan (`extractRaw` spy stays empty); changed mtime → re-read happens
- [x] Source file truncated → archive rows preserved (no cascade delete)
- [x] Background supervisor returns synchronously; runner rejections flow through `onError` instead of becoming unhandled rejections
- [x] `pnpm typecheck` clean; full suite 66 tests passing

## Additional Notes

- Out of scope (intentionally): the read-path switch (`#45`), the chokidar watcher (`#46`), visibility helper (`#47`).
- No CHANGELOG entry: per the milestone plan, #40–#44 ship silently and v0.4 is cut once #45 lands and the user-visible behaviour arrives.
- `session_scan_state` deliberately keys on `(agent, session_id)` rather than `source_path` so a future plugin whose locator isn't a single file (e.g. Codex CLI) can still use the same checkpoint shape.

## Related Links

- Closes #44