### PR TITLE
fix(plugins): detect project when cwd sits past the first 64KB

### DIFF
--- a/api/src/ingestion/ingest.test.ts
+++ b/api/src/ingestion/ingest.test.ts
@@ -300,4 +300,69 @@ describe("runIngestion", () => {
       expect(rawAfter.some((a) => a.id === r.id)).toBe(true);
     }
   });
+
+  it("fills in a session's project on a later scan once cwd is resolvable", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const pluginsList = [new ClaudeCodePlugin()];
+
+    // A session whose source carries no cwd: its project is unknown.
+    const projectDir = path.join(
+      env.homeDir,
+      ".claude",
+      "projects",
+      "-Users-test-late-app"
+    );
+    fs.mkdirSync(projectDir, { recursive: true });
+    const sourceFile = path.join(projectDir, "late.jsonl");
+    fs.writeFileSync(
+      sourceFile,
+      JSON.stringify({ type: "file-history-snapshot", messageId: "m0" }) +
+        "\n" +
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "hi" },
+          uuid: "u1",
+          timestamp: "2024-01-01T00:00:01Z",
+        }) +
+        "\n"
+    );
+
+    await runIngestion({
+      plugins: pluginsList,
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+    const before = archive.db
+      .select()
+      .from(sessions)
+      .all()
+      .find((s) => s.sourceSessionId === "late");
+    expect(before?.project).toBeNull();
+
+    // A later message now carries cwd (e.g. read further into the file).
+    fs.appendFileSync(
+      sourceFile,
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: "more" },
+        uuid: "u2",
+        timestamp: "2024-01-01T00:00:02Z",
+        cwd: "/Users/test/late-app",
+      }) + "\n"
+    );
+
+    await runIngestion({
+      plugins: pluginsList,
+      archive,
+      env: { homeDir: env.homeDir },
+    });
+    const after = archive.db
+      .select()
+      .from(sessions)
+      .all()
+      .find((s) => s.sourceSessionId === "late");
+    expect(after?.project).toBe("late-app");
+
+    archive.close();
+  });
 });

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -83,6 +83,53 @@ describe("ClaudeCodePlugin.discover", () => {
       expect(refs[0].project).toBe("my-app");
     });
   });
+
+  describe("when the first cwd line sits beyond the first 64KB", () => {
+    let tmpHome: string;
+
+    beforeEach(() => {
+      tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-bigcwd-"));
+      const projectsDir = path.join(
+        tmpHome,
+        ".claude/projects/-Users-test-my-app"
+      );
+      fs.mkdirSync(projectsDir, { recursive: true });
+      // A pasted screenshot makes the first user message a single ~80KB line
+      // with no cwd; cwd only appears on the next, smaller line.
+      const hugeContent = "x".repeat(80 * 1024);
+      const lines = [
+        JSON.stringify({ type: "file-history-snapshot", messageId: "m0" }),
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: hugeContent },
+          uuid: "u1",
+          timestamp: "2024-01-01T00:00:01Z",
+        }),
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "hi" },
+          uuid: "u2",
+          timestamp: "2024-01-01T00:00:02Z",
+          cwd: "/Users/test/my-app",
+          sessionId: "sx",
+        }),
+      ];
+      fs.writeFileSync(
+        path.join(projectsDir, "sx.jsonl"),
+        lines.join("\n") + "\n"
+      );
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    });
+
+    it("still derives project from cwd", async () => {
+      const refs = await collect(plugin.discover({ homeDir: tmpHome }));
+      expect(refs).toHaveLength(1);
+      expect(refs[0].project).toBe("my-app");
+    });
+  });
 });
 
 describe("ClaudeCodePlugin.extractRaw", () => {

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -27,7 +27,7 @@ export class ClaudeCodePlugin implements AgentPlugin {
         if (!file.isFile() || !file.name.endsWith(".jsonl")) continue;
         const sourcePath = path.join(projectPath, file.name);
         const sessionId = file.name.replace(/\.jsonl$/, "");
-        const cwd = readCwdFromJsonl(sourcePath);
+        const cwd = await readCwdFromJsonl(sourcePath);
         yield {
           sessionId,
           sourcePath,
@@ -101,37 +101,34 @@ export class ClaudeCodePlugin implements AgentPlugin {
   }
 }
 
-function readCwdFromJsonl(sourcePath: string): string | undefined {
-  let fd: number | undefined;
+// Stream lines until the first one carrying a cwd. A fixed-size head read
+// would miss the cwd when an earlier message embeds a large pasted image,
+// pushing every cwd-bearing line past the buffer.
+async function readCwdFromJsonl(
+  sourcePath: string
+): Promise<string | undefined> {
   try {
-    fd = fs.openSync(sourcePath, "r");
-    const buf = Buffer.alloc(64 * 1024);
-    const n = fs.readSync(fd, buf, 0, buf.length, 0);
-    const head = buf.subarray(0, n).toString("utf-8");
-    const lines = head.split("\n");
-    // Drop the last fragment; it may be a partial line if we truncated.
-    if (n === buf.length) lines.pop();
-    for (const line of lines) {
-      if (!line) continue;
-      try {
-        const obj = JSON.parse(line) as { cwd?: unknown };
+    const stream = fs.createReadStream(sourcePath, { encoding: "utf-8" });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    try {
+      for await (const line of rl) {
+        if (!line) continue;
+        let obj: { cwd?: unknown };
+        try {
+          obj = JSON.parse(line) as { cwd?: unknown };
+        } catch {
+          continue; // Ignore malformed lines.
+        }
         if (typeof obj.cwd === "string" && obj.cwd.length > 0) {
           return obj.cwd;
         }
-      } catch {
-        // Ignore malformed lines.
       }
+    } finally {
+      rl.close();
+      stream.destroy();
     }
   } catch {
     // Ignore I/O errors; fall back to undefined project.
-  } finally {
-    if (fd !== undefined) {
-      try {
-        fs.closeSync(fd);
-      } catch {
-        // ignore
-      }
-    }
   }
   return undefined;
 }


### PR DESCRIPTION
## Background (Why)

Closes #69.

A session showed no project in the UI: `e70492b1-44b3-4d13-a4a4-2c7e60009613`. The project is derived from the `cwd` field of the session JSONL via `readCwdFromJsonl()`, which only read the first 64KB of the file. When an
earlier message embeds a large pasted screenshot (base64), that single line can be ~280KB — pushing every `cwd`-bearing line past the 64KB window. `readCwdFromJsonl()` then returns `undefined` and the session has no project.

This was the only affected session because it is the only one whose first message embeds a large image.

## Approach (How)

Replace the fixed 64KB head read with a streaming line-by-line read that stops at the first line carrying a `cwd`. Normal sessions carry `cwd` on the first message line and stop almost immediately; pathological sessions read a few hundred KB more, which is acceptable. `readCwdFromJsonl()` becomes async; `discover()` awaits it.

No data migration is needed: affected sessions are repaired on the next on-app-open scan, since `ensureSession()` updates an existing session's `project` when a non-empty value differs from the stored one. No `archive.db` rows are touched.

## Changes (What)

- [ ] `readCwdFromJsonl()` streams lines instead of reading a fixed 64KB head
- [ ] `discover()` awaits the now-async `readCwdFromJsonl()`

### Test Verification

- [ ] `discover()` resolves the project when the first `cwd` line sits beyond 64KB (first message is an ~80KB line)
- [ ] A later on-app-open scan fills in a session's `project` once `cwd` becomes resolvable
- [ ] Existing claude-code plugin and ingestion tests still pass (full api suite: 100 passed)