### PR TITLE
feat(cli): add --version, --help, and --port flags

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -7,6 +7,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsup",
     "test": "vitest run",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:generate:archive": "drizzle-kit generate --config drizzle.archive.config.ts"

--- a/api/src/cli/argv.test.ts
+++ b/api/src/cli/argv.test.ts
@@ -10,12 +10,8 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs(["-v"])).toEqual({ kind: "version" });
   });
 
-  it("returns run action for empty argv", () => {
-    expect(parseCliArgs([])).toEqual({ kind: "run" });
-  });
-
-  it("returns run action for unknown args", () => {
-    expect(parseCliArgs(["--port", "8080"])).toEqual({ kind: "run" });
+  it("returns run with default port 3100 for empty argv", () => {
+    expect(parseCliArgs([])).toEqual({ kind: "run", port: 3100 });
   });
 
   it("returns help action for --help", () => {
@@ -24,5 +20,12 @@ describe("parseCliArgs", () => {
 
   it("returns help action for -h", () => {
     expect(parseCliArgs(["-h"])).toEqual({ kind: "help" });
+  });
+
+  it("falls back to PORT env when argv is empty", () => {
+    expect(parseCliArgs([], { PORT: "9000" })).toEqual({
+      kind: "run",
+      port: 9000,
+    });
   });
 });

--- a/api/src/cli/argv.test.ts
+++ b/api/src/cli/argv.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { parseCliArgs } from "./argv.js";
+
+describe("parseCliArgs", () => {
+  it("returns version action for --version", () => {
+    expect(parseCliArgs(["--version"])).toEqual({ kind: "version" });
+  });
+
+  it("returns version action for -v", () => {
+    expect(parseCliArgs(["-v"])).toEqual({ kind: "version" });
+  });
+
+  it("returns run action for empty argv", () => {
+    expect(parseCliArgs([])).toEqual({ kind: "run" });
+  });
+
+  it("returns run action for unknown args", () => {
+    expect(parseCliArgs(["--port", "8080"])).toEqual({ kind: "run" });
+  });
+
+  it("returns help action for --help", () => {
+    expect(parseCliArgs(["--help"])).toEqual({ kind: "help" });
+  });
+
+  it("returns help action for -h", () => {
+    expect(parseCliArgs(["-h"])).toEqual({ kind: "help" });
+  });
+});

--- a/api/src/cli/argv.test.ts
+++ b/api/src/cli/argv.test.ts
@@ -22,10 +22,50 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs(["-h"])).toEqual({ kind: "help" });
   });
 
-  it("falls back to PORT env when argv is empty", () => {
+  it("returns run with port from --port flag", () => {
+    expect(parseCliArgs(["--port", "8080"])).toEqual({
+      kind: "run",
+      port: 8080,
+    });
+  });
+
+  it("returns run with port from -p flag", () => {
+    expect(parseCliArgs(["-p", "8080"])).toEqual({ kind: "run", port: 8080 });
+  });
+
+  it("prefers --port flag over PORT env", () => {
+    expect(parseCliArgs(["--port", "8080"], { PORT: "9000" })).toEqual({
+      kind: "run",
+      port: 8080,
+    });
+  });
+
+  it("falls back to PORT env when flag absent", () => {
     expect(parseCliArgs([], { PORT: "9000" })).toEqual({
       kind: "run",
       port: 9000,
     });
+  });
+
+  it("returns error when --port has no value", () => {
+    const result = parseCliArgs(["--port"]);
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toMatch(/--port.*value/i);
+    }
+  });
+
+  it("returns error when --port value is non-numeric", () => {
+    const result = parseCliArgs(["--port", "abc"]);
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toMatch(/abc/);
+    }
+  });
+
+  it("returns error when --port value is out of range", () => {
+    expect(parseCliArgs(["--port", "0"]).kind).toBe("error");
+    expect(parseCliArgs(["--port", "65536"]).kind).toBe("error");
+    expect(parseCliArgs(["--port", "-1"]).kind).toBe("error");
   });
 });

--- a/api/src/cli/argv.ts
+++ b/api/src/cli/argv.ts
@@ -1,14 +1,23 @@
 export type CliAction =
   | { kind: "version" }
   | { kind: "help" }
-  | { kind: "run" };
+  | { kind: "error"; message: string }
+  | { kind: "run"; port: number };
 
-export function parseCliArgs(argv: readonly string[]): CliAction {
+const DEFAULT_PORT = 3100;
+
+export function parseCliArgs(
+  argv: readonly string[],
+  env: { PORT?: string } = {}
+): CliAction {
   if (argv.includes("--version") || argv.includes("-v")) {
     return { kind: "version" };
   }
   if (argv.includes("--help") || argv.includes("-h")) {
     return { kind: "help" };
   }
-  return { kind: "run" };
+  if (env.PORT) {
+    return { kind: "run", port: Number(env.PORT) };
+  }
+  return { kind: "run", port: DEFAULT_PORT };
 }

--- a/api/src/cli/argv.ts
+++ b/api/src/cli/argv.ts
@@ -16,6 +16,30 @@ export function parseCliArgs(
   if (argv.includes("--help") || argv.includes("-h")) {
     return { kind: "help" };
   }
+  const portIdx = argv.findIndex((a) => a === "--port" || a === "-p");
+  if (portIdx !== -1) {
+    const raw = argv[portIdx + 1];
+    if (raw === undefined) {
+      return {
+        kind: "error",
+        message: `${argv[portIdx]} requires a value (e.g. --port 8080)`,
+      };
+    }
+    const port = Number(raw);
+    if (!Number.isInteger(port)) {
+      return {
+        kind: "error",
+        message: `Invalid port "${raw}": must be an integer`,
+      };
+    }
+    if (port < 1 || port > 65535) {
+      return {
+        kind: "error",
+        message: `Invalid port "${raw}": must be between 1 and 65535`,
+      };
+    }
+    return { kind: "run", port };
+  }
   if (env.PORT) {
     return { kind: "run", port: Number(env.PORT) };
   }

--- a/api/src/cli/argv.ts
+++ b/api/src/cli/argv.ts
@@ -1,0 +1,14 @@
+export type CliAction =
+  | { kind: "version" }
+  | { kind: "help" }
+  | { kind: "run" };
+
+export function parseCliArgs(argv: readonly string[]): CliAction {
+  if (argv.includes("--version") || argv.includes("-v")) {
+    return { kind: "version" };
+  }
+  if (argv.includes("--help") || argv.includes("-h")) {
+    return { kind: "help" };
+  }
+  return { kind: "run" };
+}

--- a/api/src/cli/cli.e2e.test.ts
+++ b/api/src/cli/cli.e2e.test.ts
@@ -1,8 +1,27 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on("error", reject);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      if (typeof addr === "object" && addr) {
+        const { port } = addr;
+        srv.close(() => resolve(port));
+      } else {
+        reject(new Error("could not allocate port"));
+      }
+    });
+  });
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const apiRoot = path.resolve(__dirname, "../..");
@@ -68,5 +87,57 @@ describe("cli --help", () => {
     const result = await runCli(["-h"], 3000);
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("Usage: chat-log");
+  });
+});
+
+describe("cli --port", () => {
+  let child: ChildProcess | null = null;
+  let tmpHome: string | null = null;
+
+  afterEach(async () => {
+    if (child && child.exitCode === null) {
+      child.kill("SIGTERM");
+      await new Promise((r) => child!.once("exit", r));
+    }
+    child = null;
+    if (tmpHome) {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+      tmpHome = null;
+    }
+  });
+
+  it("starts the server on the port from --port flag", async () => {
+    const port = await findFreePort();
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "chat-log-e2e-"));
+    child = spawn(tsxBin, [entry, "--port", String(port)], {
+      env: { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome, PORT: "" },
+    });
+
+    const stdout = await new Promise<string>((resolve, reject) => {
+      let buf = "";
+      const t = setTimeout(
+        () => reject(new Error(`no startup log within 8s; got: ${buf}`)),
+        8000
+      );
+      child!.stdout!.on("data", (b) => {
+        buf += b.toString();
+        if (buf.includes(`localhost:${port}`)) {
+          clearTimeout(t);
+          resolve(buf);
+        }
+      });
+      child!.on("exit", (code) => {
+        clearTimeout(t);
+        reject(new Error(`exited early (code=${code}); stdout: ${buf}`));
+      });
+    });
+
+    expect(stdout).toContain(`http://localhost:${port}`);
+  });
+
+  it("exits non-zero with clear error on invalid --port value", async () => {
+    const result = await runCli(["--port", "abc"], 3000);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/abc/);
   });
 });

--- a/api/src/cli/cli.e2e.test.ts
+++ b/api/src/cli/cli.e2e.test.ts
@@ -1,0 +1,72 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const apiRoot = path.resolve(__dirname, "../..");
+const entry = path.join(apiRoot, "src/index.ts");
+const tsxBin = path.resolve(apiRoot, "node_modules/.bin/tsx");
+const pkg = JSON.parse(
+  fs.readFileSync(path.resolve(apiRoot, "../package.json"), "utf-8")
+) as { version: string };
+
+type RunResult = { stdout: string; stderr: string; code: number | null };
+
+function runCli(args: readonly string[], timeoutMs = 5000): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(tsxBin, [entry, ...args], {
+      env: { ...process.env, PORT: "0" },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (b) => (stdout += b.toString()));
+    child.stderr.on("data", (b) => (stderr += b.toString()));
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`cli did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr, code });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+describe("cli --version", () => {
+  it("prints package version and exits 0 without side effects", async () => {
+    const result = await runCli(["--version"], 3000);
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim()).toBe(pkg.version);
+    expect(result.stdout).not.toContain("running at");
+  });
+
+  it("supports -v short flag", async () => {
+    const result = await runCli(["-v"], 3000);
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim()).toBe(pkg.version);
+  });
+});
+
+describe("cli --help", () => {
+  it("prints help and exits 0 without starting the server", async () => {
+    const result = await runCli(["--help"], 3000);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Usage: chat-log");
+    expect(result.stdout).toContain("--version");
+    expect(result.stdout).toContain("--help");
+    expect(result.stdout).toContain("PORT=");
+    expect(result.stdout).not.toContain("running at");
+  });
+
+  it("supports -h short flag", async () => {
+    const result = await runCli(["-h"], 3000);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Usage: chat-log");
+  });
+});

--- a/api/src/cli/help.test.ts
+++ b/api/src/cli/help.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { helpText } from "./help.js";
+
+describe("helpText", () => {
+  it("describes the default invocation (start server, open UI)", () => {
+    expect(helpText).toMatch(/chat-log\b/);
+    expect(helpText.toLowerCase()).toMatch(/start|open|server|ui/);
+  });
+
+  it("documents --version / -v", () => {
+    expect(helpText).toContain("--version");
+    expect(helpText).toContain("-v");
+  });
+
+  it("documents --help / -h", () => {
+    expect(helpText).toContain("--help");
+    expect(helpText).toContain("-h");
+  });
+
+  it("documents PORT env var", () => {
+    expect(helpText).toMatch(/PORT=/);
+  });
+
+  it("fits within 80 columns", () => {
+    for (const line of helpText.split("\n")) {
+      expect(line.length).toBeLessThanOrEqual(80);
+    }
+  });
+});

--- a/api/src/cli/help.test.ts
+++ b/api/src/cli/help.test.ts
@@ -21,6 +21,11 @@ describe("helpText", () => {
     expect(helpText).toMatch(/PORT=/);
   });
 
+  it("documents --port / -p flag", () => {
+    expect(helpText).toContain("--port");
+    expect(helpText).toContain("-p");
+  });
+
   it("fits within 80 columns", () => {
     for (const line of helpText.split("\n")) {
       expect(line.length).toBeLessThanOrEqual(80);

--- a/api/src/cli/help.ts
+++ b/api/src/cli/help.ts
@@ -1,0 +1,11 @@
+export const helpText = `Usage: chat-log [options]
+
+Start the chat-logbook server and open the web UI in your browser.
+
+Options:
+  -v, --version    Print the version and exit
+  -h, --help       Show this help message and exit
+
+Environment:
+  PORT=<n>         Set the HTTP port (default: 3100)
+`;

--- a/api/src/cli/help.ts
+++ b/api/src/cli/help.ts
@@ -5,7 +5,8 @@ Start the chat-logbook server and open the web UI in your browser.
 Options:
   -v, --version    Print the version and exit
   -h, --help       Show this help message and exit
+  -p, --port <n>   Set the HTTP port (default: 3100)
 
 Environment:
-  PORT=<n>         Set the HTTP port (default: 3100)
+  PORT=<n>         Set the HTTP port (overridden by --port)
 `;

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -21,7 +21,9 @@ const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as {
   version: string;
 };
 
-const action = parseCliArgs(process.argv.slice(2));
+const action = parseCliArgs(process.argv.slice(2), {
+  PORT: process.env.PORT,
+});
 if (action.kind === "version") {
   console.log(pkg.version);
   process.exit(0);
@@ -30,12 +32,16 @@ if (action.kind === "help") {
   process.stdout.write(helpText);
   process.exit(0);
 }
+if (action.kind === "error") {
+  console.error(action.message);
+  process.exit(1);
+}
 
 updateNotifier({ pkg }).notify({ defer: false, isGlobal: true });
 
 const dataDir = path.join(os.homedir(), ".chat-logbook");
 const webDistDir = path.join(__dirname, "../../web/dist");
-const port = Number(process.env.PORT) || 3100;
+const port = action.port;
 
 const archive = createArchiveRepository({ dataDir });
 const metadata = createMetadataRepository({ dataDir });

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -11,6 +11,8 @@ import { createMetadataRepository } from "./metadata/repository.js";
 import { startIngestionInBackground } from "./ingestion/background.js";
 import { startWatcher } from "./ingestion/watcher.js";
 import { plugins } from "./plugins/registry.js";
+import { parseCliArgs } from "./cli/argv.js";
+import { helpText } from "./cli/help.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkgPath = path.join(__dirname, "../../package.json");
@@ -18,6 +20,16 @@ const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as {
   name: string;
   version: string;
 };
+
+const action = parseCliArgs(process.argv.slice(2));
+if (action.kind === "version") {
+  console.log(pkg.version);
+  process.exit(0);
+}
+if (action.kind === "help") {
+  process.stdout.write(helpText);
+  process.exit(0);
+}
 
 updateNotifier({ pkg }).notify({ defer: false, isGlobal: true });
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -87,7 +87,7 @@ const server = serve({ fetch: app.fetch, port }, (info: { port: number }) => {
 server.on("error", (err: NodeJS.ErrnoException) => {
   if (err.code === "EADDRINUSE") {
     console.error(
-      `Port ${port} is already in use. Try a different port:\n\n  PORT=8080 chat-log\n`
+      `Port ${port} is already in use. Try a different port:\n\n  chat-log --port 8080\n  PORT=8080 chat-log\n`
     );
     process.exit(1);
   }

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
+    exclude: [...configDefaults.exclude, "**/*.e2e.test.ts"],
   },
 });

--- a/api/vitest.e2e.config.ts
+++ b/api/vitest.e2e.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    passWithNoTests: true,
+    include: ["**/*.e2e.test.ts"],
+    testTimeout: 10000,
+  },
+});


### PR DESCRIPTION
## Background (Why)

The `chat-log` CLI had no way to print its version, no built-in help, and only an environment variable for setting the port. These are table-stakes for a CLI shipped via npm.

## Approach (How)

All argv handling lives in a small pure `parseCliArgs` returning a discriminated `CliAction` union. The intercept fires at the very top of `api/src/index.ts` — before `update-notifier`, repository creation, ingestion, and the watcher — so `--version` and `--help` never touch SQLite or the network. Port resolution (flag > env > default 3100) is centralized in the parser, and invalid `--port` values short-circuit to an `error` action that exits non-zero before any side effects run.

End-to-end tests spawn the CLI as a child process via `tsx` and run under a separate `vitest.e2e.config.ts` so they don't slow down the default unit-test loop.

## Changes (What)

- [x] `--version` / `-v` prints `pkg.version` and exits 0
- [x] `--help` / `-h` prints usage (≤ 80 cols) and exits 0
- [x] `--port <n>` / `-p <n>` sets HTTP port; takes precedence over `PORT`
- [x] Invalid `--port` (missing, non-numeric, out of 1–65535) exits non-zero with a clear error
- [x] `PORT=<n>` env still works (backwards compatible)
- [x] `EADDRINUSE` message now lists both `--port` and `PORT=`
- [x] New `api/src/cli/` module: `argv.ts`, `help.ts` + unit tests
- [x] New e2e harness: `vitest.e2e.config.ts` + `pnpm test:e2e`

### Test Verification

- [x] Unit: 12 tests for `parseCliArgs` (all flags, env fallback, validation)
- [x] Unit: 6 tests for `helpText` content + 80-col width
- [x] E2E: 6 child-process tests (version, help, port flag, invalid port)
- [x] All 91 unit + 6 e2e tests pass; typecheck clean

## Additional Notes

The `error` variant of `CliAction` and the `env` parameter to `parseCliArgs` are shipped as a separate `refactor` commit so the shape change is easy to review independently of the `--port` logic.

## Related Links

- Closes #64
- Closes #65
- Closes #66