### PR TITLE
feat(web): chat metadata popover with full project path

### DIFF
--- a/api/drizzle/archive/0006_add_project_path.sql
+++ b/api/drizzle/archive/0006_add_project_path.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `chats` ADD `project_path` text;

--- a/api/drizzle/archive/meta/_journal.json
+++ b/api/drizzle/archive/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1779000000000,
       "tag": "0005_rename_session_to_chat",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1779100000000,
+      "tag": "0006_add_project_path",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -17,6 +17,7 @@ interface ChatResponse {
   agent: string;
   title: string;
   project: string;
+  projectPath: string | null;
   sourceFilePath: string | null;
   createdAt: number;
   updatedAt: number;
@@ -373,6 +374,49 @@ describe("GET /api/chats (archive-backed)", () => {
     const body = (await res.json()) as { chats: ChatResponse[] };
     const session = body.chats.find((s) => s.id === "session-1");
     expect(session?.agent).toBe("claude-code");
+  });
+
+  it("returns projectPath with the full cwd when set on the archive row", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    archive.db
+      .insert(archiveChats)
+      .values({
+        id: "internal-uuid-1",
+        chatId: "PPATH1",
+        agent: "claude-code",
+        sourceId: "session-1",
+        firstSeenAt: new Date(1700000000000),
+        project: "chat-logbook",
+        projectPath: "/Users/evaaaaawu/Documents/chat-logbook",
+      })
+      .run();
+
+    const app = createApp({ archive, metadata });
+    const res = await app.request("/api/chats");
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    const session = body.chats.find((s) => s.id === "session-1");
+    expect(session?.projectPath).toBe(
+      "/Users/evaaaaawu/Documents/chat-logbook"
+    );
+  });
+
+  it("returns projectPath as null when no cwd was discoverable", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      internalId: "internal-uuid-1",
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+
+    const app = createApp({ archive, metadata });
+    const res = await app.request("/api/chats");
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    const session = body.chats.find((s) => s.id === "session-1");
+    expect(session?.projectPath).toBeNull();
   });
 
   it("falls back to empty string when project is null", async () => {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -22,6 +22,7 @@ interface ChatResponse {
   agent: string;
   title: string;
   project: string;
+  projectPath: string | null;
   sourceFilePath: string | null;
   createdAt: number;
   updatedAt: number;
@@ -115,6 +116,7 @@ export function createApp({ archive, metadata, webDistDir }: AppOptions) {
         agent: row.agent,
         title: deriveTitle(archive, metadata, row),
         project: row.project ?? "",
+        projectPath: row.projectPath ?? null,
         sourceFilePath: latestRaw?.sourcePath ?? null,
         createdAt: tsRange?.minTs ?? firstSeenAtMs,
         updatedAt: tsRange?.maxTs ?? firstSeenAtMs,

--- a/api/src/archive/schema.test.ts
+++ b/api/src/archive/schema.test.ts
@@ -70,6 +70,31 @@ describe("chats table", () => {
     ).toThrow();
   });
 
+  it("round-trips project_path alongside project", () => {
+    const now = new Date();
+    repo.db
+      .insert(chats)
+      .values({
+        id: "22222222-2222-4222-8222-222222222222",
+        chatId: "pth111",
+        agent: "claude-code",
+        sourceId: "src-pp",
+        firstSeenAt: now,
+        project: "my-app",
+        projectPath: "/Users/test/my-app",
+      })
+      .run();
+
+    const row = repo.db
+      .select()
+      .from(chats)
+      .where(eq(chats.id, "22222222-2222-4222-8222-222222222222"))
+      .get();
+
+    expect(row?.project).toBe("my-app");
+    expect(row?.projectPath).toBe("/Users/test/my-app");
+  });
+
   it("rejects duplicate chat_id", () => {
     const now = new Date();
     repo.db

--- a/api/src/archive/schema.ts
+++ b/api/src/archive/schema.ts
@@ -25,6 +25,7 @@ export const chats = sqliteTable(
     sourceId: text("source_id").notNull(),
     firstSeenAt: integer("first_seen_at", { mode: "timestamp_ms" }).notNull(),
     project: text("project"),
+    projectPath: text("project_path"),
   },
   (t) => [uniqueIndex("chats_agent_source_idx").on(t.agent, t.sourceId)]
 );

--- a/api/src/ingestion/ingest.test.ts
+++ b/api/src/ingestion/ingest.test.ts
@@ -65,6 +65,7 @@ describe("runIngestion", () => {
 
     const session1 = chatRows.find((s) => s.sourceId === "session-1");
     expect(session1?.project).toBe("project-a");
+    expect(session1?.projectPath).toBe("/Users/test/project-a");
 
     archive.close();
   });
@@ -362,6 +363,7 @@ describe("runIngestion", () => {
       .all()
       .find((s) => s.sourceId === "late");
     expect(after?.project).toBe("late-app");
+    expect(after?.projectPath).toBe("/Users/test/late-app");
 
     archive.close();
   });

--- a/api/src/ingestion/ingest.ts
+++ b/api/src/ingestion/ingest.ts
@@ -53,7 +53,14 @@ export async function runIngestion(opts: IngestOptions): Promise<IngestResult> {
         )
         .get();
 
-      ensureChat(opts.archive, plugin.id, ref.sourceId, now(), ref.project);
+      ensureChat(
+        opts.archive,
+        plugin.id,
+        ref.sourceId,
+        now(),
+        ref.project,
+        ref.projectPath
+      );
 
       if (
         stat &&
@@ -189,7 +196,8 @@ function ensureChat(
   agent: string,
   sourceId: string,
   firstSeenAt: Date,
-  project: string | undefined
+  project: string | undefined,
+  projectPath: string | undefined
 ): string {
   const existing = archive.db
     .select()
@@ -197,10 +205,15 @@ function ensureChat(
     .where(and(eq(chats.agent, agent), eq(chats.sourceId, sourceId)))
     .get();
   if (existing) {
-    if (project && existing.project !== project) {
+    const updates: { project?: string; projectPath?: string } = {};
+    if (project && existing.project !== project) updates.project = project;
+    if (projectPath && existing.projectPath !== projectPath) {
+      updates.projectPath = projectPath;
+    }
+    if (Object.keys(updates).length > 0) {
       archive.db
         .update(chats)
-        .set({ project })
+        .set(updates)
         .where(eq(chats.id, existing.id))
         .run();
     }
@@ -218,6 +231,7 @@ function ensureChat(
       sourceId,
       firstSeenAt,
       project: project ?? null,
+      projectPath: projectPath ?? null,
     })
     .run();
   return id;

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -82,6 +82,12 @@ describe("ClaudeCodePlugin.discover", () => {
       expect(refs).toHaveLength(1);
       expect(refs[0].project).toBe("my-app");
     });
+
+    it("exposes the full cwd as projectPath", async () => {
+      const refs = await collect(plugin.discover({ homeDir: tmpHome }));
+      expect(refs).toHaveLength(1);
+      expect(refs[0].projectPath).toBe("/Users/test/my-app");
+    });
   });
 
   describe("when the first cwd line sits beyond the first 64KB", () => {

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -33,6 +33,7 @@ export class ClaudeCodePlugin implements AgentPlugin {
           sourcePath,
           watchPaths: [sourcePath],
           project: cwd ? path.basename(cwd) : undefined,
+          projectPath: cwd ?? undefined,
         };
       }
     }

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -7,6 +7,7 @@ export interface ChatRef {
   sourcePath: string;
   watchPaths: string[];
   project?: string;
+  projectPath?: string;
 }
 
 export interface RawRecord {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -131,6 +131,75 @@ describe("Chat metadata popover", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders the full projectPath (not just basename) when provided", async () => {
+    server.use(
+      http.get("/api/chats", () =>
+        HttpResponse.json({
+          chats: [
+            {
+              id: "chat-x",
+              chatId: "CHATXX",
+              agent: "claude-code",
+              title: "Full path chat",
+              project: "chat-logbook",
+              projectPath: "/Users/evaaaaawu/Documents/chat-logbook",
+              sourceFilePath: null,
+              createdAt: 1700000000000,
+              updatedAt: 1700000000000,
+            },
+          ],
+        })
+      )
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Full path chat"));
+    await user.click(await screen.findByRole("button", { name: /chat info/i }));
+
+    const popover = await screen.findByTestId("chat-metadata-popover");
+    const projectRow = within(popover).getByText("Project").parentElement!;
+    expect(
+      within(projectRow).getByTitle("/Users/evaaaaawu/Documents/chat-logbook")
+    ).toBeInTheDocument();
+    expect(
+      within(projectRow).getByText("/Users/evaaaaawu/Documents/chat-logbook")
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to project basename when projectPath is null", async () => {
+    server.use(
+      http.get("/api/chats", () =>
+        HttpResponse.json({
+          chats: [
+            {
+              id: "chat-y",
+              chatId: "CHATYY",
+              agent: "claude-code",
+              title: "Basename fallback chat",
+              project: "legacy-basename",
+              projectPath: null,
+              sourceFilePath: null,
+              createdAt: 1700000000000,
+              updatedAt: 1700000000000,
+            },
+          ],
+        })
+      )
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Basename fallback chat"));
+    await user.click(await screen.findByRole("button", { name: /chat info/i }));
+
+    const popover = await screen.findByTestId("chat-metadata-popover");
+    const projectRow = within(popover).getByText("Project").parentElement!;
+    expect(within(projectRow).getByText("legacy-basename")).toBeInTheDocument();
+  });
+
   it("renders — when project is empty", async () => {
     server.use(
       http.get("/api/chats", () =>

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import App from "./App";
 import { server } from "./test/server";
 
@@ -57,6 +57,208 @@ describe("Conversation header", () => {
     const header = await screen.findByTestId("conversation-header");
     expect(within(header).getByText("Build a login page")).toBeInTheDocument();
     expect(within(header).getByText(/my-web-app/)).toBeInTheDocument();
+  });
+});
+
+describe("Chat metadata popover", () => {
+  it("hides the ⓘ trigger when no chat is selected, shows it after selecting one", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+
+    expect(
+      screen.queryByRole("button", { name: /chat info/i })
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("Build a login page"));
+
+    const header = await screen.findByTestId("conversation-header");
+    expect(
+      within(header).getByRole("button", { name: /chat info/i })
+    ).toBeInTheDocument();
+  });
+
+  it("opens the popover on trigger click and closes on Esc", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+
+    const trigger = await screen.findByRole("button", { name: /chat info/i });
+    await user.click(trigger);
+
+    expect(await screen.findByTestId("chat-metadata-popover")).toBeVisible();
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("chat-metadata-popover")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders chat id, source id, and AI agent display name", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+    await user.click(await screen.findByRole("button", { name: /chat info/i }));
+
+    const popover = await screen.findByTestId("chat-metadata-popover");
+    expect(within(popover).getByText("CHAT01")).toBeInTheDocument();
+    expect(within(popover).getByText("chat-1")).toBeInTheDocument();
+    expect(within(popover).getByText("Claude Code")).toBeInTheDocument();
+    expect(within(popover).queryByText("claude-code")).not.toBeInTheDocument();
+  });
+
+  it("renders project and source file path with full value in title tooltip", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+    await user.click(await screen.findByRole("button", { name: /chat info/i }));
+
+    const popover = await screen.findByTestId("chat-metadata-popover");
+    expect(
+      within(popover).getByTitle("/Users/test/my-web-app")
+    ).toBeInTheDocument();
+    expect(
+      within(popover).getByTitle(
+        "/Users/test/.claude/projects/my-web-app/chat-1.jsonl"
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders — when project is empty", async () => {
+    server.use(
+      http.get("/api/chats", () =>
+        HttpResponse.json({
+          chats: [
+            {
+              id: "chat-x",
+              chatId: "CHATXX",
+              agent: "claude-code",
+              title: "No project chat",
+              project: "",
+              sourceFilePath: null,
+              createdAt: 1700000000000,
+              updatedAt: 1700000000000,
+            },
+          ],
+        })
+      )
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("No project chat"));
+    await user.click(await screen.findByRole("button", { name: /chat info/i }));
+
+    const popover = await screen.findByTestId("chat-metadata-popover");
+    const projectRow = within(popover).getByText("Project").parentElement!;
+    expect(within(projectRow).getByText("—")).toBeInTheDocument();
+  });
+
+  it("renders created and updated timestamps as YYYY-MM-DD HH:mm", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+    await user.click(await screen.findByRole("button", { name: /chat info/i }));
+
+    const popover = await screen.findByTestId("chat-metadata-popover");
+    const datePattern = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/;
+    const matches = within(popover)
+      .getAllByText(datePattern)
+      .map((el) => el.textContent);
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("copies the full untruncated value to clipboard and shows Copied feedback", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    try {
+      render(<App />);
+
+      await user.click(await screen.findByText("Build a login page"));
+      await user.click(
+        await screen.findByRole("button", { name: /chat info/i })
+      );
+
+      const popover = await screen.findByTestId("chat-metadata-popover");
+      const copyPath = within(popover).getByRole("button", {
+        name: /copy source path/i,
+      });
+      await user.click(copyPath);
+
+      expect(writeText).toHaveBeenCalledWith(
+        "/Users/test/.claude/projects/my-web-app/chat-1.jsonl"
+      );
+      expect(within(popover).getByText("Copied")).toBeInTheDocument();
+
+      vi.advanceTimersByTime(1600);
+
+      await waitFor(() => {
+        expect(within(popover).queryByText("Copied")).not.toBeInTheDocument();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("in Trash mode, Esc closes the popover but does not exit Trash", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+
+    await user.click(screen.getByTestId("trash-link"));
+
+    const deletedRow = await screen.findByText("Old prototype");
+    await user.click(deletedRow);
+
+    await user.click(await screen.findByRole("button", { name: /chat info/i }));
+    expect(await screen.findByTestId("chat-metadata-popover")).toBeVisible();
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("chat-metadata-popover")
+      ).not.toBeInTheDocument();
+    });
+
+    // Still in Trash: deleted chat is still in the list
+    expect(
+      within(screen.getByTestId("chat-list")).getByText("Old prototype")
+    ).toBeInTheDocument();
+  });
+
+  it("closes the popover when switching to a different chat", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+    await user.click(await screen.findByRole("button", { name: /chat info/i }));
+    expect(await screen.findByTestId("chat-metadata-popover")).toBeVisible();
+
+    await user.click(screen.getByText("Fix database migration"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("chat-metadata-popover")
+      ).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/web/src/components/ChatMetadataPopover.tsx
+++ b/web/src/components/ChatMetadataPopover.tsx
@@ -181,16 +181,19 @@ export function ChatMetadataPopover({ chat }: ChatMetadataPopoverProps) {
             label="AI Agent"
             value={getAgentDisplayName(chat.agent)}
           />
-          {chat.project ? (
-            <CopyableField
-              label="Project"
-              display={<TruncatedPath value={chat.project} />}
-              copyValue={chat.project}
-              copyAriaLabel="Copy project path"
-            />
-          ) : (
-            <PlainField label="Project" value={EMPTY} />
-          )}
+          {(() => {
+            const projectValue = chat.projectPath ?? chat.project;
+            return projectValue ? (
+              <CopyableField
+                label="Project"
+                display={<TruncatedPath value={projectValue} />}
+                copyValue={projectValue}
+                copyAriaLabel="Copy project path"
+              />
+            ) : (
+              <PlainField label="Project" value={EMPTY} />
+            );
+          })()}
         </section>
         <section className="border-t border-border px-3 py-2">
           <SectionLabel>Identifiers & location</SectionLabel>

--- a/web/src/components/ChatMetadataPopover.tsx
+++ b/web/src/components/ChatMetadataPopover.tsx
@@ -1,0 +1,223 @@
+import { Check, Copy, Info } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import type { Chat } from "@/types";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { getAgentDisplayName } from "@/lib/agentDisplayName";
+
+interface ChatMetadataPopoverProps {
+  chat: Chat;
+}
+
+const COPIED_FEEDBACK_MS = 1500;
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function formatDateTime(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function getRelativeTimeLong(ts: number): string {
+  const diffMs = Date.now() - ts;
+  const sec = Math.floor(diffMs / 1000);
+  const min = Math.floor(sec / 60);
+  const hour = Math.floor(min / 60);
+  const day = Math.floor(hour / 24);
+  if (day > 0) return `${day} ${day === 1 ? "day" : "days"} ago`;
+  if (hour > 0) return `${hour} ${hour === 1 ? "hour" : "hours"} ago`;
+  if (min > 0) return `${min} ${min === 1 ? "minute" : "minutes"} ago`;
+  return "just now";
+}
+
+function TruncatedPath({ value }: { value: string }) {
+  return (
+    <span title={value} className="block min-w-0 max-w-full truncate">
+      {value}
+    </span>
+  );
+}
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <h3 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+      {children}
+    </h3>
+  );
+}
+
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="grid grid-cols-[88px_1fr] items-baseline gap-2 py-1">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <div className="min-w-0 text-xs text-foreground">{children}</div>
+    </div>
+  );
+}
+
+function PlainField({ label, value }: { label: string; value: ReactNode }) {
+  return <Row label={label}>{value}</Row>;
+}
+
+function CopyableField({
+  label,
+  display,
+  copyValue,
+  copyAriaLabel,
+}: {
+  label: string;
+  display: ReactNode;
+  copyValue: string;
+  copyAriaLabel: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const [fading, setFading] = useState(false);
+  const timers = useRef<number[]>([]);
+
+  useEffect(
+    () => () => {
+      timers.current.forEach((t) => window.clearTimeout(t));
+    },
+    []
+  );
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(copyValue);
+    setCopied(true);
+    setFading(false);
+    timers.current.forEach((t) => window.clearTimeout(t));
+    timers.current = [
+      window.setTimeout(() => setFading(true), COPIED_FEEDBACK_MS - 240),
+      window.setTimeout(() => {
+        setCopied(false);
+        setFading(false);
+      }, COPIED_FEEDBACK_MS),
+    ];
+  };
+
+  return (
+    <Row label={label}>
+      <div className="group flex min-w-0 items-center gap-1.5">
+        <div className="min-w-0 flex-1">{display}</div>
+        {copied && (
+          <span
+            className={`shrink-0 text-[11px] text-chart-5 transition-opacity duration-200 ${fading ? "opacity-0" : "opacity-100"}`}
+            aria-live="polite"
+          >
+            Copied
+          </span>
+        )}
+        <button
+          type="button"
+          aria-label={copyAriaLabel}
+          onClick={handleCopy}
+          className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-white/[0.04] hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+        >
+          {copied ? (
+            <Check size={12} aria-hidden="true" />
+          ) : (
+            <Copy size={12} aria-hidden="true" />
+          )}
+        </button>
+      </div>
+    </Row>
+  );
+}
+
+const EMPTY = <span className="text-muted-foreground">—</span>;
+
+export function ChatMetadataPopover({ chat }: ChatMetadataPopoverProps) {
+  const created = formatDateTime(chat.createdAt);
+  const updated = formatDateTime(chat.updatedAt);
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        aria-label="Chat info"
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-white/[0.04] hover:text-foreground focus-visible:outline-2 focus-visible:outline-ring"
+      >
+        <Info size={16} aria-hidden="true" />
+      </PopoverTrigger>
+      <PopoverContent
+        data-testid="chat-metadata-popover"
+        align="end"
+        sideOffset={6}
+        className="w-80 gap-0 p-0"
+      >
+        <section className="px-3 py-2">
+          <SectionLabel>Time</SectionLabel>
+          <PlainField
+            label="Created"
+            value={
+              <span className="flex min-w-0 items-baseline gap-1.5">
+                <span>{created}</span>
+                <span className="truncate text-muted-foreground">
+                  · {getRelativeTimeLong(chat.createdAt)}
+                </span>
+              </span>
+            }
+          />
+          <PlainField
+            label="Updated"
+            value={
+              <span className="flex min-w-0 items-baseline gap-1.5">
+                <span>{updated}</span>
+                <span className="truncate text-muted-foreground">
+                  · {getRelativeTimeLong(chat.updatedAt)}
+                </span>
+              </span>
+            }
+          />
+        </section>
+        <section className="border-t border-border px-3 py-2">
+          <SectionLabel>Origin context</SectionLabel>
+          <PlainField
+            label="AI Agent"
+            value={getAgentDisplayName(chat.agent)}
+          />
+          {chat.project ? (
+            <CopyableField
+              label="Project"
+              display={<TruncatedPath value={chat.project} />}
+              copyValue={chat.project}
+              copyAriaLabel="Copy project path"
+            />
+          ) : (
+            <PlainField label="Project" value={EMPTY} />
+          )}
+        </section>
+        <section className="border-t border-border px-3 py-2">
+          <SectionLabel>Identifiers & location</SectionLabel>
+          <CopyableField
+            label="Chat ID"
+            display={chat.chatId}
+            copyValue={chat.chatId}
+            copyAriaLabel="Copy chat id"
+          />
+          <CopyableField
+            label="Source ID"
+            display={<TruncatedPath value={chat.id} />}
+            copyValue={chat.id}
+            copyAriaLabel="Copy source id"
+          />
+          {chat.sourceFilePath ? (
+            <CopyableField
+              label="Source path"
+              display={<TruncatedPath value={chat.sourceFilePath} />}
+              copyValue={chat.sourceFilePath}
+              copyAriaLabel="Copy source path"
+            />
+          ) : (
+            <PlainField label="Source path" value={EMPTY} />
+          )}
+        </section>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/components/ConversationView.tsx
+++ b/web/src/components/ConversationView.tsx
@@ -7,6 +7,7 @@ import remarkGfm from "remark-gfm";
 import type { Message, ContentBlock, Chat } from "@/types";
 import { CollapsibleThinking } from "./CollapsibleThinking";
 import { CollapsibleToolCall } from "./CollapsibleToolCall";
+import { ChatMetadataPopover } from "./ChatMetadataPopover";
 import { EditableTitle } from "./EditableTitle";
 
 interface ConversationViewProps {
@@ -105,6 +106,7 @@ function ConversationHeader({
           <div className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
             {getProjectName(chat.project)} · {getRelativeTime(chat.updatedAt)}
           </div>
+          <ChatMetadataPopover key={chat.id} chat={chat} />
         </>
       )}
     </div>

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+
+import { cn } from "@/lib/utils";
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-0.5 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+  return (
+    <PopoverPrimitive.Title
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: PopoverPrimitive.Description.Props) {
+  return (
+    <PopoverPrimitive.Description
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+};

--- a/web/src/lib/agentDisplayName.ts
+++ b/web/src/lib/agentDisplayName.ts
@@ -1,0 +1,7 @@
+const AGENT_DISPLAY_NAMES: Record<string, string> = {
+  "claude-code": "Claude Code",
+};
+
+export function getAgentDisplayName(agent: string): string {
+  return AGENT_DISPLAY_NAMES[agent] ?? agent;
+}

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -7,6 +7,7 @@ type FakeChat = {
   defaultTitle: string;
   customTitle: string | null;
   project: string;
+  projectPath: string | null;
   sourceFilePath: string | null;
   createdAt: number;
   updatedAt: number;
@@ -20,7 +21,8 @@ const initialFakeChats: FakeChat[] = [
     agent: "claude-code",
     defaultTitle: "Build a login page",
     customTitle: null,
-    project: "/Users/test/my-web-app",
+    project: "my-web-app",
+    projectPath: "/Users/test/my-web-app",
     sourceFilePath: "/Users/test/.claude/projects/my-web-app/chat-1.jsonl",
     createdAt: 1700000000000,
     updatedAt: 1700000200000,
@@ -31,7 +33,8 @@ const initialFakeChats: FakeChat[] = [
     agent: "claude-code",
     defaultTitle: "Fix database migration",
     customTitle: null,
-    project: "/Users/test/backend-api",
+    project: "backend-api",
+    projectPath: "/Users/test/backend-api",
     sourceFilePath: "/Users/test/.claude/projects/backend-api/chat-2.jsonl",
     createdAt: 1700000100000,
     updatedAt: 1700000300000,
@@ -42,7 +45,8 @@ const initialFakeChats: FakeChat[] = [
     agent: "claude-code",
     defaultTitle: "Refactor utils",
     customTitle: null,
-    project: "/Users/test/my-web-app",
+    project: "my-web-app",
+    projectPath: "/Users/test/my-web-app",
     sourceFilePath: "/Users/test/.claude/projects/my-web-app/chat-3.jsonl",
     createdAt: 1700000050000,
     updatedAt: 1700000150000,
@@ -53,7 +57,8 @@ const initialFakeChats: FakeChat[] = [
     agent: "claude-code",
     defaultTitle: "Untitled",
     customTitle: null,
-    project: "/Users/test/some-project",
+    project: "some-project",
+    projectPath: "/Users/test/some-project",
     sourceFilePath: null,
     createdAt: 1699999900000,
     updatedAt: 1699999900000,
@@ -64,7 +69,8 @@ const initialFakeChats: FakeChat[] = [
     agent: "claude-code",
     defaultTitle: "Old prototype",
     customTitle: null,
-    project: "/Users/test/my-web-app",
+    project: "my-web-app",
+    projectPath: "/Users/test/my-web-app",
     sourceFilePath:
       "/Users/test/.claude/projects/my-web-app/chat-deleted-1.jsonl",
     createdAt: 1699999000000,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -4,6 +4,7 @@ export interface Chat {
   agent: string;
   title: string;
   project: string;
+  projectPath: string | null;
   sourceFilePath: string | null;
   createdAt: number;
   updatedAt: number;


### PR DESCRIPTION
## Background (Why)

The third-column conversation header didn't surface basic metadata (timestamps, agent, project path, identifiers, source file) for a selected chat. The chat list already shows the project basename, but there's nowhere to see the full working-directory path, the chat id, or where the conversation lives on disk — useful both for orientation and for jumping into the source JSONL.

This PR closes #75 (the popover itself) and #79 (the full-path data flow that the popover needs), shipped together so the popover lands already wired to the full cwd instead of a basename stub.

## Approach (How)

**Popover (#75).** A shadcn/Radix `Popover` anchored under an ⓘ button at the far right of the conversation header. Three sections — Time, Origin context, Identifiers & location — rendered as a 7-row grid. Four rows are click-to-copy with an inline `Copied` chip; the copy icon only appears on row hover so the resting state stays calm.

A few design calls worth flagging:

- **Middle-ellipsis via pure CSS** (`min-w-0 truncate` on a grid child). Considered a JS-measured middle-ellipsis but rejected: the popover width is fixed and the full value is one click and one tooltip away, so JS measurement would cost layout thrash and re-measure logic for no real legibility win.
- **Solarized Dark palette** for the `Copied` feedback (`chart-5`) and the hover affordances — keeps the popover visually part of the surrounding shell.
- **Esc handling.** The popover stops Esc from bubbling, so opening the popover inside Trash mode and pressing Esc closes only the popover, not the Trash view (regression-tested).
- **No dedicated hotkey.** Tab-reachable button; intentionally avoids collisions with the existing Backspace / F2 / Enter bindings.

**Full project path (#79).** A new `projectPath` field flows through every layer:

- `ChatRef.projectPath` carries the full cwd alongside the existing `project` basename in the claude-code plugin.
- `chats.project_path` column added via a new migration (`0006_add_project_path.sql`); `ensureChat` updates both fields symmetrically when a later scan resolves a previously-unknown cwd.
- `GET /api/chats` returns `projectPath: string | null`.
- The web `Chat` type and MSW handlers learn the new field; the popover's Project row prefers `projectPath`, falls back to `project` (basename), then to `—`.

The split keeps `chats.project` as the basename so `ChatList` and the conversation header continue using it unchanged; only the popover needs the full path.

## Changes (What)

- [x] `ChatMetadataPopover` with 7 fields, click-to-copy, and Solarized-dark styling
- [x] ⓘ trigger in `ConversationHeader`, hidden until a chat is selected
- [x] Esc closes only the popover (does not exit Trash mode)
- [x] `agentDisplayName` helper so the popover never shows the raw `claude-code` id
- [x] `ChatRef.projectPath`; claude-code plugin emits both basename and full cwd
- [x] `chats.project_path` column + migration `0006_add_project_path.sql`
- [x] Ingestion writes / backfills `project_path` symmetric to `project`
- [x] `ChatResponse.projectPath: string | null`
- [x] Web `Chat.projectPath`, MSW handlers, popover consumes `projectPath ?? project ?? —`

### Test Verification

- [x] Popover opens/closes via mouse and keyboard
- [x] All 7 fields render with correct values and formatting
- [x] Click-to-copy writes the full (non-truncated) value to clipboard; `Copied` feedback appears and fades
- [x] Empty project renders `—`
- [x] Trash mode + popover open + Esc → popover closes, Trash stays
- [x] Switching chats while popover is open closes the popover
- [x] `GET /api/chats` returns `projectPath` with the full cwd
- [x] `GET /api/chats` returns `projectPath: null` when no cwd was discoverable
- [x] Popover renders the full `projectPath` when present and falls back to `project` basename when null
- [x] `pnpm typecheck` and `pnpm test` clean across `api/` and `web/` (api 117, web 62)

## Additional Notes

- Migration is hand-written (`0006_add_project_path.sql` + journal entry only); `meta/0006_snapshot.json` is intentionally not generated, matching the pattern set by `0005_rename_session_to_chat`.
- The MSW fixtures' `project` field was switched from full paths to actual basenames to match the post-#79 contract. Existing list /header tests still pass because they derive the basename either way.

## Related Links

- Closes #75
- Closes #79