### PR TITLE
feat(web): sortable chat list with sort UI and persistence

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -13,18 +13,17 @@ export default defineConfig([
       js.configs.recommended,
       tseslint.configs.recommended,
       reactHooks.configs.flat.recommended,
-      reactRefresh.configs.vite.override({
-        rules: {
-          "react-refresh/only-export-components": [
-            "warn",
-            { allowConstantExport: true },
-          ],
-        },
-      }),
+      reactRefresh.configs.vite,
     ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+    rules: {
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
     },
   },
 ]);

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -47,6 +47,169 @@ describe("Chat list", () => {
   });
 });
 
+describe("Chat List sort", () => {
+  it("opens a sort popover listing Title, Created time, and Updated time", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+
+    const list = screen.getByTestId("chat-list");
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+
+    const popover = await screen.findByTestId("chat-sort-popover");
+    expect(within(popover).getByText("Title")).toBeInTheDocument();
+    expect(within(popover).getByText("Created time")).toBeInTheDocument();
+    expect(within(popover).getByText("Updated time")).toBeInTheDocument();
+  });
+
+  it("re-sorts the list A-Z when Title is selected", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+
+    const list = screen.getByTestId("chat-list");
+    // Default (Updated time · Newest first): Fix database migration is first.
+    expect(within(list).getAllByTestId("chat-row")[0].textContent).toContain(
+      "Fix database migration"
+    );
+
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+    const popover = await screen.findByTestId("chat-sort-popover");
+    await user.click(within(popover).getByText("Title"));
+
+    // Title A-Z: Build a login page first, Untitled (empty-ish) reorders down.
+    const rows = within(list).getAllByTestId("chat-row");
+    expect(rows[0].textContent).toContain("Build a login page");
+    expect(rows[1].textContent).toContain("Fix database migration");
+    expect(rows[2].textContent).toContain("Refactor utils");
+  });
+
+  it("toggles direction by re-clicking the active axis and re-sorts", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+
+    const list = screen.getByTestId("chat-list");
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+    const popover = await screen.findByTestId("chat-sort-popover");
+
+    // First click selects Title (A-Z); the direction label reads A-Z.
+    await user.click(within(popover).getByText("Title"));
+    expect(within(popover).getByText("A-Z")).toBeInTheDocument();
+
+    // Re-clicking the already-active axis flips its direction.
+    await user.click(within(popover).getByText("Title"));
+
+    // Z-A: the label flips and the order reverses ("Untitled" is a real title,
+    // so it leads in Z-A; "Build a login page" sinks to the bottom).
+    expect(within(popover).getByText("Z-A")).toBeInTheDocument();
+    const rows = within(list).getAllByTestId("chat-row");
+    expect(rows[0].textContent).toContain("Untitled");
+    expect(rows[3].textContent).toContain("Build a login page");
+  });
+
+  it("persists the sort preference across a reload", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<App />);
+
+    await screen.findByText("Build a login page");
+    let list = screen.getByTestId("chat-list");
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+    const popover = await screen.findByTestId("chat-sort-popover");
+    await user.click(within(popover).getByText("Title"));
+
+    unmount();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    list = screen.getByTestId("chat-list");
+    const rows = within(list).getAllByTestId("chat-row");
+    expect(rows[0].textContent).toContain("Build a login page");
+  });
+
+  it("tints the sort icon primary cyan only when the sort is non-default", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+
+    const list = screen.getByTestId("chat-list");
+    const trigger = within(list).getByRole("button", { name: /sort/i });
+
+    // Default (Updated time · Newest first): muted, not cyan.
+    expect(trigger.className).toMatch(/text-muted-foreground/);
+    expect(trigger.className).not.toMatch(/text-primary/);
+
+    await user.click(trigger);
+    const popover = await screen.findByTestId("chat-sort-popover");
+    await user.click(within(popover).getByText("Title"));
+
+    // Non-default: cyan.
+    expect(trigger.className).toMatch(/text-primary/);
+  });
+
+  it("remembers each axis's direction when switching between axes", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    const list = screen.getByTestId("chat-list");
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+    const popover = await screen.findByTestId("chat-sort-popover");
+
+    // Title: select, then re-click to flip to Z-A.
+    await user.click(within(popover).getByText("Title"));
+    await user.click(within(popover).getByText("Title"));
+    expect(within(popover).getByText("Z-A")).toBeInTheDocument();
+
+    // Updated time: its own untouched default (Newest first).
+    await user.click(within(popover).getByText("Updated time"));
+    expect(within(popover).getByText("Newest first")).toBeInTheDocument();
+
+    // Back to Title: the Z-A choice is restored (a plain select, not a flip).
+    await user.click(within(popover).getByText("Title"));
+    expect(within(popover).getByText("Z-A")).toBeInTheDocument();
+  });
+
+  it("scrolls the selected chat into view after a sort change", async () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+    scrollIntoView.mockClear();
+
+    const list = screen.getByTestId("chat-list");
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+    const popover = await screen.findByTestId("chat-sort-popover");
+    await user.click(within(popover).getByText("Title"));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+  });
+
+  it("scrolls the list to top after a sort change when nothing is selected", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+
+    const scroller = screen.getByTestId("chat-scroll");
+    scroller.scrollTop = 100;
+
+    const list = screen.getByTestId("chat-list");
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+    const popover = await screen.findByTestId("chat-sort-popover");
+    await user.click(within(popover).getByText("Title"));
+
+    expect(scroller.scrollTop).toBe(0);
+  });
+});
+
 describe("Conversation header", () => {
   it("shows the session title and project after selecting a session", async () => {
     const user = userEvent.setup();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,17 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useChats } from "@/hooks/useChats";
 import { useMessages } from "@/hooks/useMessages";
 import { useToast } from "@/hooks/useToast";
+import { useSortPreference } from "@/hooks/useSortPreference";
+import { sortChats } from "@/lib/sortChats";
+import {
+  CHAT_DIRECTION_LABELS,
+  CHAT_SORT_AXES,
+  CHAT_SORT_CONFIG,
+} from "@/lib/chatSort";
 import { FilterPanel } from "@/components/FilterPanel";
 import { ChatList } from "@/components/ChatList";
+import { SortControl } from "@/components/SortControl";
 import { ConversationView } from "@/components/ConversationView";
 import { Toast } from "@/components/Toast";
 import {
@@ -22,7 +30,16 @@ function App() {
   const [editingTitleId, setEditingTitleId] = useState<string | null>(null);
   const { messages, error } = useMessages(selectedId);
   const { toast, showToast, dismissToast } = useToast();
-  const mainChats = chats.filter((c) => !c.isDeleted);
+  const sort = useSortPreference(CHAT_SORT_CONFIG);
+  const mainChats = useMemo(
+    () =>
+      sortChats(
+        chats.filter((c) => !c.isDeleted),
+        sort.field,
+        sort.direction
+      ),
+    [chats, sort.field, sort.direction]
+  );
   const deletedChats = chats.filter((c) => c.isDeleted);
   const visibleChats = mode === "trash" ? deletedChats : mainChats;
   const selectedChat = chats.find((c) => c.id === selectedId) ?? null;
@@ -129,6 +146,19 @@ function App() {
             onBack={() => setMode("main")}
             deletedCount={deletedChats.length}
             onOpenTrash={() => setMode("trash")}
+            sortSignature={`${sort.field}:${sort.direction}`}
+            sortControl={
+              <SortControl
+                testId="chat-sort-popover"
+                axes={CHAT_SORT_AXES}
+                field={sort.field}
+                direction={sort.direction}
+                isDefault={sort.isDefault}
+                directionLabels={CHAT_DIRECTION_LABELS}
+                onSelectField={sort.selectField}
+                onToggleDirection={sort.toggleDirection}
+              />
+            }
           />
         </ResizablePanel>
         <ResizableHandle />

--- a/web/src/components/ChatList.tsx
+++ b/web/src/components/ChatList.tsx
@@ -47,7 +47,7 @@ interface ContextMenuState {
 }
 
 const TITLE_DISPLAY_CLASS =
-  "inline-block max-w-full truncate align-middle rounded px-1.5 py-0.5 -mx-1.5 text-sm font-medium text-accent-foreground cursor-text transition-colors group-hover:bg-white/[0.04]";
+  "inline-block max-w-full truncate align-middle rounded px-1.5 py-0.5 -mx-1.5 text-sm font-medium text-accent-foreground cursor-text transition-colors group-hover:bg-white/4";
 const TITLE_INPUT_CLASS =
   "min-w-[12ch] max-w-full rounded border border-border bg-transparent px-1.5 py-0.5 text-sm font-medium text-accent-foreground outline-none focus:border-primary [field-sizing:content]";
 
@@ -70,9 +70,7 @@ function MenuItem({
       role="menuitem"
       onClick={onClick}
       className={`flex w-full items-center justify-between gap-6 rounded-md px-3 py-1.5 text-left transition-colors ${
-        destructive
-          ? "text-destructive hover:bg-[#3a1d23]"
-          : "hover:bg-white/[0.06]"
+        destructive ? "text-destructive hover:bg-[#3a1d23]" : "hover:bg-white/6"
       }`}
     >
       <span className="flex items-center gap-2">
@@ -325,7 +323,7 @@ export function ChatList({
       {contextMenu && (
         <div
           role="menu"
-          className="fixed z-50 min-w-[200px] rounded-md border border-border bg-card p-1 text-sm shadow-lg"
+          className="fixed z-50 min-w-50 rounded-md border border-border bg-card p-1 text-sm shadow-lg"
           style={{ top: contextMenu.y, left: contextMenu.x }}
         >
           {!isTrash && onRenameTitle && (

--- a/web/src/components/ChatList.tsx
+++ b/web/src/components/ChatList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ArrowLeft, Pencil, RotateCcw, Trash2 } from "lucide-react";
 import type { Chat } from "@/types";
 import { EditableTitle } from "./EditableTitle";
@@ -16,6 +16,9 @@ interface ChatListProps {
   onBack?: () => void;
   deletedCount?: number;
   onOpenTrash?: () => void;
+  sortControl?: React.ReactNode;
+  /** Changes whenever the active sort changes; drives keep-selection-visible scrolling. */
+  sortSignature?: string;
 }
 
 function getProjectName(projectPath: string): string {
@@ -106,6 +109,8 @@ export function ChatList({
   onBack,
   deletedCount = 0,
   onOpenTrash,
+  sortControl,
+  sortSignature,
 }: ChatListProps) {
   const [internalEditingId, setInternalEditingId] = useState<string | null>(
     null
@@ -118,6 +123,20 @@ export function ChatList({
   };
   const isTrash = mode === "trash";
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const selectedRowRef = useRef<HTMLDivElement>(null);
+  const prevSortSignature = useRef(sortSignature);
+
+  // Keep the selected chat visible after a sort change; otherwise scroll to top.
+  useEffect(() => {
+    if (prevSortSignature.current === sortSignature) return;
+    prevSortSignature.current = sortSignature;
+    if (selectedId && selectedRowRef.current) {
+      selectedRowRef.current.scrollIntoView?.({ block: "nearest" });
+    } else if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = 0;
+    }
+  }, [sortSignature, selectedId]);
 
   useEffect(() => {
     if (!contextMenu) return;
@@ -160,14 +179,23 @@ export function ChatList({
           </>
         ) : (
           <>
-            <span className="font-semibold text-accent-foreground">Chats</span>
-            <span className="text-xs text-muted-foreground">
-              {chats.length}
+            <span className="flex items-center gap-2">
+              <span className="font-semibold text-accent-foreground">
+                Chats
+              </span>
+              <span className="rounded-full bg-card px-2 text-xs font-semibold tabular-nums text-muted-foreground">
+                {chats.length}
+              </span>
             </span>
+            {sortControl}
           </>
         )}
       </div>
-      <div className="flex-1 overflow-y-auto">
+      <div
+        ref={scrollContainerRef}
+        data-testid="chat-scroll"
+        className="flex-1 overflow-y-auto"
+      >
         {chats.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center px-6 text-center text-sm text-muted-foreground">
             {isTrash ? (
@@ -245,6 +273,7 @@ export function ChatList({
             return (
               <div
                 key={chat.id}
+                ref={isSelected ? selectedRowRef : undefined}
                 data-testid="chat-row"
                 className="group relative"
                 onContextMenu={(e) => handleContextMenu(e, chat.id)}

--- a/web/src/components/SortControl.tsx
+++ b/web/src/components/SortControl.tsx
@@ -36,7 +36,7 @@ export function SortControl<F extends string>({
       <PopoverTrigger
         aria-label="Sort chats"
         className={cn(
-          "flex h-7 w-7 shrink-0 items-center justify-center rounded transition-colors hover:bg-white/[0.04] focus-visible:outline-2 focus-visible:outline-ring",
+          "flex h-7 w-7 shrink-0 items-center justify-center rounded transition-colors hover:bg-white/4 focus-visible:outline-2 focus-visible:outline-ring",
           isDefault ? "text-muted-foreground" : "text-primary"
         )}
       >
@@ -68,7 +68,7 @@ export function SortControl<F extends string>({
                   "flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left transition-colors",
                   active
                     ? "bg-primary/10 text-primary"
-                    : "text-foreground hover:bg-white/[0.06]"
+                    : "text-foreground hover:bg-white/6"
                 )}
               >
                 <span>{axis.label}</span>

--- a/web/src/components/SortControl.tsx
+++ b/web/src/components/SortControl.tsx
@@ -1,0 +1,91 @@
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import type { SortDirection } from "@/lib/sortChats";
+import type { DirectionLabels, SortAxis } from "@/lib/chatSort";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+interface SortControlProps<F extends string> {
+  axes: SortAxis<F>[];
+  field: F;
+  direction: SortDirection;
+  isDefault: boolean;
+  directionLabels: DirectionLabels<F>;
+  onSelectField: (field: F) => void;
+  onToggleDirection: () => void;
+  testId?: string;
+}
+
+export function SortControl<F extends string>({
+  axes,
+  field,
+  direction,
+  isDefault,
+  directionLabels,
+  onSelectField,
+  onToggleDirection,
+  testId,
+}: SortControlProps<F>) {
+  const DirectionArrow = direction === "asc" ? ArrowUp : ArrowDown;
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        aria-label="Sort chats"
+        className={cn(
+          "flex h-7 w-7 shrink-0 items-center justify-center rounded transition-colors hover:bg-white/[0.04] focus-visible:outline-2 focus-visible:outline-ring",
+          isDefault ? "text-muted-foreground" : "text-primary"
+        )}
+      >
+        <ArrowUpDown size={16} aria-hidden="true" />
+      </PopoverTrigger>
+      <PopoverContent
+        data-testid={testId}
+        align="end"
+        sideOffset={6}
+        className="w-44 gap-0 overflow-visible p-1"
+      >
+        <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Sort by
+        </div>
+        {axes.map((axis) => {
+          const active = axis.field === field;
+          return (
+            <div key={axis.field} className="group/axis relative">
+              <button
+                type="button"
+                // Clicking a different axis selects it; clicking the active axis
+                // again flips its direction.
+                onClick={() =>
+                  active ? onToggleDirection() : onSelectField(axis.field)
+                }
+                aria-current={active ? "true" : undefined}
+                title={active ? "Click to reverse direction" : undefined}
+                className={cn(
+                  "flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left transition-colors",
+                  active
+                    ? "bg-primary/10 text-primary"
+                    : "text-foreground hover:bg-white/[0.06]"
+                )}
+              >
+                <span>{axis.label}</span>
+                {active && <DirectionArrow size={14} aria-hidden="true" />}
+              </button>
+              {active && (
+                <span
+                  aria-hidden="true"
+                  className="pointer-events-none absolute left-full top-1/2 ml-3 flex -translate-y-1/2 items-center whitespace-nowrap rounded-md border border-white/10 bg-[#0a0a0a] px-2 py-1 text-xs text-card-foreground opacity-0 shadow-lg transition-opacity duration-100 group-hover/axis:opacity-100"
+                >
+                  {directionLabels[axis.field][direction]}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/hooks/useChats.ts
+++ b/web/src/hooks/useChats.ts
@@ -9,10 +9,6 @@ interface UseChatsResult {
   setTitle: (id: string, title: string) => Promise<void>;
 }
 
-function sortByUpdatedDesc(chats: Chat[]): Chat[] {
-  return [...chats].sort((a, b) => b.updatedAt - a.updatedAt);
-}
-
 export function useChats(): UseChatsResult {
   const [chats, setChats] = useState<Chat[]>([]);
   const [loading, setLoading] = useState(true);
@@ -20,7 +16,7 @@ export function useChats(): UseChatsResult {
   const fetchChats = useCallback(async () => {
     const res = await fetch("/api/chats?includeTrashed=true");
     const data = (await res.json()) as { chats: Chat[] };
-    setChats(sortByUpdatedDesc(data.chats));
+    setChats(data.chats);
   }, []);
 
   useEffect(() => {

--- a/web/src/hooks/useSortPreference.ts
+++ b/web/src/hooks/useSortPreference.ts
@@ -1,0 +1,55 @@
+import { useCallback, useMemo, useState } from "react";
+import type { SortDirection } from "@/lib/sortChats";
+import {
+  isDefaultSort,
+  loadSortPreference,
+  saveSortPreference,
+  selectField,
+  toggleDirection,
+  type SortConfig,
+  type SortPreference,
+} from "@/lib/sortPreference";
+
+export interface UseSortPreferenceResult<F extends string> {
+  field: F;
+  direction: SortDirection;
+  isDefault: boolean;
+  selectField: (field: F) => void;
+  toggleDirection: () => void;
+}
+
+export function useSortPreference<F extends string>(
+  config: SortConfig<F>
+): UseSortPreferenceResult<F> {
+  const [pref, setPref] = useState<SortPreference<F>>(() =>
+    loadSortPreference(config)
+  );
+
+  const update = useCallback(
+    (next: SortPreference<F>) => {
+      saveSortPreference(config, next);
+      setPref(next);
+    },
+    [config]
+  );
+
+  const select = useCallback(
+    (field: F) => update(selectField(pref, field)),
+    [pref, update]
+  );
+  const toggle = useCallback(
+    () => update(toggleDirection(pref)),
+    [pref, update]
+  );
+
+  return useMemo(
+    () => ({
+      field: pref.field,
+      direction: pref.directions[pref.field],
+      isDefault: isDefaultSort(pref, config),
+      selectField: select,
+      toggleDirection: toggle,
+    }),
+    [pref, config, select, toggle]
+  );
+}

--- a/web/src/lib/chatSort.ts
+++ b/web/src/lib/chatSort.ts
@@ -1,0 +1,30 @@
+import type { SortDirection, SortField } from "./sortChats";
+import type { SortConfig } from "./sortPreference";
+
+export interface SortAxis<F extends string> {
+  field: F;
+  label: string;
+}
+
+export type DirectionLabels<F extends string> = Record<
+  F,
+  Record<SortDirection, string>
+>;
+
+export const CHAT_SORT_CONFIG: SortConfig<SortField> = {
+  storageKey: "chatlogbook.sort.chats",
+  defaultField: "updatedAt",
+  typeDefaults: { title: "asc", createdAt: "desc", updatedAt: "desc" },
+};
+
+export const CHAT_SORT_AXES: SortAxis<SortField>[] = [
+  { field: "title", label: "Title" },
+  { field: "createdAt", label: "Created time" },
+  { field: "updatedAt", label: "Updated time" },
+];
+
+export const CHAT_DIRECTION_LABELS: DirectionLabels<SortField> = {
+  title: { asc: "A-Z", desc: "Z-A" },
+  createdAt: { asc: "Oldest first", desc: "Newest first" },
+  updatedAt: { asc: "Oldest first", desc: "Newest first" },
+};

--- a/web/src/lib/sortChats.test.ts
+++ b/web/src/lib/sortChats.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import type { Chat } from "@/types";
+import { sortChats } from "./sortChats";
+
+function makeChat(overrides: Partial<Chat>): Chat {
+  return {
+    id: "id",
+    chatId: "CHAT",
+    agent: "claude-code",
+    title: "",
+    project: "p",
+    projectPath: null,
+    sourceFilePath: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("sortChats — title", () => {
+  it("orders titles A-Z with locale-aware comparison when direction is asc", () => {
+    const chats = [
+      makeChat({ id: "b", title: "Banana" }),
+      makeChat({ id: "a", title: "apple" }),
+      makeChat({ id: "c", title: "Cherry" }),
+    ];
+
+    const sorted = sortChats(chats, "title", "asc");
+
+    expect(sorted.map((c) => c.title)).toEqual(["apple", "Banana", "Cherry"]);
+  });
+
+  it("orders embedded numbers naturally (item2 before item10)", () => {
+    const chats = [
+      makeChat({ id: "10", title: "item10" }),
+      makeChat({ id: "2", title: "item2" }),
+      makeChat({ id: "1", title: "item1" }),
+    ];
+
+    const sorted = sortChats(chats, "title", "asc");
+
+    expect(sorted.map((c) => c.title)).toEqual(["item1", "item2", "item10"]);
+  });
+
+  it("sinks empty and null titles to the bottom in both directions", () => {
+    const chats = [
+      makeChat({ id: "empty", title: "" }),
+      makeChat({ id: "b", title: "Banana" }),
+      makeChat({ id: "null", title: null as unknown as string }),
+      makeChat({ id: "a", title: "Apple" }),
+    ];
+
+    const asc = sortChats(chats, "title", "asc");
+    expect(asc.map((c) => c.id).slice(0, 2)).toEqual(["a", "b"]);
+    expect(asc.map((c) => c.id).slice(2)).toEqual(
+      expect.arrayContaining(["empty", "null"])
+    );
+
+    const desc = sortChats(chats, "title", "desc");
+    expect(desc.map((c) => c.id).slice(0, 2)).toEqual(["b", "a"]);
+    expect(desc.map((c) => c.id).slice(2)).toEqual(
+      expect.arrayContaining(["empty", "null"])
+    );
+  });
+});
+
+describe("sortChats — time axes", () => {
+  it("orders by updatedAt newest-first when direction is desc", () => {
+    const chats = [
+      makeChat({ id: "old", updatedAt: 100 }),
+      makeChat({ id: "new", updatedAt: 300 }),
+      makeChat({ id: "mid", updatedAt: 200 }),
+    ];
+
+    const sorted = sortChats(chats, "updatedAt", "desc");
+
+    expect(sorted.map((c) => c.id)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("orders by createdAt oldest-first when direction is asc", () => {
+    const chats = [
+      makeChat({ id: "old", createdAt: 100 }),
+      makeChat({ id: "new", createdAt: 300 }),
+      makeChat({ id: "mid", createdAt: 200 }),
+    ];
+
+    const sorted = sortChats(chats, "createdAt", "asc");
+
+    expect(sorted.map((c) => c.id)).toEqual(["old", "mid", "new"]);
+  });
+});
+
+describe("sortChats — tie-breakers", () => {
+  it("breaks equal primary keys by updatedAt desc, then createdAt desc, then id asc", () => {
+    const chats = [
+      makeChat({ id: "z", title: "Same", updatedAt: 100, createdAt: 50 }),
+      makeChat({ id: "a", title: "Same", updatedAt: 100, createdAt: 50 }),
+      makeChat({
+        id: "newer-created",
+        title: "Same",
+        updatedAt: 100,
+        createdAt: 90,
+      }),
+      makeChat({
+        id: "newest-updated",
+        title: "Same",
+        updatedAt: 300,
+        createdAt: 10,
+      }),
+    ];
+
+    const sorted = sortChats(chats, "title", "asc");
+
+    expect(sorted.map((c) => c.id)).toEqual([
+      "newest-updated", // updatedAt desc wins first
+      "newer-created", // among equal updatedAt, createdAt desc
+      "a", // among equal updatedAt+createdAt, id asc
+      "z",
+    ]);
+  });
+});

--- a/web/src/lib/sortChats.ts
+++ b/web/src/lib/sortChats.ts
@@ -1,0 +1,49 @@
+import type { Chat } from "@/types";
+
+export type SortField = "title" | "createdAt" | "updatedAt";
+export type SortDirection = "asc" | "desc";
+
+function isEmptyTitle(title: string | null | undefined): boolean {
+  return title == null || title.trim() === "";
+}
+
+function compareTitle(a: Chat, b: Chat, direction: SortDirection): number {
+  const aEmpty = isEmptyTitle(a.title);
+  const bEmpty = isEmptyTitle(b.title);
+  // Empty/null titles always sink to the bottom, regardless of direction.
+  if (aEmpty || bEmpty) return Number(aEmpty) - Number(bEmpty);
+  const cmp = a.title.localeCompare(b.title, "zh-Hant", {
+    sensitivity: "base",
+    numeric: true,
+  });
+  return direction === "asc" ? cmp : -cmp;
+}
+
+function comparePrimary(
+  a: Chat,
+  b: Chat,
+  field: SortField,
+  direction: SortDirection
+): number {
+  if (field === "title") return compareTitle(a, b, direction);
+  const cmp = a[field] - b[field];
+  return direction === "asc" ? cmp : -cmp;
+}
+
+function compareTieBreakers(a: Chat, b: Chat): number {
+  return (
+    b.updatedAt - a.updatedAt ||
+    b.createdAt - a.createdAt ||
+    a.id.localeCompare(b.id)
+  );
+}
+
+export function sortChats(
+  chats: Chat[],
+  field: SortField,
+  direction: SortDirection
+): Chat[] {
+  return [...chats].sort(
+    (a, b) => comparePrimary(a, b, field, direction) || compareTieBreakers(a, b)
+  );
+}

--- a/web/src/lib/sortPreference.test.ts
+++ b/web/src/lib/sortPreference.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  defaultPreference,
+  isDefaultSort,
+  loadSortPreference,
+  saveSortPreference,
+  selectField,
+  toggleDirection,
+  type SortConfig,
+} from "./sortPreference";
+
+type Field = "title" | "createdAt" | "updatedAt";
+
+const config: SortConfig<Field> = {
+  storageKey: "test.sort",
+  defaultField: "updatedAt",
+  typeDefaults: { title: "asc", createdAt: "desc", updatedAt: "desc" },
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("loadSortPreference", () => {
+  it("returns the config default when nothing is stored", () => {
+    const pref = loadSortPreference(config);
+
+    expect(pref.field).toBe("updatedAt");
+    expect(pref.directions.updatedAt).toBe("desc");
+  });
+
+  it("round-trips a saved preference", () => {
+    saveSortPreference(config, {
+      field: "title",
+      directions: { title: "desc", createdAt: "desc", updatedAt: "asc" },
+    });
+
+    const pref = loadSortPreference(config);
+
+    expect(pref.field).toBe("title");
+    expect(pref.directions.title).toBe("desc");
+    expect(pref.directions.updatedAt).toBe("asc");
+  });
+
+  it("falls back to default when the stored version is unknown", () => {
+    localStorage.setItem(
+      config.storageKey,
+      JSON.stringify({ version: 99, field: "title", directions: {} })
+    );
+
+    const pref = loadSortPreference(config);
+
+    expect(pref.field).toBe("updatedAt");
+    expect(pref.directions.updatedAt).toBe("desc");
+  });
+
+  it("falls back to default when the stored value is malformed JSON", () => {
+    localStorage.setItem(config.storageKey, "{not json");
+
+    const pref = loadSortPreference(config);
+
+    expect(pref.field).toBe("updatedAt");
+  });
+});
+
+describe("per-field direction memory", () => {
+  it("uses each axis's type default on first selection", () => {
+    const start = defaultPreference(config);
+
+    const onTitle = selectField(start, "title");
+
+    expect(onTitle.field).toBe("title");
+    expect(onTitle.directions.title).toBe("asc"); // title type default
+  });
+
+  it("remembers each axis's last direction across switches", () => {
+    let pref = defaultPreference(config);
+
+    pref = toggleDirection(pref); // updatedAt: desc -> asc
+    expect(pref.directions.updatedAt).toBe("asc");
+
+    pref = selectField(pref, "title"); // switch axis, memory preserved
+    pref = toggleDirection(pref); // title: asc -> desc
+    expect(pref.directions.title).toBe("desc");
+
+    pref = selectField(pref, "updatedAt"); // back to updatedAt
+    expect(pref.field).toBe("updatedAt");
+    expect(pref.directions.updatedAt).toBe("asc"); // remembered
+
+    pref = selectField(pref, "title"); // back to title
+    expect(pref.directions.title).toBe("desc"); // remembered
+  });
+
+  it("toggleDirection only flips the active axis", () => {
+    const start = defaultPreference(config);
+
+    const flipped = toggleDirection(start);
+
+    expect(flipped.directions.updatedAt).toBe("asc");
+    expect(flipped.directions.title).toBe("asc"); // untouched
+    expect(flipped.directions.createdAt).toBe("desc"); // untouched
+  });
+
+  it("does not mutate the input preference", () => {
+    const start = defaultPreference(config);
+
+    selectField(start, "title");
+    toggleDirection(start);
+
+    expect(start.field).toBe("updatedAt");
+    expect(start.directions.updatedAt).toBe("desc");
+  });
+});
+
+describe("isDefaultSort", () => {
+  it("is true for the config default field and direction", () => {
+    expect(isDefaultSort(defaultPreference(config), config)).toBe(true);
+  });
+
+  it("is false when sorting by a non-default field", () => {
+    const pref = selectField(defaultPreference(config), "title");
+
+    expect(isDefaultSort(pref, config)).toBe(false);
+  });
+
+  it("is false when the default field is flipped away from its type default", () => {
+    const pref = toggleDirection(defaultPreference(config)); // updatedAt asc
+
+    expect(isDefaultSort(pref, config)).toBe(false);
+  });
+});

--- a/web/src/lib/sortPreference.ts
+++ b/web/src/lib/sortPreference.ts
@@ -1,0 +1,99 @@
+import type { SortDirection } from "./sortChats";
+
+export interface SortConfig<F extends string> {
+  storageKey: string;
+  defaultField: F;
+  typeDefaults: Record<F, SortDirection>;
+}
+
+export interface SortPreference<F extends string> {
+  field: F;
+  directions: Record<F, SortDirection>;
+}
+
+export function defaultPreference<F extends string>(
+  config: SortConfig<F>
+): SortPreference<F> {
+  return {
+    field: config.defaultField,
+    directions: { ...config.typeDefaults },
+  };
+}
+
+export function selectField<F extends string>(
+  pref: SortPreference<F>,
+  field: F
+): SortPreference<F> {
+  return { field, directions: { ...pref.directions } };
+}
+
+export function toggleDirection<F extends string>(
+  pref: SortPreference<F>
+): SortPreference<F> {
+  const next = pref.directions[pref.field] === "asc" ? "desc" : "asc";
+  return {
+    field: pref.field,
+    directions: { ...pref.directions, [pref.field]: next },
+  };
+}
+
+export function isDefaultSort<F extends string>(
+  pref: SortPreference<F>,
+  config: SortConfig<F>
+): boolean {
+  return (
+    pref.field === config.defaultField &&
+    pref.directions[pref.field] === config.typeDefaults[config.defaultField]
+  );
+}
+
+const STORAGE_VERSION = 1;
+
+export function saveSortPreference<F extends string>(
+  config: SortConfig<F>,
+  pref: SortPreference<F>
+): void {
+  const payload = {
+    version: STORAGE_VERSION,
+    field: pref.field,
+    directions: pref.directions,
+  };
+  localStorage.setItem(config.storageKey, JSON.stringify(payload));
+}
+
+export function loadSortPreference<F extends string>(
+  config: SortConfig<F>
+): SortPreference<F> {
+  const fallback = defaultPreference(config);
+  const raw = localStorage.getItem(config.storageKey);
+  if (raw == null) return fallback;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return fallback;
+  const record = parsed as Record<string, unknown>;
+  if (record.version !== STORAGE_VERSION) return fallback;
+
+  const fields = Object.keys(config.typeDefaults) as F[];
+  const field =
+    typeof record.field === "string" && fields.includes(record.field as F)
+      ? (record.field as F)
+      : config.defaultField;
+
+  // Start from type defaults, then overlay any valid stored per-field memory.
+  const directions = { ...config.typeDefaults };
+  const stored = record.directions;
+  if (typeof stored === "object" && stored !== null) {
+    for (const key of fields) {
+      const value = (stored as Record<string, unknown>)[key];
+      if (value === "asc" || value === "desc") directions[key] = value;
+    }
+  }
+
+  return { field, directions };
+}

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -58,5 +58,6 @@ afterEach(() => {
   cleanup();
   server.resetHandlers();
   resetFakeChats();
+  localStorage.clear();
 });
 afterAll(() => server.close());


### PR DESCRIPTION
## Background (Why)

The Chat List was hard-coded to sort by Updated time (newest first), with no way to reorder. This slice also lays down the sort UI and storage machinery that Trash sorting (separate issue) will reuse.

## Approach (How)

- Pure, well-tested core split from React:
  - `lib/sortChats.ts` — locale-aware title collation (`zh-Hant`, case-insensitive, numeric), empty/null titles sink to the bottom in both directions, and a stable tie-breaker chain (`primary key → updatedAt desc → createdAt desc → id asc`).
  - `lib/sortPreference.ts` — config-driven and generic over the field union: load/save to `localStorage` with version fallback, per-field direction memory, and `isDefaultSort`. Trash reuse is "pass a different config".
- `useSortPreference` binds that logic to state + persistence; `SortControl` renders the `↕` popover (base-ui).
- Sort moves out of `useChats` into `App` via `useMemo([chats, field, direction])`.
- Interaction: clicking a different axis selects it; re-clicking the active axis flips its direction. The direction label is a display-only hover tooltip (styled like `ActionTooltip`), with an inline arrow always showing direction.

## Changes (What)

- [x] Sort by Title / Created time / Updated time; default unchanged (Updated · Newest first)
- [x] Per-axis direction toggle with correct labels (A-Z/Z-A, Newest/Oldest first)
- [x] Per-field direction memory; persists across reload (`chatlogbook.sort.chats`, `version: 1`)
- [x] `↕` icon tints primary cyan when the sort is non-default
- [x] Chat count restyled as a pill next to the "Chats" title
- [x] Selected chat stays visible after a sort change (`scrollIntoView`), else scroll to top
- [x] Tests: `sortChats` (locale, tie-breakers, null titles), `sortPreference` (version fallback, per-field memory, round-trip), and App-level popover/interaction/persistence

### Tooling cleanup (folded in)

- `chore(web): repair eslint flat config` — the config called `reactRefresh.configs.vite.override()`, which the installed `eslint-plugin-react-refresh` no longer exposes, so eslint crashed before linting anything. `pnpm lint` runs again.
- `chore(web): canonical Tailwind classes` — `bg-white/[0.04]→/4`, `bg-white/[0.06]→/6`, `min-w-[200px]→min-w-50` in the touched files (visually identical).

> Re-enabling eslint surfaced 6 pre-existing violations in unrelated files (App keydown effect ordering, `set-state-in-effect` in `useChats`/`useMessages`, plus 2 warnings) caused by an `eslint-plugin-react-hooks` v6 bump. Out of scope here — tracked in separate issues.

## Test plan

- `pnpm -r test` green (web 87, api 117); `pnpm typecheck` clean.
- `pnpm lint` now runs; remaining 6 problems are pre-existing and tracked separately.

## Related Links

- Closes #81