### PR TITLE
refactor(api): rename CanonicalMessage to NormalizedMessage

### DIFF
--- a/api/src/ingestion/background.test.ts
+++ b/api/src/ingestion/background.test.ts
@@ -20,7 +20,7 @@ describe("startIngestionInBackground", () => {
     resolveIngest({
       scanned: 1,
       rawInserted: 2,
-      canonicalUpserted: 3,
+      normalizedUpserted: 3,
       skippedByMtime: 0,
     });
 

--- a/api/src/ingestion/ingest.test.ts
+++ b/api/src/ingestion/ingest.test.ts
@@ -47,7 +47,7 @@ describe("runIngestion", () => {
 
     expect(result.scanned).toBeGreaterThan(0);
     expect(result.rawInserted).toBeGreaterThan(0);
-    expect(result.canonicalUpserted).toBeGreaterThan(0);
+    expect(result.normalizedUpserted).toBeGreaterThan(0);
 
     const chatRows = archive.db.select().from(chats).all();
     const rawRows = archive.db.select().from(rawMessages).all();

--- a/api/src/ingestion/ingest.ts
+++ b/api/src/ingestion/ingest.ts
@@ -10,7 +10,7 @@ import {
 } from "../archive/schema.js";
 import type {
   AgentPlugin,
-  CanonicalMessage,
+  NormalizedMessage,
   PluginEnv,
 } from "../plugins/types.js";
 
@@ -24,7 +24,7 @@ export interface IngestOptions {
 export interface IngestResult {
   scanned: number;
   rawInserted: number;
-  canonicalUpserted: number;
+  normalizedUpserted: number;
   skippedByMtime: number;
 }
 
@@ -33,7 +33,7 @@ export async function runIngestion(opts: IngestOptions): Promise<IngestResult> {
   const result: IngestResult = {
     scanned: 0,
     rawInserted: 0,
-    canonicalUpserted: 0,
+    normalizedUpserted: 0,
     skippedByMtime: 0,
   };
 
@@ -112,17 +112,17 @@ export async function runIngestion(opts: IngestOptions): Promise<IngestResult> {
           result.rawInserted += 1;
         }
 
-        const canonical = plugin.normalize(raw);
-        if (!canonical) continue;
+        const normalized = plugin.normalize(raw);
+        if (!normalized) continue;
 
-        const upserted = upsertCanonical(
+        const upserted = upsertNormalized(
           opts.archive,
           plugin.id,
           ref.sourceId,
-          canonical,
+          normalized,
           rawId
         );
-        if (upserted) result.canonicalUpserted += 1;
+        if (upserted) result.normalizedUpserted += 1;
       }
 
       if (stat) {
@@ -237,11 +237,11 @@ function ensureChat(
   return id;
 }
 
-function upsertCanonical(
+function upsertNormalized(
   archive: ArchiveRepository,
   agent: string,
   sourceId: string,
-  msg: CanonicalMessage,
+  msg: NormalizedMessage,
   rawId: number
 ): boolean {
   const existing = archive.db

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import readline from "node:readline";
 import type {
   AgentPlugin,
-  CanonicalMessage,
+  NormalizedMessage,
   NormalizedBlock,
   PluginEnv,
   RawRecord,
@@ -57,7 +57,7 @@ export class ClaudeCodePlugin implements AgentPlugin {
     }
   }
 
-  normalize(raw: RawRecord): CanonicalMessage | null {
+  normalize(raw: RawRecord): NormalizedMessage | null {
     const payload = raw.payload as Record<string, unknown> | null;
     if (!payload || typeof payload !== "object") return null;
 

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -23,7 +23,7 @@ export type NormalizedBlock =
   | { type: "tool_use"; id: string; name: string; input: unknown }
   | { type: "tool_result"; toolUseId: string; content: unknown };
 
-export interface CanonicalMessage {
+export interface NormalizedMessage {
   messageId: string;
   role: "user" | "assistant";
   ts: string;
@@ -36,5 +36,5 @@ export interface AgentPlugin {
   displayName: string;
   discover(env: PluginEnv): AsyncIterable<ChatRef>;
   extractRaw(ref: ChatRef): AsyncIterable<RawRecord>;
-  normalize(raw: RawRecord): CanonicalMessage | null;
+  normalize(raw: RawRecord): NormalizedMessage | null;
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@ The product is designed around four separate stores. Do not merge them.
    read from source. Two layers:
    - `raw_messages` — verbatim per-agent JSON line, with `payload_hash`
      as content-based idempotency key.
-   - `messages` — canonical normalized shape used by API, UI, and FTS.
+   - `messages` — normalized shape used by API, UI, and FTS.
 
    Backup-worthy: once vendors have cleaned up source, this is the only
    remaining copy. See the archive contract below.
@@ -47,7 +47,7 @@ export interface AgentPlugin {
   displayName: string;
   discover(env: PluginEnv): AsyncIterable<ChatRef>;
   extractRaw(ref: ChatRef): AsyncIterable<RawRecord>;
-  normalize(raw: RawRecord): CanonicalMessage | null;
+  normalize(raw: RawRecord): NormalizedMessage | null;
 }
 ```
 
@@ -60,7 +60,7 @@ Two complementary modes, both inside the same Node.js process:
 - **On-app-open scan.** When `chat-log` starts, walk every source root per registered plugin and ingest only new content (mtime fast path, content-based idempotency).
 - **File watcher (chokidar).** While the app runs, watch source paths. `add` and `change` trigger incremental ingest. `unlink` records an audit row and never deletes archive rows (see Archive contract).
 
-Idempotency key: `(agent, source_id, payload_hash)`. Re-runs are no-ops. Source-side edits, truncations, or path collisions append new raw rows; the canonical layer applies last-write-wins by `ts`.
+Idempotency key: `(agent, source_id, payload_hash)`. Re-runs are no-ops. Source-side edits, truncations, or path collisions append new raw rows; the normalized layer applies last-write-wins by `ts`.
 
 ## Reading model
 
@@ -78,7 +78,7 @@ gone, archive rows are the only copy.
 
 - **Never delete archive rows in response to source deletion.** Vendor auto-cleanup, file unlink, path collisions — none of these may cascade into archive deletion.
 - **Only an explicit user purge action may delete archive rows.** Soft delete (Trash) sets `data.db.chats_meta.is_deleted` and does not touch archive. Hard delete (Purge) is the single exception, requires user confirmation, and writes an `ingestion_events('user_purged')` audit row that is itself never deleted.
-- **Schema migrations preserve `raw_payload` bytes.** The canonical layer (`messages`) is rebuildable from `raw_messages`; raw is not.
+- **Schema migrations preserve `raw_payload` bytes.** The normalized layer (`messages`) is rebuildable from `raw_messages`; raw is not.
 - **`archive.db` is the canonical export format.** Any "export to X" feature builds on top of the public schema; it never replaces it. The schema is treated as a public format — forward-only migrations, additive when possible, no app-internal columns. Vendor-specific quirks live inside `raw_payload`.
 
   **One-time rename in v0.8.0:** the `session → chat` rename (`sessions` table → `chats`, plus column renames `short_code → chat_id`, `source_session_id → source_id`, `session_id → source_id` on child tables) is a deliberate one-time exception to the "additive only" rule. The product supports multiple agents whose per-conversation unit isn't called a "session" — picking the right noun before 1.0 is worth the break. Future schema changes should remain additive.

--- a/docs/adr/0013-rename-canonical-to-normalized.md
+++ b/docs/adr/0013-rename-canonical-to-normalized.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Rename the canonical message layer to "normalized"
@@ -10,4 +10,4 @@ This is an internal code rename with no on-disk or API-shape impact — a mechan
 
 ## Status
 
-Proposed — vocabulary decided ([CONTEXT.md](../../CONTEXT.md)), code rename not yet done.
+Accepted — vocabulary decided ([CONTEXT.md](../../CONTEXT.md)), code rename done.


### PR DESCRIPTION
## Background (Why)

The glossary names the standardized Message layer **Normalized** — it pairs with **Raw** and matches the existing `normalize()` verb and `NormalizedBlock` type. The code type was still `CanonicalMessage`, leaving "canonical" as a second word for the same concept. This renames the type and related identifiers so the noun matches the verb and the CONTEXT.md **Raw vs Normalized** vocabulary.

## Approach (How)

Mechanical, code-only rename — no on-disk schema, API shape, or UI change. The normalized layer is rebuildable from raw, so there is no migration: the type and its surrounding identifiers are renamed in place, and the existing test suite is the regression gate (no new behavior to test).

"canonical" in its other sense (authoritative / portable) is left untouched: the `messages_canonical_idx` DB index name (renaming would generate a migration).

## Changes (What)

- [x] `CanonicalMessage` → `NormalizedMessage` in `plugins/types.ts`, `ingestion/ingest.ts`, `plugins/claude-code/plugin.ts`
- [x] `canonicalUpserted` → `normalizedUpserted` (`IngestResult` field) and `upsertCanonical` → `upsertNormalized`, plus the local `canonical` variable → `normalized`, in `ingestion/ingest.ts` and the two ingestion tests

### Test Verification

- [x] `tsc --noEmit` clean across the workspace
- [x] Full suite green — api 120 tests, web 98 tests
- [x] No behavior change: existing ingestion tests pass with the renamed `normalizedUpserted` field

## Related Links

- Closes #94