### PR TITLE
fix(dev): move dev backend off port 3100 and open the frontend

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "PORT=3101 CHAT_LOGBOOK_NO_OPEN=1 tsx watch src/index.ts",
     "build": "tsup",
     "test": "vitest run",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",

--- a/api/src/cli/argv.test.ts
+++ b/api/src/cli/argv.test.ts
@@ -11,7 +11,7 @@ describe("parseCliArgs", () => {
   });
 
   it("returns run with default port 3100 for empty argv", () => {
-    expect(parseCliArgs([])).toEqual({ kind: "run", port: 3100 });
+    expect(parseCliArgs([])).toEqual({ kind: "run", port: 3100, open: true });
   });
 
   it("returns help action for --help", () => {
@@ -26,17 +26,23 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs(["--port", "8080"])).toEqual({
       kind: "run",
       port: 8080,
+      open: true,
     });
   });
 
   it("returns run with port from -p flag", () => {
-    expect(parseCliArgs(["-p", "8080"])).toEqual({ kind: "run", port: 8080 });
+    expect(parseCliArgs(["-p", "8080"])).toEqual({
+      kind: "run",
+      port: 8080,
+      open: true,
+    });
   });
 
   it("prefers --port flag over PORT env", () => {
     expect(parseCliArgs(["--port", "8080"], { PORT: "9000" })).toEqual({
       kind: "run",
       port: 8080,
+      open: true,
     });
   });
 
@@ -44,6 +50,7 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs([], { PORT: "9000" })).toEqual({
       kind: "run",
       port: 9000,
+      open: true,
     });
   });
 
@@ -67,5 +74,14 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs(["--port", "0"]).kind).toBe("error");
     expect(parseCliArgs(["--port", "65536"]).kind).toBe("error");
     expect(parseCliArgs(["--port", "-1"]).kind).toBe("error");
+  });
+
+  it("opens the browser by default", () => {
+    expect(parseCliArgs([])).toEqual({ kind: "run", port: 3100, open: true });
+  });
+
+  it("does not open the browser when CHAT_LOGBOOK_NO_OPEN is set", () => {
+    const result = parseCliArgs([], { CHAT_LOGBOOK_NO_OPEN: "1" });
+    expect(result).toEqual({ kind: "run", port: 3100, open: false });
   });
 });

--- a/api/src/cli/argv.ts
+++ b/api/src/cli/argv.ts
@@ -2,13 +2,13 @@ export type CliAction =
   | { kind: "version" }
   | { kind: "help" }
   | { kind: "error"; message: string }
-  | { kind: "run"; port: number };
+  | { kind: "run"; port: number; open: boolean };
 
 const DEFAULT_PORT = 3100;
 
 export function parseCliArgs(
   argv: readonly string[],
-  env: { PORT?: string } = {}
+  env: { PORT?: string; CHAT_LOGBOOK_NO_OPEN?: string } = {}
 ): CliAction {
   if (argv.includes("--version") || argv.includes("-v")) {
     return { kind: "version" };
@@ -16,6 +16,7 @@ export function parseCliArgs(
   if (argv.includes("--help") || argv.includes("-h")) {
     return { kind: "help" };
   }
+  const open = !env.CHAT_LOGBOOK_NO_OPEN;
   const portIdx = argv.findIndex((a) => a === "--port" || a === "-p");
   if (portIdx !== -1) {
     const raw = argv[portIdx + 1];
@@ -38,10 +39,10 @@ export function parseCliArgs(
         message: `Invalid port "${raw}": must be between 1 and 65535`,
       };
     }
-    return { kind: "run", port };
+    return { kind: "run", port, open };
   }
   if (env.PORT) {
-    return { kind: "run", port: Number(env.PORT) };
+    return { kind: "run", port: Number(env.PORT), open };
   }
-  return { kind: "run", port: DEFAULT_PORT };
+  return { kind: "run", port: DEFAULT_PORT, open };
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -81,7 +81,7 @@ function openBrowser(url: string): void {
 const server = serve({ fetch: app.fetch, port }, (info: { port: number }) => {
   const url = `http://localhost:${info.port}`;
   console.log(`chat-logbook is running at \x1b[36m${url}\x1b[0m`);
-  openBrowser(url);
+  if (action.open) openBrowser(url);
 });
 
 server.on("error", (err: NodeJS.ErrnoException) => {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,8 +11,9 @@ export default defineConfig({
     },
   },
   server: {
+    open: true,
     proxy: {
-      "/api": "http://localhost:3100",
+      "/api": "http://localhost:3101",
     },
   },
   test: {


### PR DESCRIPTION
## Background (Why)

Running `pnpm dev` had two friction points in the local dev loop:

1. The dev backend defaulted to port `3100` — the same port the released `chat-log` CLI uses. Running a production instance alongside `pnpm dev` caused a port clash.
2. `pnpm dev` auto-opened the **backend** port (`3100`) in the browser instead of the Vite **frontend** port (`5173`). The backend port serves only `/api` plus a possibly-stale `web/dist`, so you landed on a UI with no HMR.

## Approach (How)

The "should we open the browser?" decision is config interpretation, so it belongs in `parseCliArgs` alongside the existing `PORT` handling — the functional core — rather than inline in the imperative entry point. `parseCliArgs` now derives an `open` flag from the `CHAT_LOGBOOK_NO_OPEN` env var; `index.ts` only calls `openBrowser` when `action.open` is true.

The dev environment then opts out of backend browser-opening and onto a separate port, while Vite opens the frontend itself. The production `chat-log` CLI is untouched: with no `CHAT_LOGBOOK_NO_OPEN` set, `open` defaults to `true` and the default port stays `3100`.

## Changes (What)

- [x] `parseCliArgs` adds an `open: boolean` to its `run` action, derived from `CHAT_LOGBOOK_NO_OPEN`
- [x] `index.ts` gates `openBrowser` behind `action.open`
- [x] `api` dev script sets `PORT=3101 CHAT_LOGBOOK_NO_OPEN=1`
- [x] `web/vite.config.ts` adds `server.open: true` and points the `/api` proxy at `3101`

### Test Verification

- [x] `parseCliArgs` opens the browser by default (no env)
- [x] `parseCliArgs` returns `open: false` when `CHAT_LOGBOOK_NO_OPEN` is set
- [x] Full suite green: api 102, web 51; typecheck clean

## Additional Notes

- The production default port `3100` and the docs (README, CHANGELOG, `help.ts`) are intentionally unchanged.
- The `PORT=3101 CHAT_LOGBOOK_NO_OPEN=1` prefix syntax does not work on Windows shells. macOS/Linux only for now; revisit with `cross-env` if a Windows contributor joins.
- Not done in this PR: a live `pnpm dev` smoke test (long-running server). Recommend verifying manually.

## Related Links

- Closes #71