### PR TITLE
feat: custom session titles with inline editing

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -513,6 +513,167 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
   });
 });
 
+describe("PATCH /api/sessions/:id/title", () => {
+  it("updates the custom title and returns it in subsequent GET /api/sessions", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedSession(archive, {
+      internalId: "internal-uuid-1",
+      sourceSessionId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceSessionId: "session-1",
+      messageId: "m-user",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "Build a login page",
+      blocks: [{ type: "text", text: "Build a login page" }],
+    });
+
+    const app = createApp({ archive, metadata });
+    const patch = await app.request("/api/sessions/session-1/title", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "My favourite chat" }),
+    });
+    expect(patch.status).toBe(204);
+
+    const list = await app.request("/api/sessions");
+    const body = (await list.json()) as { sessions: SessionResponse[] };
+    const session = body.sessions.find((s) => s.id === "session-1");
+    expect(session?.title).toBe("My favourite chat");
+  });
+
+  it("clears the custom title when an empty string is sent, reverting to derived", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedSession(archive, {
+      internalId: "internal-uuid-1",
+      sourceSessionId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceSessionId: "session-1",
+      messageId: "m-user",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "Build a login page",
+      blocks: [{ type: "text", text: "Build a login page" }],
+    });
+    metadata.setCustomTitle("internal-uuid-1", "Custom");
+
+    const app = createApp({ archive, metadata });
+    const patch = await app.request("/api/sessions/session-1/title", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "" }),
+    });
+    expect(patch.status).toBe(204);
+
+    const list = await app.request("/api/sessions");
+    const body = (await list.json()) as { sessions: SessionResponse[] };
+    const session = body.sessions.find((s) => s.id === "session-1");
+    expect(session?.title).toBe("Build a login page");
+  });
+
+  it("treats whitespace-only title as a clear", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedSession(archive, {
+      internalId: "internal-uuid-1",
+      sourceSessionId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    metadata.setCustomTitle("internal-uuid-1", "Custom");
+
+    const app = createApp({ archive, metadata });
+    const patch = await app.request("/api/sessions/session-1/title", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "   " }),
+    });
+    expect(patch.status).toBe(204);
+
+    const list = await app.request("/api/sessions");
+    const body = (await list.json()) as { sessions: SessionResponse[] };
+    const session = body.sessions.find((s) => s.id === "session-1");
+    expect(session?.title).toBe("Untitled");
+  });
+
+  it("trims whitespace around the saved title", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedSession(archive, {
+      internalId: "internal-uuid-1",
+      sourceSessionId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+
+    const app = createApp({ archive, metadata });
+    await app.request("/api/sessions/session-1/title", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "  Padded title  " }),
+    });
+
+    const list = await app.request("/api/sessions");
+    const body = (await list.json()) as { sessions: SessionResponse[] };
+    const session = body.sessions.find((s) => s.id === "session-1");
+    expect(session?.title).toBe("Padded title");
+  });
+
+  it("returns 404 when archive has no session for the given id", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const app = createApp({ archive, metadata });
+
+    const res = await app.request("/api/sessions/nonexistent/title", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "x" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when title is not a string", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedSession(archive, {
+      internalId: "internal-uuid-1",
+      sourceSessionId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const app = createApp({ archive, metadata });
+
+    const wrongType = await app.request("/api/sessions/session-1/title", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: 123 }),
+    });
+    expect(wrongType.status).toBe(400);
+  });
+
+  it("returns 400 when title exceeds 200 characters", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedSession(archive, {
+      internalId: "internal-uuid-1",
+      sourceSessionId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const app = createApp({ archive, metadata });
+
+    const tooLong = "x".repeat(201);
+    const res = await app.request("/api/sessions/session-1/title", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: tooLong }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
 describe("GET /api/sessions/:id (archive-backed)", () => {
   it("returns messages from archive.messages ordered by ts", async () => {
     const archive = createArchiveRepository({ dataDir });

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -126,6 +126,35 @@ export function createApp({ archive, metadata, webDistDir }: AppOptions) {
     return c.body(null, 204);
   });
 
+  app.patch("/api/sessions/:id/title", async (c) => {
+    const sessionId = c.req.param("id");
+    const row = findArchiveSessionBySourceId(sessionId);
+    if (!row) {
+      return c.json({ error: "Session not found" }, 404);
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    if (
+      !body ||
+      typeof body !== "object" ||
+      typeof (body as { title?: unknown }).title !== "string"
+    ) {
+      return c.json({ error: "Invalid title" }, 400);
+    }
+    const raw = (body as { title: string }).title;
+    if (raw.length > 200) {
+      return c.json({ error: "Title too long" }, 400);
+    }
+    const trimmed = raw.trim();
+    metadata.setCustomTitle(row.id, trimmed.length > 0 ? trimmed : null);
+    return c.body(null, 204);
+  });
+
   app.get("/api/sessions/:id", (c) => {
     const sessionId = c.req.param("id");
     const row = findArchiveSessionBySourceId(sessionId);

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -84,7 +84,7 @@ describe("Soft delete from session list", () => {
     if (!row) throw new Error("Session row not found");
 
     const deleteButton = within(row.parentElement!).getByRole("button", {
-      name: /delete session: fix database migration/i,
+      name: /move to trash: fix database migration/i,
     });
     await user.click(deleteButton);
 
@@ -115,7 +115,7 @@ describe("Auto-select next after delete", () => {
     // Delete it via hover button
     const list = screen.getByTestId("session-list");
     const deleteBtn = within(list).getByRole("button", {
-      name: /delete session: build a login page/i,
+      name: /move to trash: build a login page/i,
     });
     await user.click(deleteBtn);
 
@@ -135,7 +135,7 @@ describe("Undo toast on delete", () => {
 
     const list = screen.getByTestId("session-list");
     const deleteBtn = within(list).getByRole("button", {
-      name: /delete session: fix database migration/i,
+      name: /move to trash: fix database migration/i,
     });
     await user.click(deleteBtn);
 
@@ -284,7 +284,7 @@ describe("Trash mode triggers: hover button, Backspace, Esc", () => {
 
     const list = screen.getByTestId("session-list");
     const restoreBtn = within(list).getByRole("button", {
-      name: /restore session: old prototype/i,
+      name: /restore: old prototype/i,
     });
     await user.click(restoreBtn);
 
@@ -336,7 +336,7 @@ describe("Right-click context menu", () => {
 
     const menu = await screen.findByRole("menu");
     const deleteItem = within(menu).getByRole("menuitem", {
-      name: /delete session/i,
+      name: /move to trash/i,
     });
 
     await user.click(deleteItem);
@@ -346,6 +346,38 @@ describe("Right-click context menu", () => {
       expect(
         within(list).queryByText("Build a login page")
       ).not.toBeInTheDocument();
+    });
+  });
+
+  it("can reopen the context menu after closing it (no stale close-listener)", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const row = await screen.findByText("Build a login page");
+    fireEvent.contextMenu(row);
+    expect(await screen.findByRole("menu")).toBeInTheDocument();
+
+    // Close via outside click.
+    await user.click(document.body);
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    // Reopen — must not be torn down by a leftover document-level listener.
+    fireEvent.contextMenu(row);
+    expect(await screen.findByRole("menu")).toBeInTheDocument();
+  });
+
+  it("closes the context menu when Escape is pressed", async () => {
+    render(<App />);
+
+    const row = await screen.findByText("Build a login page");
+    fireEvent.contextMenu(row);
+    expect(await screen.findByRole("menu")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     });
   });
 
@@ -361,7 +393,7 @@ describe("Right-click context menu", () => {
 
     const menu = await screen.findByRole("menu");
     expect(
-      within(menu).getByRole("menuitem", { name: /restore session/i })
+      within(menu).getByRole("menuitem", { name: /^restore/i })
     ).toBeInTheDocument();
   });
 });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -37,7 +37,7 @@ describe("Session list", () => {
     const list = screen.getByTestId("session-list");
     const rowButtons = within(list)
       .getAllByRole("button")
-      .filter((el) => !el.getAttribute("aria-label")?.startsWith("Delete"));
+      .filter((el) => !el.getAttribute("aria-label"));
     const titles = rowButtons.map((item) => item.textContent);
 
     // session-2 has updatedAt 1700000300000 (newer)
@@ -609,6 +609,156 @@ describe("Thinking block rendering", () => {
     expect(
       screen.queryByText(/read the current utils file/)
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("Custom session titles — inline edit", () => {
+  it("clicking the title in the conversation header enters edit mode", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+
+    const header = screen.getByTestId("conversation-header");
+    await user.click(within(header).getByText("Build a login page"));
+
+    const input = within(header).getByRole("textbox", {
+      name: /session title/i,
+    }) as HTMLInputElement;
+    expect(input.value).toBe("Build a login page");
+  });
+
+  it("saving via Enter updates both header and list row immediately", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+
+    const header = screen.getByTestId("conversation-header");
+    await user.click(within(header).getByText("Build a login page"));
+    const input = within(header).getByRole("textbox", {
+      name: /session title/i,
+    }) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "My favourite chat" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(within(header).getByText("My favourite chat")).toBeInTheDocument();
+    });
+    const list = screen.getByTestId("session-list");
+    expect(within(list).getByText("My favourite chat")).toBeInTheDocument();
+    expect(
+      within(list).queryByText("Build a login page")
+    ).not.toBeInTheDocument();
+  });
+
+  it("pressing Escape cancels the edit and keeps the original title", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+
+    const header = screen.getByTestId("conversation-header");
+    await user.click(within(header).getByText("Build a login page"));
+    const input = within(header).getByRole("textbox", {
+      name: /session title/i,
+    }) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Discard me" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(within(header).getByText("Build a login page")).toBeInTheDocument();
+    expect(within(header).queryByText("Discard me")).not.toBeInTheDocument();
+  });
+
+  it("clearing a custom title reverts to the default derived title", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+    const header = screen.getByTestId("conversation-header");
+
+    await user.click(within(header).getByText("Build a login page"));
+    let input = within(header).getByRole("textbox", {
+      name: /session title/i,
+    }) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Temporary" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() =>
+      expect(within(header).getByText("Temporary")).toBeInTheDocument()
+    );
+
+    await user.click(within(header).getByText("Temporary"));
+    input = within(header).getByRole("textbox", {
+      name: /session title/i,
+    }) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(
+        within(header).getByText("Build a login page")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("clicking the title of an already-selected list row enters edit mode", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const list = await screen.findByTestId("session-list");
+    // First click selects the session
+    await user.click(within(list).getByText("Fix database migration"));
+    // Second click on the title of the already-selected row enters edit
+    await user.click(within(list).getByText("Fix database migration"));
+
+    const input = within(list).getByRole("textbox", {
+      name: /session title/i,
+    }) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Migrate me" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(within(list).getByText("Migrate me")).toBeInTheDocument();
+    });
+    expect(
+      within(list).queryByText("Fix database migration")
+    ).not.toBeInTheDocument();
+  });
+
+  it("right-click Rename on a session row enters edit mode", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    const list = screen.getByTestId("session-list");
+    fireEvent.contextMenu(within(list).getByText("Fix database migration"));
+
+    const menu = await screen.findByRole("menu");
+    await user.click(within(menu).getByRole("menuitem", { name: /rename/i }));
+
+    const input = within(list).getByRole("textbox", {
+      name: /session title/i,
+    }) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Renamed via menu" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(within(list).getByText("Renamed via menu")).toBeInTheDocument();
+    });
+  });
+
+  it("pressing F2 on a selected session enters edit mode in the list row", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+    await user.keyboard("{F2}");
+
+    const list = screen.getByTestId("session-list");
+    const input = within(list).getByRole("textbox", {
+      name: /session title/i,
+    }) as HTMLInputElement;
+    expect(input.value).toBe("Build a login page");
   });
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,9 +13,13 @@ import {
 } from "@/components/ui/resizable";
 
 function App() {
-  const { sessions, softDelete, restore } = useSessions();
+  const { sessions, softDelete, restore, setTitle } = useSessions();
+  const handleRenameTitle = (id: string, title: string) => {
+    void setTitle(id, title);
+  };
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [mode, setMode] = useState<"main" | "trash">("main");
+  const [editingTitleId, setEditingTitleId] = useState<string | null>(null);
   const { messages, error } = useMessages(selectedId);
   const { toast, showToast, dismissToast } = useToast();
   const mainSessions = sessions.filter((s) => !s.isDeleted);
@@ -45,6 +49,16 @@ function App() {
         } else {
           handleDelete(selectedId);
         }
+        return;
+      }
+
+      if (
+        (e.key === "F2" || e.key === "Enter") &&
+        selectedId &&
+        mode === "main"
+      ) {
+        e.preventDefault();
+        setEditingTitleId(selectedId);
         return;
       }
 
@@ -106,9 +120,12 @@ function App() {
             mode={mode}
             sessions={visibleSessions}
             selectedId={selectedId}
+            editingId={editingTitleId}
+            onEditingIdChange={setEditingTitleId}
             onSelect={setSelectedId}
             onDelete={handleDelete}
             onRestore={handleRestore}
+            onRenameTitle={handleRenameTitle}
             onBack={() => setMode("main")}
             deletedCount={deletedSessions.length}
             onOpenTrash={() => setMode("trash")}
@@ -121,6 +138,7 @@ function App() {
             messages={messages}
             error={error}
             onRestore={handleRestore}
+            onRenameTitle={handleRenameTitle}
           />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/web/src/components/ConversationView.tsx
+++ b/web/src/components/ConversationView.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { RotateCcw } from "lucide-react";
 import Markdown from "react-markdown";
@@ -7,12 +7,16 @@ import remarkGfm from "remark-gfm";
 import type { Message, ContentBlock, Session } from "@/types";
 import { CollapsibleThinking } from "./CollapsibleThinking";
 import { CollapsibleToolCall } from "./CollapsibleToolCall";
+import { EditableTitle } from "./EditableTitle";
 
 interface ConversationViewProps {
   session: Session | null;
   messages: Message[];
   error?: string | null;
   onRestore?: (id: string) => void;
+  onRenameTitle?: (id: string, title: string) => void;
+  editingTitle?: boolean;
+  onEditingTitleChange?: (next: boolean) => void;
 }
 
 function DeletedBanner({
@@ -59,7 +63,22 @@ function getRelativeTime(timestamp: number): string {
   return "just now";
 }
 
-function ConversationHeader({ session }: { session: Session | null }) {
+const HEADER_TITLE_DISPLAY_CLASS =
+  "inline-block max-w-full truncate align-middle rounded px-1.5 py-0.5 -mx-1.5 text-sm font-semibold text-accent-foreground cursor-text transition-colors hover:bg-white/[0.04]";
+const HEADER_TITLE_INPUT_CLASS =
+  "min-w-[12ch] max-w-full rounded border border-border bg-transparent px-1.5 py-0.5 text-sm font-semibold text-accent-foreground outline-none focus:border-primary [field-sizing:content]";
+
+function ConversationHeader({
+  session,
+  editing,
+  onEditingChange,
+  onRenameTitle,
+}: {
+  session: Session | null;
+  editing: boolean;
+  onEditingChange: (next: boolean) => void;
+  onRenameTitle?: (id: string, title: string) => void;
+}) {
   return (
     <div
       data-testid="conversation-header"
@@ -67,8 +86,23 @@ function ConversationHeader({ session }: { session: Session | null }) {
     >
       {session && (
         <>
-          <div className="min-w-0 flex-1 truncate text-sm font-semibold text-accent-foreground">
-            {session.title}
+          <div className="min-w-0 flex-1">
+            {onRenameTitle ? (
+              <EditableTitle
+                value={session.title}
+                editing={editing}
+                onEditStart={() => onEditingChange(true)}
+                onEditEnd={() => onEditingChange(false)}
+                onSave={(next) => onRenameTitle(session.id, next)}
+                displayClassName={HEADER_TITLE_DISPLAY_CLASS}
+                inputClassName={HEADER_TITLE_INPUT_CLASS}
+                inputAriaLabel="Session title"
+              />
+            ) : (
+              <span className={HEADER_TITLE_DISPLAY_CLASS}>
+                {session.title}
+              </span>
+            )}
           </div>
           <div className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
             {getProjectName(session.project)} ·{" "}
@@ -136,7 +170,17 @@ export function ConversationView({
   messages,
   error,
   onRestore,
+  onRenameTitle,
+  editingTitle,
+  onEditingTitleChange,
 }: ConversationViewProps) {
+  const [internalEditing, setInternalEditing] = useState(false);
+  const headerEditing =
+    editingTitle !== undefined ? editingTitle : internalEditing;
+  const setHeaderEditing = (next: boolean) => {
+    setInternalEditing(next);
+    onEditingTitleChange?.(next);
+  };
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const virtualizer = useVirtualizer({
@@ -148,7 +192,12 @@ export function ConversationView({
 
   return (
     <div className="flex h-full flex-col">
-      <ConversationHeader session={session} />
+      <ConversationHeader
+        session={session}
+        editing={headerEditing}
+        onEditingChange={setHeaderEditing}
+        onRenameTitle={onRenameTitle}
+      />
       {session?.isDeleted && onRestore && (
         <DeletedBanner sessionId={session.id} onRestore={onRestore} />
       )}

--- a/web/src/components/EditableTitle.tsx
+++ b/web/src/components/EditableTitle.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, type KeyboardEvent } from "react";
+
+interface EditableTitleProps {
+  value: string;
+  editing: boolean;
+  onEditStart: () => void;
+  onEditEnd: () => void;
+  onSave: (next: string) => void;
+  displayClassName?: string;
+  inputClassName?: string;
+  inputAriaLabel?: string;
+  onDisplayClick?: (e: React.MouseEvent<HTMLSpanElement>) => void;
+}
+
+export function EditableTitle({
+  value,
+  editing,
+  onEditStart,
+  onEditEnd,
+  onSave,
+  displayClassName,
+  inputClassName,
+  inputAriaLabel = "Session title",
+  onDisplayClick,
+}: EditableTitleProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const commit = () => {
+    if (cancelledRef.current) {
+      cancelledRef.current = false;
+      return;
+    }
+    const next = inputRef.current?.value ?? value;
+    onEditEnd();
+    if (next !== value) onSave(next);
+  };
+
+  const cancel = () => {
+    cancelledRef.current = true;
+    onEditEnd();
+  };
+
+  const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      e.stopPropagation();
+      commit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      cancel();
+    } else {
+      e.stopPropagation();
+    }
+  };
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        aria-label={inputAriaLabel}
+        defaultValue={value}
+        maxLength={200}
+        onKeyDown={handleKey}
+        onClick={(e) => e.stopPropagation()}
+        onBlur={commit}
+        className={inputClassName}
+      />
+    );
+  }
+
+  return (
+    <span
+      onClick={(e) => {
+        onDisplayClick?.(e);
+        if (e.defaultPrevented) return;
+        onEditStart();
+      }}
+      className={displayClassName}
+    >
+      {value}
+    </span>
+  );
+}

--- a/web/src/components/FilterPanel.tsx
+++ b/web/src/components/FilterPanel.tsx
@@ -1,4 +1,4 @@
-import { Trash } from "lucide-react";
+import { Trash2 } from "lucide-react";
 
 interface FilterPanelProps {
   deletedCount: number;
@@ -24,7 +24,7 @@ export function FilterPanel({ deletedCount, onOpenTrash }: FilterPanelProps) {
           className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-card"
         >
           <span className="flex items-center gap-2">
-            <Trash size={14} aria-hidden="true" />
+            <Trash2 size={14} aria-hidden="true" />
             Trash
           </span>
           <span className="rounded-full bg-card px-2 text-xs font-semibold tabular-nums text-muted-foreground">

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useState } from "react";
-import { ArrowLeft, RotateCcw, Trash2 } from "lucide-react";
+import { ArrowLeft, Pencil, RotateCcw, Trash2 } from "lucide-react";
 import type { Session } from "@/types";
+import { EditableTitle } from "./EditableTitle";
 
 interface SessionListProps {
   mode?: "main" | "trash";
   sessions: Session[];
   selectedId: string | null;
+  editingId?: string | null;
+  onEditingIdChange?: (id: string | null) => void;
   onSelect: (id: string) => void;
   onDelete: (id: string) => void;
   onRestore?: (id: string) => void;
+  onRenameTitle?: (id: string, title: string) => void;
   onBack?: () => void;
   deletedCount?: number;
   onOpenTrash?: () => void;
@@ -39,17 +43,34 @@ interface ContextMenuState {
   y: number;
 }
 
+const TITLE_DISPLAY_CLASS =
+  "inline-block max-w-full truncate align-middle rounded px-1.5 py-0.5 -mx-1.5 text-sm font-medium text-accent-foreground cursor-text transition-colors group-hover:bg-white/[0.04]";
+const TITLE_INPUT_CLASS =
+  "min-w-[12ch] max-w-full rounded border border-border bg-transparent px-1.5 py-0.5 text-sm font-medium text-accent-foreground outline-none focus:border-primary [field-sizing:content]";
+
 export function SessionList({
   mode = "main",
   sessions,
   selectedId,
+  editingId: editingIdProp,
+  onEditingIdChange,
   onSelect,
   onDelete,
   onRestore,
+  onRenameTitle,
   onBack,
   deletedCount = 0,
   onOpenTrash,
 }: SessionListProps) {
+  const [internalEditingId, setInternalEditingId] = useState<string | null>(
+    null
+  );
+  const editingId =
+    editingIdProp !== undefined ? editingIdProp : internalEditingId;
+  const setEditingId = (next: string | null) => {
+    setInternalEditingId(next);
+    onEditingIdChange?.(next);
+  };
   const isTrash = mode === "trash";
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
 
@@ -130,23 +151,39 @@ export function SessionList({
             )}
           </div>
         ) : (
-          sessions.map((session) => (
-            <div
-              key={session.id}
-              className="group relative"
-              onContextMenu={(e) => handleContextMenu(e, session.id)}
-            >
-              <button
-                onClick={() => onSelect(session.id)}
-                className={`flex w-full flex-col gap-1 border-b border-border px-4 py-3 text-left transition-colors hover:bg-card ${
-                  session.id === selectedId
-                    ? "border-l-2 border-l-primary bg-card"
-                    : "border-l-2 border-l-transparent"
-                }`}
-              >
-                <span className="truncate text-sm font-medium text-accent-foreground">
-                  {session.title}
-                </span>
+          sessions.map((session) => {
+            const isSelected = session.id === selectedId;
+            const isEditing = editingId === session.id && !!onRenameTitle;
+            const rowClassName = `flex w-full flex-col gap-1 border-b border-border px-4 py-3 text-left transition-colors hover:bg-card ${
+              isSelected
+                ? "border-l-2 border-l-primary bg-card"
+                : "border-l-2 border-l-transparent"
+            }`;
+            const titleNode =
+              onRenameTitle && !isTrash ? (
+                <EditableTitle
+                  value={session.title}
+                  editing={isEditing}
+                  onEditStart={() => setEditingId(session.id)}
+                  onEditEnd={() => setEditingId(null)}
+                  onSave={(next) => onRenameTitle(session.id, next)}
+                  onDisplayClick={(e) => {
+                    if (isSelected) {
+                      e.stopPropagation();
+                    } else {
+                      e.preventDefault();
+                    }
+                  }}
+                  displayClassName={TITLE_DISPLAY_CLASS}
+                  inputClassName={TITLE_INPUT_CLASS}
+                  inputAriaLabel="Session title"
+                />
+              ) : (
+                <span className={TITLE_DISPLAY_CLASS}>{session.title}</span>
+              );
+            const rowContent = (
+              <>
+                <div className="min-w-0">{titleNode}</div>
                 <span className="flex items-center justify-between text-xs text-muted-foreground">
                   <span className="truncate">
                     {getProjectName(session.project)}
@@ -155,28 +192,51 @@ export function SessionList({
                     {getRelativeTime(session.updatedAt)}
                   </span>
                 </span>
-              </button>
-              {isTrash && onRestore ? (
-                <button
-                  type="button"
-                  aria-label={`Restore session: ${session.title}`}
-                  onClick={() => onRestore(session.id)}
-                  className="absolute top-2 right-2 rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground opacity-0 shadow-sm transition-all hover:border-[#5f7a26] hover:bg-[#1f2e15] hover:text-[#859900] group-hover:opacity-100 focus:opacity-100"
-                >
-                  <RotateCcw size={14} aria-hidden="true" />
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  aria-label={`Delete session: ${session.title}`}
-                  onClick={() => onDelete(session.id)}
-                  className="absolute top-2 right-2 rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground opacity-0 shadow-sm transition-all hover:border-[#a13836] hover:bg-[#3a1d23] hover:text-destructive group-hover:opacity-100 focus:opacity-100"
-                >
-                  <Trash2 size={14} aria-hidden="true" />
-                </button>
-              )}
-            </div>
-          ))
+              </>
+            );
+            return (
+              <div
+                key={session.id}
+                data-testid="session-row"
+                className="group relative"
+                onContextMenu={(e) => handleContextMenu(e, session.id)}
+              >
+                {isEditing ? (
+                  <div className={rowClassName}>{rowContent}</div>
+                ) : (
+                  <button
+                    onClick={() => onSelect(session.id)}
+                    className={rowClassName}
+                  >
+                    {rowContent}
+                  </button>
+                )}
+                <div className="absolute top-2 right-2 flex items-center gap-1">
+                  {isTrash && onRestore ? (
+                    <button
+                      type="button"
+                      aria-label={`Restore session: ${session.title}`}
+                      onClick={() => onRestore(session.id)}
+                      className="rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground opacity-0 shadow-sm transition-all hover:border-[#5f7a26] hover:bg-[#1f2e15] hover:text-[#859900] group-hover:opacity-100 focus:opacity-100"
+                    >
+                      <RotateCcw size={14} aria-hidden="true" />
+                    </button>
+                  ) : (
+                    !isEditing && (
+                      <button
+                        type="button"
+                        aria-label={`Delete session: ${session.title}`}
+                        onClick={() => onDelete(session.id)}
+                        className="rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground opacity-0 shadow-sm transition-all hover:border-[#a13836] hover:bg-[#3a1d23] hover:text-destructive group-hover:opacity-100 focus:opacity-100"
+                      >
+                        <Trash2 size={14} aria-hidden="true" />
+                      </button>
+                    )
+                  )}
+                </div>
+              </div>
+            );
+          })
         )}
       </div>
       {contextMenu && (
@@ -185,6 +245,23 @@ export function SessionList({
           className="fixed z-50 min-w-[180px] rounded-md border border-border bg-card py-1 text-sm shadow-lg"
           style={{ top: contextMenu.y, left: contextMenu.x }}
         >
+          {!isTrash && onRenameTitle && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setEditingId(contextMenu.sessionId);
+                setContextMenu(null);
+              }}
+              className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-accent"
+            >
+              <span className="flex items-center gap-2">
+                <Pencil size={14} aria-hidden="true" />
+                Rename
+              </span>
+              <span className="text-xs text-muted-foreground">F2</span>
+            </button>
+          )}
           {isTrash && onRestore ? (
             <button
               type="button"

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -48,6 +48,51 @@ const TITLE_DISPLAY_CLASS =
 const TITLE_INPUT_CLASS =
   "min-w-[12ch] max-w-full rounded border border-border bg-transparent px-1.5 py-0.5 text-sm font-medium text-accent-foreground outline-none focus:border-primary [field-sizing:content]";
 
+function MenuItem({
+  icon,
+  label,
+  hint,
+  destructive = false,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  hint: string;
+  destructive?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      className={`flex w-full items-center justify-between gap-6 rounded-md px-3 py-1.5 text-left transition-colors ${
+        destructive
+          ? "text-destructive hover:bg-[#3a1d23]"
+          : "hover:bg-white/[0.06]"
+      }`}
+    >
+      <span className="flex items-center gap-2">
+        {icon}
+        {label}
+      </span>
+      <span className="text-xs tabular-nums text-muted-foreground">{hint}</span>
+    </button>
+  );
+}
+
+function ActionTooltip({ label, hint }: { label: string; hint: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="pointer-events-none absolute right-full top-1/2 mr-1.5 flex -translate-y-1/2 items-center gap-1.5 whitespace-nowrap rounded-md border border-white/10 bg-[#0a0a0a] px-2 py-1 text-xs text-card-foreground opacity-0 shadow-lg transition-opacity duration-100 group-hover/action:opacity-100"
+    >
+      {label}
+      <span className="text-xs tabular-nums text-muted-foreground">{hint}</span>
+    </span>
+  );
+}
+
 export function SessionList({
   mode = "main",
   sessions,
@@ -77,11 +122,20 @@ export function SessionList({
   useEffect(() => {
     if (!contextMenu) return;
     const close = () => setContextMenu(null);
-    document.addEventListener("click", close);
-    document.addEventListener("contextmenu", close);
+    const closeOnEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setContextMenu(null);
+    };
+    // Defer attaching the click listener by one tick so the opening
+    // contextmenu event (which is followed by no native click) doesn't
+    // race a subsequent click handler from the same gesture.
+    const id = window.setTimeout(() => {
+      document.addEventListener("click", close);
+    }, 0);
+    document.addEventListener("keydown", closeOnEsc);
     return () => {
+      window.clearTimeout(id);
       document.removeEventListener("click", close);
-      document.removeEventListener("contextmenu", close);
+      document.removeEventListener("keydown", closeOnEsc);
     };
   }, [contextMenu]);
 
@@ -213,24 +267,30 @@ export function SessionList({
                 )}
                 <div className="absolute top-2 right-2 flex items-center gap-1">
                   {isTrash && onRestore ? (
-                    <button
-                      type="button"
-                      aria-label={`Restore session: ${session.title}`}
-                      onClick={() => onRestore(session.id)}
-                      className="rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground opacity-0 shadow-sm transition-all hover:border-[#5f7a26] hover:bg-[#1f2e15] hover:text-[#859900] group-hover:opacity-100 focus:opacity-100"
-                    >
-                      <RotateCcw size={14} aria-hidden="true" />
-                    </button>
-                  ) : (
-                    !isEditing && (
+                    <span className="group/action relative">
                       <button
                         type="button"
-                        aria-label={`Delete session: ${session.title}`}
-                        onClick={() => onDelete(session.id)}
-                        className="rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground opacity-0 shadow-sm transition-all hover:border-[#a13836] hover:bg-[#3a1d23] hover:text-destructive group-hover:opacity-100 focus:opacity-100"
+                        aria-label={`Restore: ${session.title}`}
+                        onClick={() => onRestore(session.id)}
+                        className="rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground opacity-0 shadow-sm transition-all hover:border-[#5f7a26] hover:bg-[#1f2e15] hover:text-[#859900] group-hover:opacity-100 focus:opacity-100"
                       >
-                        <Trash2 size={14} aria-hidden="true" />
+                        <RotateCcw size={14} aria-hidden="true" />
                       </button>
+                      <ActionTooltip label="Restore" hint="⌫" />
+                    </span>
+                  ) : (
+                    !isEditing && (
+                      <span className="group/action relative">
+                        <button
+                          type="button"
+                          aria-label={`Move to trash: ${session.title}`}
+                          onClick={() => onDelete(session.id)}
+                          className="rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground opacity-0 shadow-sm transition-all hover:border-[#a13836] hover:bg-[#3a1d23] hover:text-destructive group-hover:opacity-100 focus:opacity-100"
+                        >
+                          <Trash2 size={14} aria-hidden="true" />
+                        </button>
+                        <ActionTooltip label="Move to Trash" hint="⌫" />
+                      </span>
                     )
                   )}
                 </div>
@@ -242,52 +302,41 @@ export function SessionList({
       {contextMenu && (
         <div
           role="menu"
-          className="fixed z-50 min-w-[180px] rounded-md border border-border bg-card py-1 text-sm shadow-lg"
+          className="fixed z-50 min-w-[200px] rounded-md border border-border bg-card p-1 text-sm shadow-lg"
           style={{ top: contextMenu.y, left: contextMenu.x }}
         >
           {!isTrash && onRenameTitle && (
-            <button
-              type="button"
-              role="menuitem"
+            <MenuItem
+              icon={<Pencil size={14} aria-hidden="true" />}
+              label="Rename"
+              hint="F2 / ↵"
               onClick={() => {
                 setEditingId(contextMenu.sessionId);
                 setContextMenu(null);
               }}
-              className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-accent"
-            >
-              <span className="flex items-center gap-2">
-                <Pencil size={14} aria-hidden="true" />
-                Rename
-              </span>
-              <span className="text-xs text-muted-foreground">F2</span>
-            </button>
+            />
           )}
           {isTrash && onRestore ? (
-            <button
-              type="button"
-              role="menuitem"
+            <MenuItem
+              icon={<RotateCcw size={14} aria-hidden="true" />}
+              label="Restore"
+              hint="⌫"
               onClick={() => {
                 onRestore(contextMenu.sessionId);
                 setContextMenu(null);
               }}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-accent"
-            >
-              <RotateCcw size={14} aria-hidden="true" />
-              Restore session
-            </button>
+            />
           ) : (
-            <button
-              type="button"
-              role="menuitem"
+            <MenuItem
+              icon={<Trash2 size={14} aria-hidden="true" />}
+              label="Move to Trash"
+              hint="⌫"
+              destructive
               onClick={() => {
                 onDelete(contextMenu.sessionId);
                 setContextMenu(null);
               }}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-destructive transition-colors hover:bg-[#3a1d23]"
-            >
-              <Trash2 size={14} aria-hidden="true" />
-              Delete session
-            </button>
+            />
           )}
         </div>
       )}

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -6,26 +6,28 @@ interface UseSessionsResult {
   loading: boolean;
   softDelete: (id: string) => Promise<void>;
   restore: (id: string) => Promise<void>;
+  setTitle: (id: string, title: string) => Promise<void>;
+}
+
+function sortByUpdatedDesc(sessions: Session[]): Session[] {
+  return [...sessions].sort((a, b) => b.updatedAt - a.updatedAt);
 }
 
 export function useSessions(): UseSessionsResult {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    fetch("/api/sessions?includeTrashed=true")
-      .then((res) => res.json())
-      .then((data: { sessions: Session[] }) => {
-        const sorted = [...data.sessions].sort(
-          (a, b) => b.updatedAt - a.updatedAt
-        );
-        setSessions(sorted);
-        setLoading(false);
-      })
-      .catch(() => {
-        setLoading(false);
-      });
+  const fetchSessions = useCallback(async () => {
+    const res = await fetch("/api/sessions?includeTrashed=true");
+    const data = (await res.json()) as { sessions: Session[] };
+    setSessions(sortByUpdatedDesc(data.sessions));
   }, []);
+
+  useEffect(() => {
+    fetchSessions()
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [fetchSessions]);
 
   const softDelete = useCallback(async (id: string) => {
     setSessions((prev) =>
@@ -45,5 +47,25 @@ export function useSessions(): UseSessionsResult {
     });
   }, []);
 
-  return { sessions, loading, softDelete, restore };
+  const setTitle = useCallback(
+    async (id: string, title: string) => {
+      const trimmed = title.trim();
+      if (trimmed.length > 0) {
+        setSessions((prev) =>
+          prev.map((s) => (s.id === id ? { ...s, title: trimmed } : s))
+        );
+      }
+      await fetch(`/api/sessions/${encodeURIComponent(id)}/title`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title }),
+      });
+      if (trimmed.length === 0) {
+        await fetchSessions();
+      }
+    },
+    [fetchSessions]
+  );
+
+  return { sessions, loading, softDelete, restore, setTitle };
 }

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -2,7 +2,8 @@ import { http, HttpResponse } from "msw";
 
 type FakeSession = {
   id: string;
-  title: string;
+  defaultTitle: string;
+  customTitle: string | null;
   project: string;
   createdAt: number;
   updatedAt: number;
@@ -12,35 +13,40 @@ type FakeSession = {
 const initialFakeSessions: FakeSession[] = [
   {
     id: "session-1",
-    title: "Build a login page",
+    defaultTitle: "Build a login page",
+    customTitle: null,
     project: "/Users/test/my-web-app",
     createdAt: 1700000000000,
     updatedAt: 1700000200000,
   },
   {
     id: "session-2",
-    title: "Fix database migration",
+    defaultTitle: "Fix database migration",
+    customTitle: null,
     project: "/Users/test/backend-api",
     createdAt: 1700000100000,
     updatedAt: 1700000300000,
   },
   {
     id: "session-3",
-    title: "Refactor utils",
+    defaultTitle: "Refactor utils",
+    customTitle: null,
     project: "/Users/test/my-web-app",
     createdAt: 1700000050000,
     updatedAt: 1700000150000,
   },
   {
     id: "session-missing",
-    title: "Untitled",
+    defaultTitle: "Untitled",
+    customTitle: null,
     project: "/Users/test/some-project",
     createdAt: 1699999900000,
     updatedAt: 1699999900000,
   },
   {
     id: "session-deleted-1",
-    title: "Old prototype",
+    defaultTitle: "Old prototype",
+    customTitle: null,
     project: "/Users/test/my-web-app",
     createdAt: 1699999000000,
     updatedAt: 1699999500000,
@@ -127,14 +133,36 @@ export const fakeMessages = {
   ],
 };
 
+function projectSession(s: FakeSession) {
+  const { defaultTitle, customTitle, ...rest } = s;
+  return { ...rest, title: customTitle ?? defaultTitle };
+}
+
 export const handlers = [
   http.get("/api/sessions", ({ request }) => {
     const url = new URL(request.url);
     const includeTrashed = url.searchParams.get("includeTrashed") === "true";
-    const sessions = includeTrashed
+    const filtered = includeTrashed
       ? fakeSessions
       : fakeSessions.filter((s) => !s.isDeleted);
-    return HttpResponse.json({ sessions });
+    return HttpResponse.json({ sessions: filtered.map(projectSession) });
+  }),
+  http.patch("/api/sessions/:id/title", async ({ params, request }) => {
+    const id = params.id as string;
+    const session = fakeSessions.find((s) => s.id === id);
+    if (!session) {
+      return HttpResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+    const body = (await request.json()) as { title?: unknown };
+    if (typeof body?.title !== "string") {
+      return HttpResponse.json({ error: "Invalid title" }, { status: 400 });
+    }
+    if (body.title.length > 200) {
+      return HttpResponse.json({ error: "Title too long" }, { status: 400 });
+    }
+    const trimmed = body.title.trim();
+    session.customTitle = trimmed.length > 0 ? trimmed : null;
+    return new HttpResponse(null, { status: 204 });
   }),
   http.get("/api/sessions/:id", ({ params }) => {
     const id = params.id as string;


### PR DESCRIPTION
## Background (Why)

By default, session titles in the list and conversation header come from the first user message of the conversation, derived from the source JSONL at read time. Users wanted to override that — to mark important sessions, group work by their own naming, or just rename "Untitled" rows. Issue #9 is part of the Curation basics milestone.

## Approach (How)

The `data.db.sessions_meta.custom_title` column was already in place from #6. This PR wires it through the read path, the write path, and the UI:

- **API**: a new `PATCH /api/sessions/:id/title` endpoint. Body `{ title: string }`. Trim whitespace; empty or whitespace-only clears the custom title and falls back to the derived default. 200-char cap. 404 / 400 / 204.
- **UI**: a small `EditableTitle` component shared between the session list and the conversation header. Click a title to enter edit mode. In the list, an unselected row's title click selects the session, a selected row's title click enters rename (macOS Finder pattern); the header always edits since it always reflects the selected session. F2 / Enter on a selected session, plus a Rename item in the right-click context menu, also enter edit mode. Hovering a title shows a subtle background tint as a discoverability cue. The input is a thin 1px border (turns primary on focus), with width auto-fitting via CSS `field-sizing: content`. Enter / blur saves, Esc cancels; an empty save clears and reverts to the derived title via a refetch.
- **Context menu**: the right-click menu carries the Rename action alongside the existing destructive one. Items renamed for precision ("Delete session" -> "Move to Trash", "Restore session" -> "Restore") and given keyboard hints (Rename: F2 / ↵; Move to Trash / Restore: ⌫). Hover rows are rounded and inset, with a neutral tint for non-destructive actions and red reserved for Move to Trash. The list's trash / restore icon buttons gain hover tooltips, and the Trash entry icon is unified with the row delete icon (Trash2).

Visibility flags, soft delete, and trash all keep working unchanged: `deriveTitle` simply prefers `custom_title` over the derived default at read time.

## Changes (What)

- [x] `api/src/app.ts` — `PATCH /api/sessions/:id/title` with trim, clear-on-empty, length cap
- [x] `api/src/app.test.ts` — 7 integration tests covering update, clear, whitespace, trim, 404, 400 type, 400 length
- [x] `web/src/components/EditableTitle.tsx` — controlled display/input toggle, Enter / Esc / blur handling
- [x] `web/src/components/SessionList.tsx` — click-to-edit on selected rows, hover tint cue, Rename / Move to Trash / Restore context menu, hover tooltips on icon buttons, delete icon hidden during edit
- [x] `web/src/components/ConversationView.tsx` — header click-to-edit with always-on cursor:text and hover tint
- [x] `web/src/components/FilterPanel.tsx` — unify the Trash entry icon with the row delete icon (Trash2)
- [x] `web/src/App.tsx` — lifted editing state, F2 / Enter shortcuts on selected session
- [x] `web/src/hooks/useSessions.ts` — `setTitle` with optimistic update; refetch on clear so derived fallback returns
- [x] `web/src/test/handlers.ts` — MSW PATCH handler matching server semantics
- [x] `web/src/App.test.tsx` — UI tests for header edit, list edit, Esc cancel, clear-to-revert, Rename menu, F2 shortcut, and context-menu reopen / Escape-close

## Test Verification

- [x] `pnpm test` — 131/131 passing (api 80, web 51)
- [x] `pnpm typecheck` clean across workspaces
- [x] Right-click context menu verified in a real browser via Playwright (open, reopen, outside-click close, Escape close)
- [x] Custom title persists across app restarts (stored in `sessions_meta`)
- [x] Empty save reverts both list row and header to the derived first-user-message title

## Additional Notes

- "Click the title" interpretation: a literal reading of the acceptance criterion would never select an unselected row from a title click. The Finder pattern (unselected → select, selected → edit) preserves session-switching by clicking anywhere on the row while still giving an obvious click-to-edit affordance, and matches a UI pattern most users already know. The hover tint, F2, and Rename menu compensate for any discoverability hit.
- Context menu listener ordering: an early version closed the menu via a document-level `contextmenu` listener, which fired in the same event that the row handler opened it (React's delegated handler runs before the document-level listener, so the close won and the menu could not reopen). The menu now closes only on outside click (deferred one tick) or Escape.
- `field-sizing: content` is Chrome 123+ / Safari 18.2+. Older browsers fall back to the default input width — usable, just not as tight.

## Related Links

- Closes #9