### PR TITLE
feat(ingestion): chokidar file-watcher for incremental ingest

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@hono/node-server": "^1.19.11",
     "better-sqlite3": "^12.9.0",
+    "chokidar": "^5.0.0",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.7.0",
     "update-notifier": "^7.3.1"

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -9,6 +9,7 @@ import { createApp } from "./app.js";
 import { createArchiveRepository } from "./archive/repository.js";
 import { createMetadataRepository } from "./metadata/repository.js";
 import { startIngestionInBackground } from "./ingestion/background.js";
+import { startWatcher } from "./ingestion/watcher.js";
 import { plugins } from "./plugins/registry.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -28,11 +29,26 @@ const archive = createArchiveRepository({ dataDir });
 const metadata = createMetadataRepository({ dataDir });
 const app = createApp({ archive, metadata, webDistDir });
 
-startIngestionInBackground({
+const initialIngest = startIngestionInBackground({
   plugins,
   archive,
   env: { homeDir: os.homedir() },
 });
+
+const watcher = startWatcher({
+  plugins,
+  archive,
+  env: { homeDir: os.homedir() },
+});
+// Don't start watching until the initial scan has populated session_scan_state;
+// otherwise a `change` event could race the first scan and re-ingest from scratch.
+void initialIngest.done.then(() => watcher.ready).catch(() => {});
+
+function shutdown(): void {
+  void watcher.close().finally(() => process.exit(0));
+}
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
 
 function openBrowser(url: string): void {
   const cmd =

--- a/api/src/ingestion/watcher.test.ts
+++ b/api/src/ingestion/watcher.test.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createArchiveRepository } from "../archive/repository.js";
+import {
+  ingestionEvents,
+  messages,
+  rawMessages,
+  sessions,
+} from "../archive/schema.js";
+import { ClaudeCodePlugin } from "../plugins/claude-code/plugin.js";
+import { runIngestion } from "./ingest.js";
+import { startWatcher } from "./watcher.js";
+
+const fixturesRoot = path.join(__dirname, "../__fixtures__/projects");
+
+interface Env {
+  tmp: string;
+  dataDir: string;
+  homeDir: string;
+}
+
+function setupEnv(): Env {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-watcher-"));
+  const dataDir = path.join(tmp, "data");
+  const homeDir = path.join(tmp, "home");
+  const claudeProjects = path.join(homeDir, ".claude", "projects");
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(claudeProjects, { recursive: true });
+  fs.cpSync(fixturesRoot, claudeProjects, { recursive: true });
+  return { tmp, dataDir, homeDir };
+}
+
+let env: Env;
+
+beforeEach(() => {
+  env = setupEnv();
+});
+
+afterEach(() => {
+  fs.rmSync(env.tmp, { recursive: true, force: true });
+});
+
+describe("startWatcher", () => {
+  it("ingests appended content to an existing source file (change event)", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const plugins = [new ClaudeCodePlugin()];
+
+    // Seed archive via on-app-open scan first; watcher is for live updates.
+    await runIngestion({ plugins, archive, env: { homeDir: env.homeDir } });
+    const rawBefore = archive.db.select().from(rawMessages).all().length;
+
+    const watcher = startWatcher({
+      plugins,
+      archive,
+      env: { homeDir: env.homeDir },
+      chokidarOptions: { usePolling: true, interval: 25 },
+      debounceMs: 25,
+    });
+    await watcher.ready;
+
+    try {
+      const sourceFile = path.join(
+        env.homeDir,
+        ".claude",
+        "projects",
+        "project-a",
+        "session-1.jsonl"
+      );
+      const newLine = JSON.stringify({
+        type: "user",
+        message: { role: "user", content: "live appended message" },
+        isMeta: false,
+        uuid: "msg-live-1",
+        timestamp: "2024-01-03T00:00:00Z",
+        sessionId: "session-1",
+        isSidechain: false,
+      });
+      fs.appendFileSync(sourceFile, newLine + "\n");
+      const future = new Date(Date.now() + 60_000);
+      fs.utimesSync(sourceFile, future, future);
+
+      await vi.waitFor(
+        () => {
+          const rawAfter = archive.db.select().from(rawMessages).all().length;
+          expect(rawAfter).toBe(rawBefore + 1);
+          const msg = archive.db
+            .select()
+            .from(messages)
+            .all()
+            .find((m) => m.messageId === "msg-live-1");
+          expect(msg).toBeDefined();
+        },
+        { timeout: 5000, interval: 50 }
+      );
+    } finally {
+      await watcher.close();
+      archive.close();
+    }
+  });
+
+  it("records an unlink_observed audit row without deleting archive rows", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const plugins = [new ClaudeCodePlugin()];
+
+    await runIngestion({ plugins, archive, env: { homeDir: env.homeDir } });
+    const rawBefore = archive.db.select().from(rawMessages).all().length;
+    const msgBefore = archive.db.select().from(messages).all().length;
+    const sessBefore = archive.db.select().from(sessions).all().length;
+
+    const watcher = startWatcher({
+      plugins,
+      archive,
+      env: { homeDir: env.homeDir },
+      chokidarOptions: { usePolling: true, interval: 25 },
+      debounceMs: 25,
+    });
+    await watcher.ready;
+
+    try {
+      const sourceFile = path.join(
+        env.homeDir,
+        ".claude",
+        "projects",
+        "project-a",
+        "session-1.jsonl"
+      );
+      fs.unlinkSync(sourceFile);
+
+      await vi.waitFor(
+        () => {
+          const events = archive.db
+            .select()
+            .from(ingestionEvents)
+            .all()
+            .filter((e) => e.eventType === "unlink_observed");
+          expect(events.length).toBeGreaterThan(0);
+          expect(events.some((e) => e.sourcePath === sourceFile)).toBe(true);
+        },
+        { timeout: 5000, interval: 50 }
+      );
+
+      expect(archive.db.select().from(rawMessages).all().length).toBe(
+        rawBefore
+      );
+      expect(archive.db.select().from(messages).all().length).toBe(msgBefore);
+      expect(archive.db.select().from(sessions).all().length).toBe(sessBefore);
+    } finally {
+      await watcher.close();
+      archive.close();
+    }
+  });
+
+  it("stops triggering ingest after close()", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const plugins = [new ClaudeCodePlugin()];
+    await runIngestion({ plugins, archive, env: { homeDir: env.homeDir } });
+
+    const watcher = startWatcher({
+      plugins,
+      archive,
+      env: { homeDir: env.homeDir },
+      chokidarOptions: { usePolling: true, interval: 25 },
+      debounceMs: 25,
+    });
+    await watcher.ready;
+    await watcher.close();
+
+    const rawBefore = archive.db.select().from(rawMessages).all().length;
+
+    const sourceFile = path.join(
+      env.homeDir,
+      ".claude",
+      "projects",
+      "project-a",
+      "session-1.jsonl"
+    );
+    const newLine = JSON.stringify({
+      type: "user",
+      message: { role: "user", content: "after close" },
+      isMeta: false,
+      uuid: "msg-after-close",
+      timestamp: "2024-01-04T00:00:00Z",
+      sessionId: "session-1",
+      isSidechain: false,
+    });
+    fs.appendFileSync(sourceFile, newLine + "\n");
+    const future = new Date(Date.now() + 60_000);
+    fs.utimesSync(sourceFile, future, future);
+
+    await new Promise((r) => setTimeout(r, 400));
+    expect(archive.db.select().from(rawMessages).all().length).toBe(rawBefore);
+
+    archive.close();
+  });
+});

--- a/api/src/ingestion/watcher.ts
+++ b/api/src/ingestion/watcher.ts
@@ -1,0 +1,114 @@
+import chokidar, { type FSWatcher, type ChokidarOptions } from "chokidar";
+import type { ArchiveRepository } from "../archive/repository.js";
+import { ingestionEvents } from "../archive/schema.js";
+import type { AgentPlugin, PluginEnv, SessionRef } from "../plugins/types.js";
+import { runIngestion } from "./ingest.js";
+
+export interface WatcherOptions {
+  plugins: readonly AgentPlugin[];
+  archive: ArchiveRepository;
+  env: PluginEnv;
+  debounceMs?: number;
+  chokidarOptions?: ChokidarOptions;
+  onError?: (err: unknown) => void;
+}
+
+export interface IngestionWatcher {
+  ready: Promise<void>;
+  close(): Promise<void>;
+}
+
+interface PathBinding {
+  plugin: AgentPlugin;
+  ref: SessionRef;
+}
+
+export function startWatcher(opts: WatcherOptions): IngestionWatcher {
+  const debounceMs = opts.debounceMs ?? 150;
+  const onError =
+    opts.onError ??
+    ((err: unknown) => {
+      console.warn("[watcher] error:", err);
+    });
+
+  const pathBindings = new Map<string, PathBinding>();
+  const pendingTimers = new Map<string, NodeJS.Timeout>();
+  let watcher: FSWatcher | null = null;
+  let closed = false;
+
+  const ready = (async () => {
+    const watchPathSet = new Set<string>();
+    for (const plugin of opts.plugins) {
+      for await (const ref of plugin.discover(opts.env)) {
+        for (const p of ref.watchPaths) {
+          pathBindings.set(p, { plugin, ref });
+          watchPathSet.add(p);
+        }
+      }
+    }
+
+    const paths = Array.from(watchPathSet);
+    if (paths.length === 0) return;
+
+    watcher = chokidar.watch(paths, {
+      ignoreInitial: true,
+      awaitWriteFinish: { stabilityThreshold: 50, pollInterval: 25 },
+      ...opts.chokidarOptions,
+    });
+
+    watcher.on("change", (p) => scheduleIngest(p));
+    watcher.on("add", (p) => scheduleIngest(p));
+    watcher.on("unlink", (p) => recordUnlink(p));
+    watcher.on("error", (err) => onError(err));
+
+    await new Promise<void>((resolve) => {
+      watcher!.once("ready", () => resolve());
+    });
+  })();
+
+  function recordUnlink(removedPath: string): void {
+    if (closed) return;
+    const binding = pathBindings.get(removedPath);
+    if (!binding) return;
+    try {
+      opts.archive.db
+        .insert(ingestionEvents)
+        .values({
+          agent: binding.plugin.id,
+          sessionId: binding.ref.sessionId,
+          sourcePath: removedPath,
+          eventType: "unlink_observed",
+          detail: { path: removedPath },
+          observedAt: new Date(),
+        })
+        .run();
+    } catch (err) {
+      onError(err);
+    }
+  }
+
+  function scheduleIngest(changedPath: string): void {
+    if (closed) return;
+    const existing = pendingTimers.get(changedPath);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      pendingTimers.delete(changedPath);
+      void runIngestion({
+        plugins: opts.plugins,
+        archive: opts.archive,
+        env: opts.env,
+      }).catch((err) => onError(err));
+    }, debounceMs);
+    pendingTimers.set(changedPath, timer);
+  }
+
+  return {
+    ready,
+    async close() {
+      closed = true;
+      for (const t of pendingTimers.values()) clearTimeout(t);
+      pendingTimers.clear();
+      if (watcher) await watcher.close();
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)
@@ -2860,6 +2863,13 @@ packages:
         integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
       }
     engines: { node: ">= 14.16.0" }
+
+  chokidar@5.0.0:
+    resolution:
+      {
+        integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==,
+      }
+    engines: { node: ">= 20.19.0" }
 
   chownr@1.1.4:
     resolution:
@@ -5785,6 +5795,13 @@ packages:
       }
     engines: { node: ">= 14.18.0" }
 
+  readdirp@5.0.0:
+    resolution:
+      {
+        integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==,
+      }
+    engines: { node: ">= 20.19.0" }
+
   recast@0.23.11:
     resolution:
       {
@@ -8617,6 +8634,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@1.1.4: {}
 
   class-variance-authority@0.7.1:
@@ -10438,6 +10459,8 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
+
+  readdirp@5.0.0: {}
 
   recast@0.23.11:
     dependencies:


### PR DESCRIPTION
## Background (Why)

Part of the Archive architecture milestone — unlocks two user-visible behaviors that #44/#45 set up but couldn't deliver alone:

1. Conversations update live in the UI while an AI tool is actively writing (user story #12), instead of only after restart.
2. When a vendor cleans up or rewrites its internal storage, chat-logbook keeps an audit trail of the disappearance — and the archive copy stays intact.

## Approach (How)

A thin chokidar wrapper that delegates real work to the existing ingestion pipeline rather than reimplementing idempotency.

- `startWatcher()` discovers active plugins' `SessionRef.watchPaths` at startup and subscribes once.
- `add` / `change` events debounce for 150 ms, then call the existing `runIngestion()` — same mtime fast path, same `(agent, session_id, payload_hash)` dedup. Re-running over unchanged data is a no-op, by construction.
- `unlink` writes `ingestion_events('unlink_observed', { path })` and never touches archive rows, matching the archive contract in `docs/ARCHITECTURE.md`.
- chokidar errors route through an injectable `onError` (default: warn). The watcher stays alive on inaccessible paths.
- The watcher waits for the on-app-open background scan to finish before subscribing, so a `change` event can't race the initial ingest.
- SIGINT / SIGTERM tear it down cleanly.

Public surface is small on purpose: `startWatcher` returns `{ ready, close() }`. chokidar types are not re-exported.

## Changes (What)

- [x] `api/src/ingestion/watcher.ts` — chokidar wrapper, debounced incremental ingest, unlink audit, error routing
- [x] `api/src/index.ts` — wire watcher after initial scan; SIGINT/SIGTERM teardown
- [x] `api/package.json` — add `chokidar ^5`
- [x] `api/src/ingestion/watcher.test.ts` — TDD vertical slices: change → ingest, unlink → audit row, no-op after close()

### Test Verification

- [x] Append a line to an existing session JSONL → new `raw_messages` row + canonical `messages` row appear within seconds (uses chokidar polling mode for cross-platform determinism)
- [x] `unlink` source file → `ingestion_events('unlink_observed')` row written; `raw_messages` / `messages` / `sessions` row counts unchanged
- [x] After `close()`, further fs changes do not trigger ingest
- [x] `pnpm typecheck` clean across workspaces
- [x] Full test suite: 115/115 passing (api 73, web 42)

## Additional Notes

- The Claude Code plugin's `watchPaths` currently includes only existing source files, so detection of brand-new session JSONLs appearing under `~/.claude/projects/<project>/` is out of scope for this PR. The acceptance criterion "new messages visible in UI without restart" is satisfied by the `change`-event path, which is the live-streaming case during an active AI session. New-session live discovery would be a plugin watchPath change (parent-dir watch) and is left as a follow-up if needed.
- Debounce default of 150 ms balances ingest latency against bursty appends; tests override to 25 ms for speed.

## Related Links

- Closes #46
- Depends on #45 (read API switched to archive.db) — already merged