### PR TITLE
chore(web): clear remaining lint warnings after react-hooks v6 bump

### DIFF
--- a/web/src/components/ConversationView.tsx
+++ b/web/src/components/ConversationView.tsx
@@ -182,6 +182,13 @@ export function ConversationView({
   };
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
+  // TanStack Virtual's useVirtualizer returns functions (e.g. measureElement)
+  // that the React Compiler cannot memoize without risking stale UI, so the
+  // compiler intentionally skips memoizing this component. This is expected and
+  // safe here: the virtualizer values are consumed locally and not passed into
+  // other memoized components/hooks. The warning cannot be compiled away, so we
+  // silence it at the call site rather than disabling the rule globally.
+  // eslint-disable-next-line react-hooks/incompatible-library
   const virtualizer = useVirtualizer({
     count: messages.length,
     getScrollElement: () => scrollContainerRef.current,

--- a/web/src/components/ui/button-variants.ts
+++ b/web/src/components/ui/button-variants.ts
@@ -1,0 +1,38 @@
+import { cva } from "class-variance-authority";
+
+export const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+        icon: "size-8",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -1,44 +1,8 @@
 import { Button as ButtonPrimitive } from "@base-ui/react/button";
-import { cva, type VariantProps } from "class-variance-authority";
+import { type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
-
-const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-        outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
-        destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
-        icon: "size-8",
-        "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-);
+import { buttonVariants } from "./button-variants";
 
 function Button({
   className,
@@ -55,4 +19,4 @@ function Button({
   );
 }
 
-export { Button, buttonVariants };
+export { Button };


### PR DESCRIPTION
## Background (Why)

After the react-hooks v6 bump, `pnpm lint` still emitted two warnings. This PR clears both so the lint output for these rules is clean.

- `web/src/components/ui/button.tsx` — `react-refresh/only-export-components`: exporting `buttonVariants` alongside the `Button` component breaks Fast Refresh.
- `web/src/components/ConversationView.tsx` — `react-hooks/incompatible-library` ("Compilation Skipped: Use of incompatible library"): the React Compiler refuses to memoize the component that calls TanStack Virtual's `useVirtualizer`.

## Approach (How)

- Move the `buttonVariants` `cva` definition into its own module, `button-variants.ts`, so `button.tsx` only exports a component. `button.tsx` now imports `buttonVariants` from that module.
- The `useVirtualizer` warning is a by-design limitation: TanStack Virtual returns functions that cannot be memoized without risking stale UI, so the compiler skips this component. It cannot be compiled away, so we document why at the call site and silence the rule there (not globally).

## Changes (What)

- [x] Add `web/src/components/ui/button-variants.ts` holding `buttonVariants`.
- [x] `button.tsx` imports `buttonVariants` from the new module and exports only `Button`.
- [x] Document the `useVirtualizer` compiler-skip in `ConversationView.tsx` and add a scoped `eslint-disable-next-line react-hooks/incompatible-library`.

### Test Verification

- [x] `pnpm lint` — the two targeted warnings are gone (0 warnings). The 4 remaining errors belong to sibling issues #85 (useChats/useMessages) and #86 (App.tsx) and are out of scope here.
- [x] `pnpm --filter web test` — all 87 tests pass.
- [x] `pnpm typecheck` — passes.

## Additional Notes

`buttonVariants` had no external consumers (only `button.tsx` itself referenced it), so no other imports needed updating; it now lives at `@/components/ui/button-variants`.

## Related Links

- Closes #87