### PR TITLE
feat(api): add metadata fields to chats list response

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -13,8 +13,11 @@ import {
 
 interface ChatResponse {
   id: string;
+  chatId: string;
+  agent: string;
   title: string;
   project: string;
+  sourceFilePath: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -88,6 +91,29 @@ function seedMessage(
       text: opts.text,
       blocks: opts.blocks,
       rawId: rawRow.id,
+    })
+    .run();
+}
+
+function seedRawMessage(
+  archive: ReturnType<typeof createArchiveRepository>,
+  opts: {
+    sourceId: string;
+    sourcePath: string;
+    payloadHash: string;
+    ingestedAt: Date;
+  }
+): void {
+  archive.db
+    .insert(archiveRawMessages)
+    .values({
+      agent: "claude-code",
+      sourceId: opts.sourceId,
+      sourcePath: opts.sourcePath,
+      sourceLocator: `${opts.payloadHash}:0`,
+      rawPayload: JSON.stringify({ hash: opts.payloadHash }),
+      payloadHash: opts.payloadHash,
+      ingestedAt: opts.ingestedAt,
     })
     .run();
 }
@@ -216,7 +242,7 @@ describe("GET /api/chats (archive-backed)", () => {
     expect(session?.title).toBe("Untitled");
   });
 
-  it("sets updatedAt to MAX(messages.ts) when messages exist", async () => {
+  it("sets createdAt to MIN(messages.ts) and updatedAt to MAX(messages.ts) when messages exist", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
 
@@ -247,10 +273,10 @@ describe("GET /api/chats (archive-backed)", () => {
     const body = (await res.json()) as { chats: ChatResponse[] };
     const session = body.chats.find((s) => s.id === "session-1");
     expect(session?.updatedAt).toBe(1700000500000);
-    expect(session?.createdAt).toBe(1700000000000);
+    expect(session?.createdAt).toBe(1700000100000);
   });
 
-  it("falls back updatedAt to firstSeenAt when there are no messages", async () => {
+  it("falls back createdAt and updatedAt to firstSeenAt when there are no messages", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
 
@@ -265,6 +291,88 @@ describe("GET /api/chats (archive-backed)", () => {
     const body = (await res.json()) as { chats: ChatResponse[] };
     const session = body.chats.find((s) => s.id === "session-1");
     expect(session?.updatedAt).toBe(1700000000000);
+    expect(session?.createdAt).toBe(1700000000000);
+  });
+
+  it("returns chatId from chats.chat_id (short code)", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      internalId: "internal-uuid-1",
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+
+    const app = createApp({ archive, metadata });
+    const res = await app.request("/api/chats");
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    const session = body.chats.find((s) => s.id === "session-1");
+    // seedChat assigns chatId = internalId.slice(0, 6).toUpperCase()
+    expect(session?.chatId).toBe("INTERN");
+  });
+
+  it("returns sourceFilePath from the most-recently-ingested raw row", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      internalId: "internal-uuid-1",
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedRawMessage(archive, {
+      sourceId: "session-1",
+      sourcePath: "/old/path.jsonl",
+      payloadHash: "hash-old",
+      ingestedAt: new Date(1700000100000),
+    });
+    seedRawMessage(archive, {
+      sourceId: "session-1",
+      sourcePath: "/new/path.jsonl",
+      payloadHash: "hash-new",
+      ingestedAt: new Date(1700000900000),
+    });
+
+    const app = createApp({ archive, metadata });
+    const res = await app.request("/api/chats");
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    const session = body.chats.find((s) => s.id === "session-1");
+    expect(session?.sourceFilePath).toBe("/new/path.jsonl");
+  });
+
+  it("returns sourceFilePath as null when no raw rows exist for the chat", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      internalId: "internal-uuid-1",
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+
+    const app = createApp({ archive, metadata });
+    const res = await app.request("/api/chats");
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    const session = body.chats.find((s) => s.id === "session-1");
+    expect(session?.sourceFilePath).toBeNull();
+  });
+
+  it("returns agent as the raw agent id from chats.agent", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      internalId: "internal-uuid-1",
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+
+    const app = createApp({ archive, metadata });
+    const res = await app.request("/api/chats");
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    const session = body.chats.find((s) => s.id === "session-1");
+    expect(session?.agent).toBe("claude-code");
   });
 
   it("falls back to empty string when project is null", async () => {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,10 +1,11 @@
 import { Hono } from "hono";
 import { serveStatic } from "@hono/node-server/serve-static";
-import { and, asc, desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
 import type { ArchiveRepository } from "./archive/repository.js";
 import {
   chats as archiveChats,
   messages as archiveMessages,
+  rawMessages as archiveRawMessages,
 } from "./archive/schema.js";
 import type { MetadataRepository } from "./metadata/repository.js";
 import { loadChatVisibility } from "./visibility.js";
@@ -17,8 +18,11 @@ interface AppOptions {
 
 interface ChatResponse {
   id: string;
+  chatId: string;
+  agent: string;
   title: string;
   project: string;
+  sourceFilePath: string | null;
   createdAt: number;
   updatedAt: number;
   isDeleted?: boolean;
@@ -77,8 +81,24 @@ export function createApp({ archive, metadata, webDistDir }: AppOptions) {
       if (!visibility.isVisible(row.id)) continue;
       const isDeleted = visibility.isTrashed(row.id);
 
-      const lastMessage = archive.db
-        .select({ ts: archiveMessages.ts })
+      const latestRaw = archive.db
+        .select({ sourcePath: archiveRawMessages.sourcePath })
+        .from(archiveRawMessages)
+        .where(
+          and(
+            eq(archiveRawMessages.agent, CLAUDE_CODE_AGENT),
+            eq(archiveRawMessages.sourceId, row.sourceId)
+          )
+        )
+        .orderBy(desc(archiveRawMessages.ingestedAt))
+        .limit(1)
+        .get();
+
+      const tsRange = archive.db
+        .select({
+          minTs: sql<number | null>`min(${archiveMessages.ts})`,
+          maxTs: sql<number | null>`max(${archiveMessages.ts})`,
+        })
         .from(archiveMessages)
         .where(
           and(
@@ -86,18 +106,18 @@ export function createApp({ archive, metadata, webDistDir }: AppOptions) {
             eq(archiveMessages.sourceId, row.sourceId)
           )
         )
-        .orderBy(desc(archiveMessages.ts))
-        .limit(1)
         .get();
 
+      const firstSeenAtMs = row.firstSeenAt.getTime();
       const chat: ChatResponse = {
         id: row.sourceId,
+        chatId: row.chatId,
+        agent: row.agent,
         title: deriveTitle(archive, metadata, row),
         project: row.project ?? "",
-        createdAt: row.firstSeenAt.getTime(),
-        updatedAt: lastMessage
-          ? lastMessage.ts.getTime()
-          : row.firstSeenAt.getTime(),
+        sourceFilePath: latestRaw?.sourcePath ?? null,
+        createdAt: tsRange?.minTs ?? firstSeenAtMs,
+        updatedAt: tsRange?.maxTs ?? firstSeenAtMs,
       };
       if (isDeleted) chat.isDeleted = true;
       chats.push(chat);

--- a/web/e2e/virtual-scrolling.spec.ts
+++ b/web/e2e/virtual-scrolling.spec.ts
@@ -24,8 +24,11 @@ test.describe("Virtual scrolling", () => {
           chats: [
             {
               id: "large-chat",
+              chatId: "LARGEC",
+              agent: "claude-code",
               title: "Large conversation",
               project: "/test/project",
+              sourceFilePath: null,
               createdAt: 1700000000000,
               updatedAt: 1700000000000 + MESSAGE_COUNT * 1000,
             },

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -406,8 +406,11 @@ describe("Empty states", () => {
           chats: [
             {
               id: "chat-1",
+              chatId: "CHAT01",
+              agent: "claude-code",
               title: "Build a login page",
               project: "/Users/test/my-web-app",
+              sourceFilePath: null,
               createdAt: 1700000000000,
               updatedAt: 1700000200000,
             },
@@ -433,8 +436,11 @@ describe("Empty states", () => {
           chats: [
             {
               id: "chat-deleted-only",
+              chatId: "CHATDX",
+              agent: "claude-code",
               title: "Only deleted",
               project: "/Users/test/p",
+              sourceFilePath: null,
               createdAt: 1,
               updatedAt: 2,
               isDeleted: true,

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -2,9 +2,12 @@ import { http, HttpResponse } from "msw";
 
 type FakeChat = {
   id: string;
+  chatId: string;
+  agent: string;
   defaultTitle: string;
   customTitle: string | null;
   project: string;
+  sourceFilePath: string | null;
   createdAt: number;
   updatedAt: number;
   isDeleted?: boolean;
@@ -13,41 +16,57 @@ type FakeChat = {
 const initialFakeChats: FakeChat[] = [
   {
     id: "chat-1",
+    chatId: "CHAT01",
+    agent: "claude-code",
     defaultTitle: "Build a login page",
     customTitle: null,
     project: "/Users/test/my-web-app",
+    sourceFilePath: "/Users/test/.claude/projects/my-web-app/chat-1.jsonl",
     createdAt: 1700000000000,
     updatedAt: 1700000200000,
   },
   {
     id: "chat-2",
+    chatId: "CHAT02",
+    agent: "claude-code",
     defaultTitle: "Fix database migration",
     customTitle: null,
     project: "/Users/test/backend-api",
+    sourceFilePath: "/Users/test/.claude/projects/backend-api/chat-2.jsonl",
     createdAt: 1700000100000,
     updatedAt: 1700000300000,
   },
   {
     id: "chat-3",
+    chatId: "CHAT03",
+    agent: "claude-code",
     defaultTitle: "Refactor utils",
     customTitle: null,
     project: "/Users/test/my-web-app",
+    sourceFilePath: "/Users/test/.claude/projects/my-web-app/chat-3.jsonl",
     createdAt: 1700000050000,
     updatedAt: 1700000150000,
   },
   {
     id: "chat-missing",
+    chatId: "CHATMI",
+    agent: "claude-code",
     defaultTitle: "Untitled",
     customTitle: null,
     project: "/Users/test/some-project",
+    sourceFilePath: null,
     createdAt: 1699999900000,
     updatedAt: 1699999900000,
   },
   {
     id: "chat-deleted-1",
+    chatId: "CHATDE",
+    agent: "claude-code",
     defaultTitle: "Old prototype",
     customTitle: null,
     project: "/Users/test/my-web-app",
+    sourceFilePath:
+      "/Users/test/.claude/projects/my-web-app/chat-deleted-1.jsonl",
     createdAt: 1699999000000,
     updatedAt: 1699999500000,
     isDeleted: true,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,7 +1,10 @@
 export interface Chat {
   id: string;
+  chatId: string;
+  agent: string;
   title: string;
   project: string;
+  sourceFilePath: string | null;
   createdAt: number;
   updatedAt: number;
   isDeleted?: boolean;


### PR DESCRIPTION
## Background (Why)

The upcoming Chat Metadata Popover (#75) needs `chatId`, `agent`, `sourceFilePath`, and a real "first message" `createdAt` to render. Exposing them on the existing `GET /api/chats` list response keeps the popover read-only from already-loaded data — no extra fetch.

## Approach (How)

- Extend `ChatResponse` with `chatId`, `agent`, `sourceFilePath`.
- `chatId` / `agent` are already columns on `chats`; map them through.
- Change `createdAt` semantics to `MIN(messages.ts)`, combined with `MAX(messages.ts)` into a single aggregate query per chat. Fall back to `firstSeenAt` only when the chat has no messages yet.
- `sourceFilePath` = `source_path` of the most-recently ingested `raw_messages` row for the chat (or `null` if none).
- Sync the `Chat` frontend type, MSW handlers, and inline fixtures so `pnpm typecheck` verifies the contract end-to-end. No UI consumption yet — the popover is the next slice.

## Changes (What)

- [x] `ChatResponse` gains `chatId`, `agent`, `sourceFilePath`
- [x] `createdAt` reflects `MIN(messages.ts)` with fallback to `firstSeenAt`
- [x] Combine `MIN/MAX(ts)` into one query per chat
- [x] `sourceFilePath` lookup walks `raw_messages_idem_idx` (no full scan)
- [x] `Chat` type, MSW handlers, `App.test.tsx`, and the e2e route mock updated

### Test Verification

- [x] `createdAt` = MIN(ts) when messages exist (new API test)
- [x] `createdAt`/`updatedAt` fall back to `firstSeenAt` when no messages
- [x] `chatId` returned from `chats.chat_id`
- [x] `agent` returned from `chats.agent`
- [x] `sourceFilePath` returns latest raw row's path with multiple raw rows
- [x] `sourceFilePath` = `null` when no raw rows exist
- [x] `pnpm typecheck` clean
- [x] `pnpm test` clean (api 113, web 51)

## Additional Notes

`createdAt` semantic sweep: the frontend has no business logic on `createdAt` (sorting and display use `updatedAt`), so the change is contract-only with no UI impact.

## Related Links

- Closes #74. 
- Unblocks #75 (Chat Metadata Popover).