### PR TITLE
refactor(api): rename Metadata store file data.db to metadata.db

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Three places, all on your machine:
 
 - `~/.claude/` (and equivalents for other tools) — read-only source.
 - `~/.chat-logbook/archive.db` — chat-logbook's copy of the conversations it has read.
-- `~/.chat-logbook/data.db` — your tags, titles, annotations, and soft-delete flags.
+- `~/.chat-logbook/metadata.db` — your tags, titles, annotations, and soft-delete flags.
 
 Back up the two `~/.chat-logbook/` files together; they are the complete chat-logbook state.
 

--- a/api/src/metadata/repository.test.ts
+++ b/api/src/metadata/repository.test.ts
@@ -29,12 +29,56 @@ afterEach(() => {
 });
 
 describe("MetadataRepository", () => {
+  it("creates metadata.db on a fresh install and never a data.db", () => {
+    createMetadataRepository({ dataDir });
+
+    expect(fs.existsSync(path.join(dataDir, "metadata.db"))).toBe(true);
+    expect(fs.existsSync(path.join(dataDir, "data.db"))).toBe(false);
+  });
+
+  it("renames an existing data.db to metadata.db, preserving rows and removing the old file", () => {
+    seedFromFixture(dataDir);
+
+    createMetadataRepository({ dataDir });
+
+    expect(fs.existsSync(path.join(dataDir, "metadata.db"))).toBe(true);
+    expect(fs.existsSync(path.join(dataDir, "data.db"))).toBe(false);
+
+    const sqlite = new Database(path.join(dataDir, "metadata.db"), {
+      readonly: true,
+    });
+    try {
+      const ids = (
+        sqlite
+          .prepare("SELECT id FROM chats_meta ORDER BY created_at")
+          .all() as { id: string }[]
+      ).map((r) => r.id);
+      expect(ids).toEqual([
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("does not clobber an existing metadata.db when a stale data.db is also present", () => {
+    const existing = createMetadataRepository({ dataDir });
+    existing.softDelete("keeper");
+    seedFromFixture(dataDir);
+
+    const reopened = createMetadataRepository({ dataDir });
+
+    expect(reopened.isDeleted("keeper")).toBe(true);
+    expect(fs.existsSync(path.join(dataDir, "data.db"))).toBe(true);
+  });
+
   it("migrates a v0.7.1 data.db: sessions_meta is renamed to chats_meta preserving rows", () => {
     seedFromFixture(dataDir);
 
     createMetadataRepository({ dataDir });
 
-    const sqlite = new Database(path.join(dataDir, "data.db"), {
+    const sqlite = new Database(path.join(dataDir, "metadata.db"), {
       readonly: true,
     });
     try {
@@ -74,7 +118,7 @@ describe("MetadataRepository", () => {
 
     createMetadataRepository({ dataDir });
 
-    const sqlite = new Database(path.join(dataDir, "data.db"), {
+    const sqlite = new Database(path.join(dataDir, "metadata.db"), {
       readonly: true,
     });
     try {

--- a/api/src/metadata/repository.ts
+++ b/api/src/metadata/repository.ts
@@ -23,6 +23,24 @@ function resolveMigrationsFolder(): string {
   return found;
 }
 
+const DB_FILE = "metadata.db";
+const LEGACY_DB_FILE = "data.db";
+
+/**
+ * Rename a pre-v0.9 `data.db` to `metadata.db` in place (ADR-0012).
+ *
+ * Same-filesystem rename is atomic and loses no data. If `metadata.db`
+ * already exists we never clobber it — the stale `data.db` is left on disk
+ * untouched, in keeping with "only an explicit user purge deletes data".
+ */
+function migrateLegacyDbFile(dataDir: string): void {
+  const legacy = path.join(dataDir, LEGACY_DB_FILE);
+  const current = path.join(dataDir, DB_FILE);
+  if (!fs.existsSync(legacy)) return;
+  if (fs.existsSync(current)) return;
+  fs.renameSync(legacy, current);
+}
+
 export interface MetadataRepository {
   softDelete(internalId: string): void;
   restore(internalId: string): void;
@@ -54,7 +72,8 @@ export function createMetadataRepository({
   ensureChat,
 }: RepositoryOptions): MetadataRepository {
   fs.mkdirSync(dataDir, { recursive: true });
-  const sqlite = new Database(path.join(dataDir, "data.db"));
+  migrateLegacyDbFile(dataDir);
+  const sqlite = new Database(path.join(dataDir, DB_FILE));
   const db: BetterSQLite3Database = drizzle(sqlite);
   migrate(db, { migrationsFolder: resolveMigrationsFolder() });
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 Today the codebase implements one store under `~/.chat-logbook/`:
 
-- `data.db` — user-added metadata (titles, tags, soft-delete flags).
+- `metadata.db` — user-added metadata (titles, tags, soft-delete flags).
   Code lives in `api/src/metadata/`.
 
 `archive.db` and `index.db` described below are planned, not yet implemented. Source directories under `~/.claude/` are read directly while the app is running.
@@ -18,13 +18,13 @@ The product is designed around four separate stores. Do not merge them.
 | Store   | Path                            | Backed up?            |
 | ------- | ------------------------------- | --------------------- |
 | Source  | `~/.claude/`, `~/.codex/`, etc. | Out of our hands      |
-| Data    | `~/.chat-logbook/data.db`       | Yes — back this up    |
+| Data    | `~/.chat-logbook/metadata.db`   | Yes — back this up    |
 | Archive | `~/.chat-logbook/archive.db`    | Yes — back this up    |
 | Index   | `~/.chat-logbook/index.db`      | No — `rm` and rebuild |
 
 1. **Source directories** (`~/.claude/`, `~/.codex/`, etc.) — read-only conversation data. Vendor-controlled. May be auto-cleaned by the vendor (Claude Code defaults to 30 days; Codex CLI has multiple retention windows).
 
-2. **`~/.chat-logbook/data.db`** — user-added metadata: custom titles, tags, annotations, highlights, soft-delete flags, message overrides (when the edit feature is wired up). User-owned and backup-worthy. Keys against chat-logbook's internal chat `id` (UUID), not the vendor's.
+2. **`~/.chat-logbook/metadata.db`** — user-added metadata: custom titles, tags, annotations, highlights, soft-delete flags, message overrides (when the edit feature is wired up). User-owned and backup-worthy. Keys against chat-logbook's internal chat `id` (UUID), not the vendor's.
 
 3. **`~/.chat-logbook/archive.db`** — derived snapshot of conversations
    read from source. Two layers:
@@ -68,7 +68,7 @@ API routes read from `archive.db.messages` (joined with `archive.db.chats` for c
 
 ### Two ids per chat
 
-- `chats.id` — internal UUID, primary key, never exposed to users. Used as the join key from `data.db.chats_meta` and as the stable identity across vendor source-id collisions.
+- `chats.id` — internal UUID, primary key, never exposed to users. Used as the join key from `metadata.db.chats_meta` and as the stable identity across vendor source-id collisions.
 - `chats.chat_id` — short, user-facing identifier (Crockford base-32, 6 chars). What we'd surface in URLs and short references. Formerly named `short_code`.
 
 ## Archive contract
@@ -77,7 +77,7 @@ API routes read from `archive.db.messages` (joined with `archive.db.chats` for c
 gone, archive rows are the only copy.
 
 - **Never delete archive rows in response to source deletion.** Vendor auto-cleanup, file unlink, path collisions — none of these may cascade into archive deletion.
-- **Only an explicit user purge action may delete archive rows.** Soft delete (Trash) sets `data.db.chats_meta.is_deleted` and does not touch archive. Hard delete (Purge) is the single exception, requires user confirmation, and writes an `ingestion_events('user_purged')` audit row that is itself never deleted.
+- **Only an explicit user purge action may delete archive rows.** Soft delete (Trash) sets `metadata.db.chats_meta.is_deleted` and does not touch archive. Hard delete (Purge) is the single exception, requires user confirmation, and writes an `ingestion_events('user_purged')` audit row that is itself never deleted.
 - **Schema migrations preserve `raw_payload` bytes.** The normalized layer (`messages`) is rebuildable from `raw_messages`; raw is not.
 - **`archive.db` is the canonical export format.** Any "export to X" feature builds on top of the public schema; it never replaces it. The schema is treated as a public format — forward-only migrations, additive when possible, no app-internal columns. Vendor-specific quirks live inside `raw_payload`.
 

--- a/docs/adr/0001-four-store-split.md
+++ b/docs/adr/0001-four-store-split.md
@@ -6,4 +6,4 @@ chat-logbook keeps four stores with distinct durability postures and never merge
 
 - Reads join across stores rather than hitting one table.
 - Each store has its own migration lineage and backup posture (Archive and Metadata are backup-worthy; Index is `rm` + rebuild; Source is out of our hands).
-- The Metadata store's file is `data.db` today; see [ADR-0012](0012-rename-data-db-to-metadata-db.md).
+- The Metadata store's file is `metadata.db` (renamed from `data.db`; see [ADR-0012](0012-rename-data-db-to-metadata-db.md)).

--- a/docs/adr/0012-rename-data-db-to-metadata-db.md
+++ b/docs/adr/0012-rename-data-db-to-metadata-db.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Rename data.db to metadata.db
@@ -10,4 +10,4 @@ This changes a path on users' disks, so it needs a migration that detects and re
 
 ## Status
 
-Proposed — vocabulary decided ([CONTEXT.md](../../CONTEXT.md)), file rename and migration not yet implemented.
+Accepted — the Metadata store opens `metadata.db`, and `createMetadataRepository` renames an existing `data.db` in place on launch (`api/src/metadata/repository.ts`). A same-filesystem rename is atomic and loses no data; if `metadata.db` already exists the rename is skipped and the stale `data.db` is left untouched, never clobbered.

--- a/docs/adr/0014-scan-checkpoints-in-separate-store.md
+++ b/docs/adr/0014-scan-checkpoints-in-separate-store.md
@@ -6,7 +6,7 @@ The ingestion scan watermark (the `chat_scan_state` table — per-Source-file la
 
 - **Leave it in `archive.db`.** Simplest, but keeps an app-internal, rebuildable table inside the public export format — the exact thing ADR-0003 forbids.
 - **Fold it into `index.db`** (the Index store). Both are rebuildable, so on that axis it fits. Rejected because their rebuild lifecycles must stay independent: Index derives from Archive and is rebuilt on a tokenizer or FTS-schema change, while Checkpoint derives from Source and is "rebuilt" by a full re-scan. Co-locating them means `rm index.db` to rebuild search would also wipe the checkpoint and force an unnecessary full re-scan.
-- **Move it into `data.db`** (the Metadata store). Rejected: Metadata is user-owned and backup-worthy; machine-operational state does not belong there and must not be backed up.
+- **Move it into `metadata.db`** (the Metadata store). Rejected: Metadata is user-owned and backup-worthy; machine-operational state does not belong there and must not be backed up.
 
 ## Consequences
 


### PR DESCRIPTION
## Background (Why)

The user-added Metadata store lived on disk as `data.db` — a name with no bearing on what it holds, since every store holds data. The glossary (`CONTEXT.md`) calls it the **Metadata** store, so the file should be `metadata.db`: the name then matches the vocabulary and an agent grepping for "metadata" finds it. This is a deliberate pre-1.0 breaking change, in the spirit of the v0.8.0 `session` → `chat` rename.

## Approach (How)

Because this changes a path on users' disks, it migrates an existing file in place rather than starting clean. `createMetadataRepository` runs a one-time file rename before opening the database:

- A same-filesystem `fs.renameSync` is atomic and loses no data.
- If `metadata.db` already exists, the rename is skipped and the stale `data.db` is left untouched — never clobbered, in keeping with "only an explicit user purge deletes data".
- WAL/sidecar files are not a concern: the repo uses the default rollback journal, so no `-wal`/`-shm` files exist at launch.

Built with TDD — three vertical slices (fresh install, migration from an existing `data.db`, the already-exists edge case).

## Changes (What)

- [x] Metadata store now opens `metadata.db`; new `migrateLegacyDbFile()` renames an existing `data.db` in place, skipping when `metadata.db` already exists (`api/src/metadata/repository.ts`).
- [x] Tests cover fresh install, migration, and the no-clobber edge case (`api/src/metadata/repository.test.ts`).
- [x] The v0.7.1 test fixture keeps the `data.db` name on purpose — it simulates an old install and is the migration test's input.

### Test Verification

- [x] Fresh install creates `metadata.db` and never a `data.db`.
- [x] An existing `data.db` is renamed to `metadata.db` on launch, rows preserved, old file removed.
- [x] When `metadata.db` already exists alongside a stale `data.db`, the existing `metadata.db` is not clobbered and `data.db` is left in place.
- [x] Existing v0.7.1 schema-migration tests still pass through the renamed file.
- [x] Full suite green (api 123, web 98) + typecheck clean (run by the pre-commit hook).

## Related Links

- Closes #93