### PR TITLE
feat: sortable Trash with deletedAt schema and API

### DIFF
--- a/api/drizzle/0003_add_deleted_at.sql
+++ b/api/drizzle/0003_add_deleted_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `chats_meta` ADD `deleted_at` integer;--> statement-breakpoint
+UPDATE `chats_meta` SET `deleted_at` = `updated_at` WHERE `is_deleted` = 1;

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1779000000000,
       "tag": "0002_rename_sessions_meta_to_chats_meta",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1779500000000,
+      "tag": "0003_add_deleted_at",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -496,6 +496,35 @@ describe("Soft delete and restore (archive-backed)", () => {
     expect(s?.isDeleted).toBe(true);
   });
 
+  it("exposes deletedAt: null for active chats and a timestamp for trashed chats", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedChat(archive, {
+      internalId: "active-uuid-1",
+      sourceId: "session-active",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedChat(archive, {
+      internalId: "trashd-uuid-1",
+      sourceId: "session-trashed",
+      firstSeenAt: new Date(1700000000000),
+    });
+
+    const app = createApp({ archive, metadata });
+    const before = Date.now();
+    await app.request("/api/chats/session-trashed", { method: "DELETE" });
+
+    const res = await app.request("/api/chats?includeTrashed=true");
+    const body = (await res.json()) as {
+      chats: (ChatResponse & { deletedAt: number | null })[];
+    };
+    const active = body.chats.find((c) => c.id === "session-active");
+    const trashed = body.chats.find((c) => c.id === "session-trashed");
+    expect(active?.deletedAt).toBeNull();
+    expect(typeof trashed?.deletedAt).toBe("number");
+    expect(trashed!.deletedAt!).toBeGreaterThanOrEqual(before);
+  });
+
   it("restores a previously deleted session", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -26,6 +26,7 @@ interface ChatResponse {
   sourceFilePath: string | null;
   createdAt: number;
   updatedAt: number;
+  deletedAt: number | null;
   isDeleted?: boolean;
 }
 
@@ -120,6 +121,7 @@ export function createApp({ archive, metadata, webDistDir }: AppOptions) {
         sourceFilePath: latestRaw?.sourcePath ?? null,
         createdAt: tsRange?.minTs ?? firstSeenAtMs,
         updatedAt: tsRange?.maxTs ?? firstSeenAtMs,
+        deletedAt: visibility.deletedAt(row.id),
       };
       if (isDeleted) chat.isDeleted = true;
       chats.push(chat);

--- a/api/src/metadata/repository.test.ts
+++ b/api/src/metadata/repository.test.ts
@@ -69,6 +69,35 @@ describe("MetadataRepository", () => {
     }
   });
 
+  it("backfills deleted_at from updated_at for already-trashed rows on migration", () => {
+    seedFromFixture(dataDir);
+
+    createMetadataRepository({ dataDir });
+
+    const sqlite = new Database(path.join(dataDir, "data.db"), {
+      readonly: true,
+    });
+    try {
+      const rows = sqlite
+        .prepare(
+          "SELECT id, is_deleted, deleted_at, updated_at FROM chats_meta ORDER BY created_at"
+        )
+        .all() as {
+        id: string;
+        is_deleted: number;
+        deleted_at: number | null;
+        updated_at: number;
+      }[];
+
+      const active = rows.find((r) => r.is_deleted === 0)!;
+      const trashed = rows.find((r) => r.is_deleted === 1)!;
+      expect(active.deleted_at).toBeNull();
+      expect(trashed.deleted_at).toBe(trashed.updated_at);
+    } finally {
+      sqlite.close();
+    }
+  });
+
   it("marks a session as deleted after softDelete", () => {
     const repo = createMetadataRepository({ dataDir });
 
@@ -97,6 +126,22 @@ describe("MetadataRepository", () => {
     const second = createMetadataRepository({ dataDir });
 
     expect(second.isDeleted("session-1")).toBe(true);
+  });
+
+  it("stamps deletedAt on softDelete and clears it on restore", () => {
+    const repo = createMetadataRepository({ dataDir });
+
+    expect(repo.getDeletedAt("session-1")).toBeNull();
+
+    const before = Date.now();
+    repo.softDelete("session-1");
+    const stamped = repo.getDeletedAt("session-1");
+    expect(stamped).toBeInstanceOf(Date);
+    expect(stamped!.getTime()).toBeGreaterThanOrEqual(before);
+    expect(stamped!.getTime()).toBeLessThanOrEqual(Date.now());
+
+    repo.restore("session-1");
+    expect(repo.getDeletedAt("session-1")).toBeNull();
   });
 
   it("returns null for custom title before it is set, and the stored value after", () => {

--- a/api/src/metadata/repository.ts
+++ b/api/src/metadata/repository.ts
@@ -27,7 +27,8 @@ export interface MetadataRepository {
   softDelete(internalId: string): void;
   restore(internalId: string): void;
   isDeleted(internalId: string): boolean;
-  listDeletedIds(): string[];
+  getDeletedAt(internalId: string): Date | null;
+  listDeleted(): Array<{ id: string; deletedAt: Date | null }>;
   getCustomTitle(internalId: string): string | null;
   setCustomTitle(internalId: string, title: string | null): void;
 }
@@ -70,10 +71,11 @@ export function createMetadataRepository({
           isDeleted: true,
           createdAt: now,
           updatedAt: now,
+          deletedAt: now,
         })
         .onConflictDoUpdate({
           target: chatsMeta.id,
-          set: { isDeleted: true, updatedAt: now },
+          set: { isDeleted: true, updatedAt: now, deletedAt: now },
         })
         .run();
     },
@@ -81,7 +83,7 @@ export function createMetadataRepository({
     restore(internalId) {
       const now = new Date();
       db.update(chatsMeta)
-        .set({ isDeleted: false, updatedAt: now })
+        .set({ isDeleted: false, updatedAt: now, deletedAt: null })
         .where(eq(chatsMeta.id, internalId))
         .run();
     },
@@ -95,13 +97,22 @@ export function createMetadataRepository({
       return row?.isDeleted ?? false;
     },
 
-    listDeletedIds() {
+    getDeletedAt(internalId) {
+      const row = db
+        .select({ deletedAt: chatsMeta.deletedAt })
+        .from(chatsMeta)
+        .where(eq(chatsMeta.id, internalId))
+        .get();
+      return row?.deletedAt ?? null;
+    },
+
+    listDeleted() {
       const rows = db
-        .select({ id: chatsMeta.id })
+        .select({ id: chatsMeta.id, deletedAt: chatsMeta.deletedAt })
         .from(chatsMeta)
         .where(eq(chatsMeta.isDeleted, true))
         .all();
-      return rows.map((r) => r.id);
+      return rows.map((r) => ({ id: r.id, deletedAt: r.deletedAt ?? null }));
     },
 
     getCustomTitle(internalId) {

--- a/api/src/metadata/schema.ts
+++ b/api/src/metadata/schema.ts
@@ -8,4 +8,7 @@ export const chatsMeta = sqliteTable("chats_meta", {
   customTitle: text("custom_title"),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+  // Set when a chat is moved to Trash; null while active. Drives the Trash
+  // view's independent "Deleted time" sort axis.
+  deletedAt: integer("deleted_at", { mode: "timestamp_ms" }),
 });

--- a/api/src/visibility.ts
+++ b/api/src/visibility.ts
@@ -13,16 +13,23 @@ export interface VisibilityOptions {
 export interface ChatVisibility {
   isTrashed(internalId: string): boolean;
   isVisible(internalId: string): boolean;
+  /** Soft-delete time in ms, or null when the chat is not trashed. */
+  deletedAt(internalId: string): number | null;
 }
 
 export function loadChatVisibility(
   metadata: MetadataRepository,
   opts: VisibilityOptions
 ): ChatVisibility {
-  const trashed = new Set(metadata.listDeletedIds());
+  const deleted = metadata.listDeleted();
+  const trashed = new Set(deleted.map((r) => r.id));
+  const deletedAtById = new Map(
+    deleted.map((r) => [r.id, r.deletedAt?.getTime() ?? null] as const)
+  );
   const showTrashed = opts.includeTrashed === true;
   return {
     isTrashed: (internalId) => trashed.has(internalId),
     isVisible: (internalId) => showTrashed || !trashed.has(internalId),
+    deletedAt: (internalId) => deletedAtById.get(internalId) ?? null,
   };
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -502,7 +502,113 @@ describe("Trash link in filter panel", () => {
 
     const trashLink = await screen.findByTestId("trash-link");
     expect(within(trashLink).getByText(/trash/i)).toBeInTheDocument();
-    expect(within(trashLink).getByText("1")).toBeInTheDocument();
+    expect(within(trashLink).getByText("2")).toBeInTheDocument();
+  });
+});
+
+describe("Trash sort", () => {
+  it("offers Title, Created, Updated, and Deleted time with Deleted last", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+
+    const list = screen.getByTestId("chat-list");
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+
+    const popover = await screen.findByTestId("trash-sort-popover");
+    const labels = within(popover)
+      .getAllByRole("button")
+      .map((b) => b.textContent?.trim());
+    expect(labels).toEqual([
+      "Title",
+      "Created time",
+      "Updated time",
+      "Deleted time",
+    ]);
+  });
+
+  it("defaults to Deleted time, newest first", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+
+    const list = screen.getByTestId("chat-list");
+    // chat-deleted-1 deletedAt 1700000200000 > chat-deleted-2 1700000100000
+    const rows = within(list).getAllByTestId("chat-row");
+    expect(rows[0].textContent).toContain("Old prototype");
+    expect(rows[1].textContent).toContain("Newer experiment");
+
+    // The active axis reads "Deleted time" with the "Newest first" label.
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+    const popover = await screen.findByTestId("trash-sort-popover");
+    expect(within(popover).getByText("Newest first")).toBeInTheDocument();
+  });
+
+  it("reorders by Updated time when that axis is selected", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+
+    const list = screen.getByTestId("chat-list");
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+    const popover = await screen.findByTestId("trash-sort-popover");
+    await user.click(within(popover).getByText("Updated time"));
+
+    // Updated time desc: chat-deleted-2 (1699999800000) before chat-deleted-1.
+    const rows = within(list).getAllByTestId("chat-row");
+    expect(rows[0].textContent).toContain("Newer experiment");
+    expect(rows[1].textContent).toContain("Old prototype");
+  });
+
+  it("no longer shows the 'Trash (N)' text label in the header", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+
+    await screen.findByText("Old prototype");
+    expect(screen.queryByText(/^Trash \(\d+\)$/)).not.toBeInTheDocument();
+    const list = screen.getByTestId("chat-list");
+    expect(
+      within(list).getByRole("button", { name: /back/i })
+    ).toBeInTheDocument();
+    expect(
+      within(list).getByRole("button", { name: /sort/i })
+    ).toBeInTheDocument();
+  });
+
+  it("persists the Trash sort independently of the Chats list sort", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("trash-link"));
+
+    const list = screen.getByTestId("chat-list");
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+    const popover = await screen.findByTestId("trash-sort-popover");
+    await user.click(within(popover).getByText("Title"));
+
+    // Trash preference is stored under its own key; the Chats key is untouched.
+    const trashPref = JSON.parse(
+      localStorage.getItem("chatlogbook.sort.trash") ?? "{}"
+    );
+    expect(trashPref.field).toBe("title");
+    expect(localStorage.getItem("chatlogbook.sort.chats")).toBeNull();
+
+    // Back in the Chats list, the default Updated-time order still holds.
+    await user.click(within(list).getByRole("button", { name: /back/i }));
+    const mainRows = within(screen.getByTestId("chat-list")).getAllByTestId(
+      "chat-row"
+    );
+    expect(mainRows[0].textContent).toContain("Fix database migration");
   });
 });
 
@@ -529,9 +635,9 @@ describe("Soft delete from chat list", () => {
       ).not.toBeInTheDocument();
     });
 
-    // Trash count: 1 → 2
+    // Trash count: 2 → 3
     const trashLink = screen.getByTestId("trash-link");
-    expect(within(trashLink).getByText("2")).toBeInTheDocument();
+    expect(within(trashLink).getByText("3")).toBeInTheDocument();
   });
 });
 
@@ -585,7 +691,7 @@ describe("Undo toast on delete", () => {
     });
 
     const trashLink = screen.getByTestId("trash-link");
-    expect(within(trashLink).getByText("1")).toBeInTheDocument();
+    expect(within(trashLink).getByText("2")).toBeInTheDocument();
   });
 });
 
@@ -633,7 +739,6 @@ describe("Enter Trash mode", () => {
     await user.click(screen.getByTestId("trash-link"));
 
     const list = screen.getByTestId("chat-list");
-    expect(within(list).getByText(/trash \(1\)/i)).toBeInTheDocument();
     expect(within(list).getByText("Old prototype")).toBeInTheDocument();
     expect(
       within(list).queryByText("Build a login page")
@@ -751,7 +856,9 @@ describe("Trash mode triggers: hover button, Backspace, Esc", () => {
     await user.click(screen.getByTestId("trash-link"));
 
     const list = screen.getByTestId("chat-list");
-    expect(within(list).getByText(/trash/i)).toBeInTheDocument();
+    expect(
+      within(list).getByRole("button", { name: /back/i })
+    ).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,9 @@ import {
   CHAT_DIRECTION_LABELS,
   CHAT_SORT_AXES,
   CHAT_SORT_CONFIG,
+  TRASH_DIRECTION_LABELS,
+  TRASH_SORT_AXES,
+  TRASH_SORT_CONFIG,
 } from "@/lib/chatSort";
 import { FilterPanel } from "@/components/FilterPanel";
 import { ChatList } from "@/components/ChatList";
@@ -31,6 +34,7 @@ function App() {
   const { messages, error } = useMessages(selectedId);
   const { toast, showToast, dismissToast } = useToast();
   const sort = useSortPreference(CHAT_SORT_CONFIG);
+  const trashSort = useSortPreference(TRASH_SORT_CONFIG);
   const mainChats = useMemo(
     () =>
       sortChats(
@@ -40,8 +44,17 @@ function App() {
       ),
     [chats, sort.field, sort.direction]
   );
-  const deletedChats = chats.filter((c) => c.isDeleted);
+  const deletedChats = useMemo(
+    () =>
+      sortChats(
+        chats.filter((c) => c.isDeleted),
+        trashSort.field,
+        trashSort.direction
+      ),
+    [chats, trashSort.field, trashSort.direction]
+  );
   const visibleChats = mode === "trash" ? deletedChats : mainChats;
+  const activeSort = mode === "trash" ? trashSort : sort;
   const selectedChat = chats.find((c) => c.id === selectedId) ?? null;
 
   const handleRestore = (id: string) => {
@@ -146,18 +159,31 @@ function App() {
             onBack={() => setMode("main")}
             deletedCount={deletedChats.length}
             onOpenTrash={() => setMode("trash")}
-            sortSignature={`${sort.field}:${sort.direction}`}
+            sortSignature={`${mode}:${activeSort.field}:${activeSort.direction}`}
             sortControl={
-              <SortControl
-                testId="chat-sort-popover"
-                axes={CHAT_SORT_AXES}
-                field={sort.field}
-                direction={sort.direction}
-                isDefault={sort.isDefault}
-                directionLabels={CHAT_DIRECTION_LABELS}
-                onSelectField={sort.selectField}
-                onToggleDirection={sort.toggleDirection}
-              />
+              mode === "trash" ? (
+                <SortControl
+                  testId="trash-sort-popover"
+                  axes={TRASH_SORT_AXES}
+                  field={trashSort.field}
+                  direction={trashSort.direction}
+                  isDefault={trashSort.isDefault}
+                  directionLabels={TRASH_DIRECTION_LABELS}
+                  onSelectField={trashSort.selectField}
+                  onToggleDirection={trashSort.toggleDirection}
+                />
+              ) : (
+                <SortControl
+                  testId="chat-sort-popover"
+                  axes={CHAT_SORT_AXES}
+                  field={sort.field}
+                  direction={sort.direction}
+                  isDefault={sort.isDefault}
+                  directionLabels={CHAT_DIRECTION_LABELS}
+                  onSelectField={sort.selectField}
+                  onToggleDirection={sort.toggleDirection}
+                />
+              )
             }
           />
         </ResizablePanel>

--- a/web/src/components/ChatList.tsx
+++ b/web/src/components/ChatList.tsx
@@ -171,9 +171,7 @@ export function ChatList({
               <ArrowLeft size={14} aria-hidden="true" />
               Back
             </button>
-            <span className="font-semibold text-accent-foreground">
-              Trash ({chats.length})
-            </span>
+            {sortControl}
           </>
         ) : (
           <>

--- a/web/src/hooks/useChats.ts
+++ b/web/src/hooks/useChats.ts
@@ -36,8 +36,13 @@ export function useChats(): UseChatsResult {
   }, []);
 
   const softDelete = useCallback(async (id: string) => {
+    // Mirror the server contract optimistically so the Trash view sorts by a
+    // real Deleted time immediately, before any refetch.
+    const now = Date.now();
     setChats((prev) =>
-      prev.map((c) => (c.id === id ? { ...c, isDeleted: true } : c))
+      prev.map((c) =>
+        c.id === id ? { ...c, isDeleted: true, deletedAt: now } : c
+      )
     );
     await fetch(`/api/chats/${encodeURIComponent(id)}`, {
       method: "DELETE",
@@ -46,7 +51,9 @@ export function useChats(): UseChatsResult {
 
   const restore = useCallback(async (id: string) => {
     setChats((prev) =>
-      prev.map((c) => (c.id === id ? { ...c, isDeleted: false } : c))
+      prev.map((c) =>
+        c.id === id ? { ...c, isDeleted: false, deletedAt: null } : c
+      )
     );
     await fetch(`/api/chats/${encodeURIComponent(id)}/restore`, {
       method: "POST",

--- a/web/src/lib/chatSort.test.ts
+++ b/web/src/lib/chatSort.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { defaultPreference } from "./sortPreference";
+import {
+  TRASH_SORT_AXES,
+  TRASH_SORT_CONFIG,
+  TRASH_DIRECTION_LABELS,
+} from "./chatSort";
+
+describe("TRASH_SORT_CONFIG", () => {
+  it("persists under the chatlogbook.sort.trash key", () => {
+    expect(TRASH_SORT_CONFIG.storageKey).toBe("chatlogbook.sort.trash");
+  });
+
+  it("defaults to Deleted time, newest first", () => {
+    const pref = defaultPreference(TRASH_SORT_CONFIG);
+    expect(pref.field).toBe("deletedAt");
+    expect(pref.directions.deletedAt).toBe("desc");
+  });
+});
+
+describe("TRASH_SORT_AXES", () => {
+  it("offers Title, Created, Updated, and Deleted time with Deleted last", () => {
+    expect(TRASH_SORT_AXES.map((a) => a.field)).toEqual([
+      "title",
+      "createdAt",
+      "updatedAt",
+      "deletedAt",
+    ]);
+    expect(TRASH_SORT_AXES.at(-1)?.label).toBe("Deleted time");
+  });
+
+  it("labels the deletedAt direction as oldest/newest first", () => {
+    expect(TRASH_DIRECTION_LABELS.deletedAt).toEqual({
+      asc: "Oldest first",
+      desc: "Newest first",
+    });
+  });
+});

--- a/web/src/lib/chatSort.ts
+++ b/web/src/lib/chatSort.ts
@@ -11,10 +11,19 @@ export type DirectionLabels<F extends string> = Record<
   Record<SortDirection, string>
 >;
 
+const TIME_LABELS = { asc: "Oldest first", desc: "Newest first" } as const;
+
+// The Chats list omits the deletedAt axis (only Trash sorts by it), but the
+// shared SortField type still requires an entry in these per-field records.
 export const CHAT_SORT_CONFIG: SortConfig<SortField> = {
   storageKey: "chatlogbook.sort.chats",
   defaultField: "updatedAt",
-  typeDefaults: { title: "asc", createdAt: "desc", updatedAt: "desc" },
+  typeDefaults: {
+    title: "asc",
+    createdAt: "desc",
+    updatedAt: "desc",
+    deletedAt: "desc",
+  },
 };
 
 export const CHAT_SORT_AXES: SortAxis<SortField>[] = [
@@ -25,6 +34,34 @@ export const CHAT_SORT_AXES: SortAxis<SortField>[] = [
 
 export const CHAT_DIRECTION_LABELS: DirectionLabels<SortField> = {
   title: { asc: "A-Z", desc: "Z-A" },
-  createdAt: { asc: "Oldest first", desc: "Newest first" },
-  updatedAt: { asc: "Oldest first", desc: "Newest first" },
+  createdAt: { ...TIME_LABELS },
+  updatedAt: { ...TIME_LABELS },
+  deletedAt: { ...TIME_LABELS },
+};
+
+// Trash sorts independently of the Chats list, defaulting to most-recently
+// deleted first. Deleted time is placed last in the axis menu.
+export const TRASH_SORT_CONFIG: SortConfig<SortField> = {
+  storageKey: "chatlogbook.sort.trash",
+  defaultField: "deletedAt",
+  typeDefaults: {
+    title: "asc",
+    createdAt: "desc",
+    updatedAt: "desc",
+    deletedAt: "desc",
+  },
+};
+
+export const TRASH_SORT_AXES: SortAxis<SortField>[] = [
+  { field: "title", label: "Title" },
+  { field: "createdAt", label: "Created time" },
+  { field: "updatedAt", label: "Updated time" },
+  { field: "deletedAt", label: "Deleted time" },
+];
+
+export const TRASH_DIRECTION_LABELS: DirectionLabels<SortField> = {
+  title: { asc: "A-Z", desc: "Z-A" },
+  createdAt: { ...TIME_LABELS },
+  updatedAt: { ...TIME_LABELS },
+  deletedAt: { ...TIME_LABELS },
 };

--- a/web/src/lib/sortChats.test.ts
+++ b/web/src/lib/sortChats.test.ts
@@ -88,6 +88,28 @@ describe("sortChats — time axes", () => {
 
     expect(sorted.map((c) => c.id)).toEqual(["old", "mid", "new"]);
   });
+
+  it("orders by deletedAt newest-first when direction is desc", () => {
+    const chats = [
+      makeChat({ id: "old", deletedAt: 100 }),
+      makeChat({ id: "new", deletedAt: 300 }),
+      makeChat({ id: "mid", deletedAt: 200 }),
+    ];
+
+    const sorted = sortChats(chats, "deletedAt", "desc");
+
+    expect(sorted.map((c) => c.id)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("treats a null deletedAt as the oldest when sorting by deletedAt", () => {
+    const chats = [
+      makeChat({ id: "set", deletedAt: 200 }),
+      makeChat({ id: "null", deletedAt: null }),
+    ];
+
+    const desc = sortChats(chats, "deletedAt", "desc");
+    expect(desc.map((c) => c.id)).toEqual(["set", "null"]);
+  });
 });
 
 describe("sortChats — tie-breakers", () => {

--- a/web/src/lib/sortChats.ts
+++ b/web/src/lib/sortChats.ts
@@ -1,7 +1,14 @@
 import type { Chat } from "@/types";
 
-export type SortField = "title" | "createdAt" | "updatedAt";
+export type SortField = "title" | "createdAt" | "updatedAt" | "deletedAt";
 export type SortDirection = "asc" | "desc";
+
+// A missing deletedAt (active chat) sorts as the oldest possible time, so it
+// never floats above chats with a real deletion timestamp under desc.
+function timeField(chat: Chat, field: Exclude<SortField, "title">): number {
+  if (field === "deletedAt") return chat.deletedAt ?? 0;
+  return chat[field];
+}
 
 function isEmptyTitle(title: string | null | undefined): boolean {
   return title == null || title.trim() === "";
@@ -26,7 +33,7 @@ function comparePrimary(
   direction: SortDirection
 ): number {
   if (field === "title") return compareTitle(a, b, direction);
-  const cmp = a[field] - b[field];
+  const cmp = timeField(a, field) - timeField(b, field);
   return direction === "asc" ? cmp : -cmp;
 }
 

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -11,6 +11,7 @@ type FakeChat = {
   sourceFilePath: string | null;
   createdAt: number;
   updatedAt: number;
+  deletedAt?: number | null;
   isDeleted?: boolean;
 };
 
@@ -75,6 +76,24 @@ const initialFakeChats: FakeChat[] = [
       "/Users/test/.claude/projects/my-web-app/chat-deleted-1.jsonl",
     createdAt: 1699999000000,
     updatedAt: 1699999500000,
+    deletedAt: 1700000200000,
+    isDeleted: true,
+  },
+  {
+    id: "chat-deleted-2",
+    chatId: "CHATD2",
+    agent: "claude-code",
+    defaultTitle: "Newer experiment",
+    customTitle: null,
+    project: "my-web-app",
+    projectPath: "/Users/test/my-web-app",
+    sourceFilePath:
+      "/Users/test/.claude/projects/my-web-app/chat-deleted-2.jsonl",
+    createdAt: 1699999100000,
+    // Updated more recently than chat-deleted-1, but deleted earlier — so
+    // sorting by Updated time vs Deleted time yields a different order.
+    updatedAt: 1699999800000,
+    deletedAt: 1700000100000,
     isDeleted: true,
   },
 ];
@@ -204,6 +223,7 @@ export const handlers = [
       return HttpResponse.json({ error: "Chat not found" }, { status: 404 });
     }
     chat.isDeleted = true;
+    chat.deletedAt = Date.now();
     return new HttpResponse(null, { status: 204 });
   }),
   http.post("/api/chats/:id/restore", ({ params }) => {
@@ -213,6 +233,7 @@ export const handlers = [
       return HttpResponse.json({ error: "Chat not found" }, { status: 404 });
     }
     chat.isDeleted = false;
+    chat.deletedAt = null;
     return new HttpResponse(null, { status: 204 });
   }),
 ];

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -8,6 +8,8 @@ export interface Chat {
   sourceFilePath: string | null;
   createdAt: number;
   updatedAt: number;
+  /** Soft-delete time in ms; null while the chat is active. */
+  deletedAt?: number | null;
   isDeleted?: boolean;
 }
 


### PR DESCRIPTION
## Background (Why)

The Trash view reused the Chats list ordering and had no notion of *when* a chat was deleted. This adds an independent, sortable order for Trash with a real **Deleted time** axis, backed by a `deletedAt` timestamp.

## Approach (How)

- Schema change is **additive / forward-only**: a new nullable `deleted_at` (`timestamp_ms`) on `data.db.chats_meta`. Migration `0003` backfills already-trashed rows from `updated_at`. Hand-written SQL + journal entry rather than `drizzle-kit generate` (the `meta/` snapshots for 0001/0002 are absent, so generate would diff against a stale snapshot).
- Visibility stays the single read-path translator: it now also exposes `deletedAt`, so `archive.db` / ingestion remain unaware of trash state.
- Frontend reuses the #81 sort machinery — `deletedAt` becomes a sort field, and Trash gets its own `SortConfig` persisted under `chatlogbook.sort.trash`.

## Changes (What)

- [x] `chats_meta.deleted_at` column + migration `0003` backfilling trashed rows
- [x] `softDelete` stamps `deletedAt`; `restore` clears it
- [x] `GET /api/chats` exposes `deletedAt` (null while active)
- [x] Trash sort popover offers Title / Created / Updated / **Deleted** (last)
- [x] Trash defaults to Deleted time · Newest first, persisted independently
- [x] Trash header drops the "Trash (N)" label (Back + ↕ only)

### Test Verification

- [x] Repo: `deletedAt` set on delete, cleared on restore
- [x] Migration: trashed fixture rows backfilled `deleted_at = updated_at`
- [x] API: `deletedAt` null for active, timestamp for trashed
- [x] `sortChats`: Deleted-time ordering; null treated as oldest
- [x] Trash UI: four axes, default Deleted·Newest, reorders by axis, header label gone, independent persistence
- [x] Full suites green: api 120, web 98; both typechecks clean

## Related Links

- Closes #82
- Builds on #81 (sort UI/storage machinery)