### PR TITLE
fix(web): resolve react-hooks/set-state-in-effect in data-fetching effects

### DIFF
--- a/web/src/hooks/useChats.ts
+++ b/web/src/hooks/useChats.ts
@@ -20,10 +20,20 @@ export function useChats(): UseChatsResult {
   }, []);
 
   useEffect(() => {
-    fetchChats()
+    let cancelled = false;
+    fetch("/api/chats?includeTrashed=true")
+      .then((res) => res.json() as Promise<{ chats: Chat[] }>)
+      .then((data) => {
+        if (!cancelled) setChats(data.chats);
+      })
       .catch(() => {})
-      .finally(() => setLoading(false));
-  }, [fetchChats]);
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const softDelete = useCallback(async (id: string) => {
     setChats((prev) =>

--- a/web/src/hooks/useMessages.ts
+++ b/web/src/hooks/useMessages.ts
@@ -1,21 +1,29 @@
 import { useEffect, useState } from "react";
 import type { Message } from "@/types";
 
+interface MessagesState {
+  chatId: string | null;
+  messages: Message[];
+  error: string | null;
+}
+
+const initialState: MessagesState = {
+  chatId: null,
+  messages: [],
+  error: null,
+};
+
 export function useMessages(chatId: string | null): {
   messages: Message[];
   loading: boolean;
   error: string | null;
 } {
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [state, setState] = useState<MessagesState>(initialState);
 
   useEffect(() => {
     if (!chatId) return;
 
     let cancelled = false;
-    setLoading(true);
-    setError(null);
 
     fetch(`/api/chats/${chatId}?includeTrashed=true`)
       .then((res) => {
@@ -28,15 +36,16 @@ export function useMessages(chatId: string | null): {
       })
       .then((data: { messages: Message[] }) => {
         if (!cancelled) {
-          setMessages(data.messages);
-          setLoading(false);
+          setState({ chatId, messages: data.messages, error: null });
         }
       })
       .catch((err: unknown) => {
         if (!cancelled) {
-          setMessages([]);
-          setError(err instanceof Error ? err.message : "Failed to load chat");
-          setLoading(false);
+          setState({
+            chatId,
+            messages: [],
+            error: err instanceof Error ? err.message : "Failed to load chat",
+          });
         }
       });
 
@@ -45,9 +54,16 @@ export function useMessages(chatId: string | null): {
     };
   }, [chatId]);
 
+  // Derive loading/error from whether the resolved state matches the currently
+  // requested chatId, instead of writing state synchronously inside the effect.
+  // A request is in flight whenever the latest settled chatId does not match the
+  // requested one. Messages keep the last loaded value until the new request
+  // settles, matching the previous behavior.
+  const settled = state.chatId === chatId;
+
   return {
-    messages: chatId ? messages : [],
-    loading,
-    error: chatId ? error : null,
+    messages: chatId ? state.messages : [],
+    loading: chatId !== null && !settled,
+    error: chatId && settled ? state.error : null,
   };
 }


### PR DESCRIPTION
## Background (Why)

After the react-hooks v6 bump, `pnpm lint` reported two `react-hooks/set-state-in-effect` errors in the data-fetching hooks. The stricter React Compiler rules reject calling `setState` synchronously inside an effect body. This PR refactors both hooks to drive state from the fetch lifecycle instead, following the React guidance (https://react.dev/learn/you-might-not-need-an-effect).

- `web/src/hooks/useChats.ts` — `setChats(data.chats)` ran inside the `fetchChats` effect.
- `web/src/hooks/useMessages.ts` — `setLoading(true)` / `setError(null)` ran synchronously at the top of the effect body.

## Approach (How)

- `useChats.ts`: the initial-load effect previously called the async `fetchChats()` (which calls `setChats`) and then `setLoading(false)`. The fetch now runs inline in the effect, so `setChats` / `setLoading` only fire inside promise callbacks, guarded by a cancellation flag. The standalone `fetchChats` callback stays for the empty-title refetch path in `setTitle`.
- `useMessages.ts`: removed the synchronous `setLoading(true)` / `setError(null)`. Messages and error are now a single `chatId`-keyed state, and `loading` / `error` are derived from whether the settled `chatId` matches the requested one. The cancellation guard is preserved.

## Changes (What)

- [x] `useChats.ts` — move the fetch inline so state updates fire only inside promise callbacks, behind a cancellation guard; keep the standalone `fetchChats` for `setTitle`'s refetch.
- [x] `useMessages.ts` — replace in-effect synchronous setState with a single `chatId`-keyed state and derive `loading` / `error`.

### Test Verification

- [x] `pnpm lint` — no `react-hooks/set-state-in-effect` errors remain in either file. The 2 remaining warnings are in unrelated files, handled by sibling issue #87.
- [x] `pnpm --filter web test` — all 87 tests pass.
- [x] `tsc --noEmit` — clean.

## Additional Notes

Observable behavior (loading / error / data flow) is unchanged. Messages keep their last loaded value until the new request settles, matching the prior behavior. `loading` is not consumed externally (App.tsx reads only `messages` and `error`).

## Related Links

- Closes #85