### PR TITLE
refactor: move scan checkpoints to a dedicated checkpoint.db store

### DIFF
--- a/api/drizzle.checkpoint.config.ts
+++ b/api/drizzle.checkpoint.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "sqlite",
+  schema: "./src/checkpoint/schema.ts",
+  out: "./drizzle/checkpoint",
+});

--- a/api/drizzle/archive/0007_drop_session_scan_state.sql
+++ b/api/drizzle/archive/0007_drop_session_scan_state.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS `session_scan_state_idx`;--> statement-breakpoint
+DROP TABLE IF EXISTS `session_scan_state`;

--- a/api/drizzle/archive/meta/_journal.json
+++ b/api/drizzle/archive/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1779100000000,
       "tag": "0006_add_project_path",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1779200000000,
+      "tag": "0007_drop_session_scan_state",
+      "breakpoints": true
     }
   ]
 }

--- a/api/drizzle/checkpoint/0000_sour_zeigeist.sql
+++ b/api/drizzle/checkpoint/0000_sour_zeigeist.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `chat_scan_state` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`agent` text NOT NULL,
+	`source_id` text NOT NULL,
+	`source_path` text NOT NULL,
+	`last_mtime_ms` integer NOT NULL,
+	`last_size_bytes` integer NOT NULL,
+	`last_scanned_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `chat_scan_state_idx` ON `chat_scan_state` (`agent`,`source_id`);

--- a/api/drizzle/checkpoint/meta/0000_snapshot.json
+++ b/api/drizzle/checkpoint/meta/0000_snapshot.json
@@ -1,0 +1,83 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7000812a-0b76-46c3-a086-0b2a551fe473",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "chat_scan_state": {
+      "name": "chat_scan_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_mtime_ms": {
+          "name": "last_mtime_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_size_bytes": {
+          "name": "last_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_scan_state_idx": {
+          "name": "chat_scan_state_idx",
+          "columns": ["agent", "source_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/api/drizzle/checkpoint/meta/_journal.json
+++ b/api/drizzle/checkpoint/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1781328041144,
+      "tag": "0000_sour_zeigeist",
+      "breakpoints": true
+    }
+  ]
+}

--- a/api/package.json
+++ b/api/package.json
@@ -10,7 +10,8 @@
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
-    "db:generate:archive": "drizzle-kit generate --config drizzle.archive.config.ts"
+    "db:generate:archive": "drizzle-kit generate --config drizzle.archive.config.ts",
+    "db:generate:checkpoint": "drizzle-kit generate --config drizzle.checkpoint.config.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.11",

--- a/api/src/archive/repository.test.ts
+++ b/api/src/archive/repository.test.ts
@@ -201,7 +201,7 @@ describe("ArchiveRepository", () => {
     }
   });
 
-  it("migrates a v0.7.1 archive.db: session_scan_state.session_id is renamed to source_id preserving data", () => {
+  it("migrates a v0.7.1 archive.db: session_scan_state table is dropped (moved to checkpoint.db)", () => {
     seedFromFixture(dataDir);
 
     const repo = createArchiveRepository({ dataDir });
@@ -211,20 +211,18 @@ describe("ArchiveRepository", () => {
       readonly: true,
     });
     try {
-      const cols = sqlite
-        .prepare("PRAGMA table_info('session_scan_state')")
+      const tables = sqlite
+        .prepare("SELECT name FROM sqlite_master WHERE type='table'")
         .all() as { name: string }[];
-      const names = cols.map((c) => c.name);
-      expect(names).toContain("source_id");
-      expect(names).not.toContain("session_id");
+      const names = tables.map((t) => t.name);
+      expect(names).not.toContain("session_scan_state");
 
-      const rows = sqlite
-        .prepare("SELECT agent, source_id FROM session_scan_state ORDER BY id")
-        .all();
-      expect(rows).toEqual([
-        { agent: "claude-code", source_id: "source-session-a" },
-        { agent: "claude-code", source_id: "source-session-b" },
-      ]);
+      const indexes = sqlite
+        .prepare("SELECT name FROM sqlite_master WHERE type='index'")
+        .all() as { name: string }[];
+      expect(indexes.map((i) => i.name)).not.toContain(
+        "session_scan_state_idx"
+      );
     } finally {
       sqlite.close();
     }

--- a/api/src/archive/schema.ts
+++ b/api/src/archive/schema.ts
@@ -67,21 +67,9 @@ export const messages = sqliteTable(
   ]
 );
 
-export const chatScanState = sqliteTable(
-  "session_scan_state",
-  {
-    id: integer("id").primaryKey({ autoIncrement: true }),
-    agent: text("agent").notNull(),
-    sourceId: text("source_id").notNull(),
-    sourcePath: text("source_path").notNull(),
-    lastMtimeMs: integer("last_mtime_ms").notNull(),
-    lastSizeBytes: integer("last_size_bytes").notNull(),
-    lastScannedAt: integer("last_scanned_at", {
-      mode: "timestamp_ms",
-    }).notNull(),
-  },
-  (t) => [uniqueIndex("session_scan_state_idx").on(t.agent, t.sourceId)]
-);
+// The per-Source-file scan watermark formerly lived here as `session_scan_state`.
+// It moved to its own Checkpoint store (checkpoint.db) — see ADR-0014 and
+// api/src/checkpoint/. Archive migration 0007 drops the old table.
 
 export const ingestionEvents = sqliteTable("ingestion_events", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/api/src/checkpoint/repository.test.ts
+++ b/api/src/checkpoint/repository.test.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCheckpointRepository } from "./repository.js";
+import { chatScanState } from "./schema.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-checkpoint-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("CheckpointRepository", () => {
+  it("creates checkpoint.db with a chat_scan_state table and its unique index", () => {
+    const repo = createCheckpointRepository({ dataDir });
+    repo.close();
+
+    expect(fs.existsSync(path.join(dataDir, "checkpoint.db"))).toBe(true);
+
+    const sqlite = new Database(path.join(dataDir, "checkpoint.db"), {
+      readonly: true,
+    });
+    try {
+      const tables = sqlite
+        .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+        .all() as { name: string }[];
+      expect(tables.map((t) => t.name)).toContain("chat_scan_state");
+
+      const indexes = sqlite
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='chat_scan_state'"
+        )
+        .all() as { name: string }[];
+      expect(indexes.map((i) => i.name)).toContain("chat_scan_state_idx");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("round-trips a scan watermark and updates it in place for the same (agent, source_id)", () => {
+    const repo = createCheckpointRepository({ dataDir });
+
+    expect(repo.getScanState("claude-code", "src-1")).toBeUndefined();
+
+    const firstScannedAt = new Date(1_700_000_000_000);
+    repo.recordScanState(
+      "claude-code",
+      "src-1",
+      "/src/one.jsonl",
+      { mtimeMs: 1000, sizeBytes: 4096 },
+      firstScannedAt
+    );
+
+    expect(repo.getScanState("claude-code", "src-1")).toEqual({
+      lastMtimeMs: 1000,
+      lastSizeBytes: 4096,
+      lastScannedAt: firstScannedAt,
+    });
+
+    // A later scan of the same file updates the watermark, not appends a row.
+    const secondScannedAt = new Date(1_700_000_060_000);
+    repo.recordScanState(
+      "claude-code",
+      "src-1",
+      "/src/one.jsonl",
+      { mtimeMs: 2000, sizeBytes: 8192 },
+      secondScannedAt
+    );
+
+    expect(repo.getScanState("claude-code", "src-1")).toEqual({
+      lastMtimeMs: 2000,
+      lastSizeBytes: 8192,
+      lastScannedAt: secondScannedAt,
+    });
+    expect(repo.db.select().from(chatScanState).all()).toHaveLength(1);
+
+    repo.close();
+  });
+});

--- a/api/src/checkpoint/repository.ts
+++ b/api/src/checkpoint/repository.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { and, eq } from "drizzle-orm";
+import {
+  drizzle,
+  type BetterSQLite3Database,
+} from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import * as schema from "./schema.js";
+import { chatScanState } from "./schema.js";
+
+export type CheckpointDb = BetterSQLite3Database<typeof schema>;
+
+export interface ScanStat {
+  mtimeMs: number;
+  sizeBytes: number;
+}
+
+export interface ScanState {
+  lastMtimeMs: number;
+  lastSizeBytes: number;
+  lastScannedAt: Date;
+}
+
+export interface CheckpointRepository {
+  readonly db: CheckpointDb;
+  getScanState(agent: string, sourceId: string): ScanState | undefined;
+  recordScanState(
+    agent: string,
+    sourceId: string,
+    sourcePath: string,
+    stat: ScanStat,
+    scannedAt: Date
+  ): void;
+  close(): void;
+}
+
+interface RepositoryOptions {
+  dataDir: string;
+}
+
+function resolveMigrationsFolder(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(here, "../../drizzle/checkpoint"),
+    path.join(here, "./drizzle/checkpoint"),
+  ];
+  const found = candidates.find((p) => fs.existsSync(p));
+  if (!found) {
+    throw new Error("Could not locate checkpoint drizzle migrations folder");
+  }
+  return found;
+}
+
+export function createCheckpointRepository({
+  dataDir,
+}: RepositoryOptions): CheckpointRepository {
+  fs.mkdirSync(dataDir, { recursive: true });
+  const sqlite = new Database(path.join(dataDir, "checkpoint.db"));
+  const db: CheckpointDb = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: resolveMigrationsFolder() });
+
+  return {
+    db,
+    getScanState(agent, sourceId) {
+      const row = db
+        .select({
+          lastMtimeMs: chatScanState.lastMtimeMs,
+          lastSizeBytes: chatScanState.lastSizeBytes,
+          lastScannedAt: chatScanState.lastScannedAt,
+        })
+        .from(chatScanState)
+        .where(
+          and(
+            eq(chatScanState.agent, agent),
+            eq(chatScanState.sourceId, sourceId)
+          )
+        )
+        .get();
+      return row ?? undefined;
+    },
+    recordScanState(agent, sourceId, sourcePath, stat, scannedAt) {
+      const existing = db
+        .select({ id: chatScanState.id })
+        .from(chatScanState)
+        .where(
+          and(
+            eq(chatScanState.agent, agent),
+            eq(chatScanState.sourceId, sourceId)
+          )
+        )
+        .get();
+
+      if (existing) {
+        db.update(chatScanState)
+          .set({
+            sourcePath,
+            lastMtimeMs: stat.mtimeMs,
+            lastSizeBytes: stat.sizeBytes,
+            lastScannedAt: scannedAt,
+          })
+          .where(eq(chatScanState.id, existing.id))
+          .run();
+      } else {
+        db.insert(chatScanState)
+          .values({
+            agent,
+            sourceId,
+            sourcePath,
+            lastMtimeMs: stat.mtimeMs,
+            lastSizeBytes: stat.sizeBytes,
+            lastScannedAt: scannedAt,
+          })
+          .run();
+      }
+    },
+    close() {
+      sqlite.close();
+    },
+  };
+}

--- a/api/src/checkpoint/schema.ts
+++ b/api/src/checkpoint/schema.ts
@@ -1,0 +1,26 @@
+import {
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+// Per-Source-file scan watermark. Rebuildable operational state: it lets a Scan
+// skip a Source file whose mtime and size are unchanged since the last scan.
+// Lives in its own Checkpoint store (checkpoint.db), never backed up — see
+// ADR-0014.
+export const chatScanState = sqliteTable(
+  "chat_scan_state",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    agent: text("agent").notNull(),
+    sourceId: text("source_id").notNull(),
+    sourcePath: text("source_path").notNull(),
+    lastMtimeMs: integer("last_mtime_ms").notNull(),
+    lastSizeBytes: integer("last_size_bytes").notNull(),
+    lastScannedAt: integer("last_scanned_at", {
+      mode: "timestamp_ms",
+    }).notNull(),
+  },
+  (t) => [uniqueIndex("chat_scan_state_idx").on(t.agent, t.sourceId)]
+);

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,6 +7,7 @@ import { serve } from "@hono/node-server";
 import updateNotifier from "update-notifier";
 import { createApp } from "./app.js";
 import { createArchiveRepository } from "./archive/repository.js";
+import { createCheckpointRepository } from "./checkpoint/repository.js";
 import { createMetadataRepository } from "./metadata/repository.js";
 import { startIngestionInBackground } from "./ingestion/background.js";
 import { startWatcher } from "./ingestion/watcher.js";
@@ -44,22 +45,26 @@ const webDistDir = path.join(__dirname, "../../web/dist");
 const port = action.port;
 
 const archive = createArchiveRepository({ dataDir });
+const checkpoint = createCheckpointRepository({ dataDir });
 const metadata = createMetadataRepository({ dataDir });
 const app = createApp({ archive, metadata, webDistDir });
 
 const initialIngest = startIngestionInBackground({
   plugins,
   archive,
+  checkpoint,
   env: { homeDir: os.homedir() },
 });
 
 const watcher = startWatcher({
   plugins,
   archive,
+  checkpoint,
   env: { homeDir: os.homedir() },
 });
-// Don't start watching until the initial scan has populated session_scan_state;
-// otherwise a `change` event could race the first scan and re-ingest from scratch.
+// Don't start watching until the initial scan has populated the checkpoint store
+// (chat_scan_state); otherwise a `change` event could race the first scan and
+// re-ingest from scratch.
 void initialIngest.done.then(() => watcher.ready).catch(() => {});
 
 function shutdown(): void {

--- a/api/src/ingestion/ingest.test.ts
+++ b/api/src/ingestion/ingest.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createArchiveRepository } from "../archive/repository.js";
 import { chats, messages, rawMessages } from "../archive/schema.js";
+import { createCheckpointRepository } from "../checkpoint/repository.js";
+import { chatScanState } from "../checkpoint/schema.js";
 import { ClaudeCodePlugin } from "../plugins/claude-code/plugin.js";
 import { runIngestion } from "./ingest.js";
 
@@ -38,10 +40,12 @@ afterEach(() => {
 describe("runIngestion", () => {
   it("populates archive.db sessions, raw_messages, and messages from source on first run", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
 
     const result = await runIngestion({
       plugins: [new ClaudeCodePlugin()],
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
 
@@ -72,11 +76,13 @@ describe("runIngestion", () => {
 
   it("is a no-op on second run: zero new raw rows and row counts unchanged", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
     const pluginsList = [new ClaudeCodePlugin()];
 
     const first = await runIngestion({
       plugins: pluginsList,
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
     const rawBefore = archive.db.select().from(rawMessages).all().length;
@@ -86,6 +92,7 @@ describe("runIngestion", () => {
     const second = await runIngestion({
       plugins: pluginsList,
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
 
@@ -100,11 +107,13 @@ describe("runIngestion", () => {
 
   it("appends a new raw row when source content at the same line changes", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
     const pluginsList = [new ClaudeCodePlugin()];
 
     await runIngestion({
       plugins: pluginsList,
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
     const rawBefore = archive.db.select().from(rawMessages).all();
@@ -132,6 +141,7 @@ describe("runIngestion", () => {
     const second = await runIngestion({
       plugins: pluginsList,
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
 
@@ -149,10 +159,12 @@ describe("runIngestion", () => {
 
   it("writes raw for every payload but skips messages when normalize returns null", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
 
     await runIngestion({
       plugins: [new ClaudeCodePlugin()],
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
 
@@ -186,11 +198,13 @@ describe("runIngestion", () => {
 
   it("mtime fast path: skips files whose mtime and size are unchanged since last scan", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
 
     // First run records scan state.
     await runIngestion({
       plugins: [new ClaudeCodePlugin()],
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
 
@@ -206,6 +220,7 @@ describe("runIngestion", () => {
     const second = await runIngestion({
       plugins: [observedPlugin],
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
 
@@ -218,10 +233,12 @@ describe("runIngestion", () => {
 
   it("mtime fast path: re-reads a file when mtime changes", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
 
     await runIngestion({
       plugins: [new ClaudeCodePlugin()],
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
 
@@ -249,6 +266,7 @@ describe("runIngestion", () => {
     const second = await runIngestion({
       plugins: [new ClaudeCodePlugin()],
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
 
@@ -260,10 +278,12 @@ describe("runIngestion", () => {
 
   it("preserves archive rows when source file is shrunk between scans", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
 
     await runIngestion({
       plugins: [new ClaudeCodePlugin()],
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
     const rawBefore = archive.db.select().from(rawMessages).all();
@@ -287,6 +307,7 @@ describe("runIngestion", () => {
     await runIngestion({
       plugins: [new ClaudeCodePlugin()],
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
 
@@ -304,6 +325,7 @@ describe("runIngestion", () => {
 
   it("fills in a session's project on a later scan once cwd is resolvable", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
     const pluginsList = [new ClaudeCodePlugin()];
 
     // A session whose source carries no cwd: its project is unknown.
@@ -331,6 +353,7 @@ describe("runIngestion", () => {
     await runIngestion({
       plugins: pluginsList,
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
     const before = archive.db
@@ -355,6 +378,7 @@ describe("runIngestion", () => {
     await runIngestion({
       plugins: pluginsList,
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
     });
     const after = archive.db
@@ -366,5 +390,94 @@ describe("runIngestion", () => {
     expect(after?.projectPath).toBe("/Users/test/late-app");
 
     archive.close();
+  });
+
+  it("records the scan watermark in the checkpoint store, not archive.db", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
+    const pluginsList = [new ClaudeCodePlugin()];
+
+    const first = await runIngestion({
+      plugins: pluginsList,
+      archive,
+      checkpoint,
+      env: { homeDir: env.homeDir },
+    });
+    expect(first.rawInserted).toBeGreaterThan(0);
+
+    // The watermark lands in checkpoint.db.
+    const watermarks = checkpoint.db.select().from(chatScanState).all();
+    expect(watermarks.length).toBeGreaterThan(0);
+
+    // A second scan skips unchanged files using the checkpoint store.
+    const second = await runIngestion({
+      plugins: pluginsList,
+      archive,
+      checkpoint,
+      env: { homeDir: env.homeDir },
+    });
+    expect(second.skippedByMtime).toBeGreaterThan(0);
+    expect(second.rawInserted).toBe(0);
+
+    archive.close();
+    checkpoint.close();
+  });
+
+  it("upgrade path: a scan with an empty checkpoint but a populated archive rebuilds the watermark and is a no-op at the Raw layer", async () => {
+    const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const pluginsList = [new ClaudeCodePlugin()];
+
+    // Pre-upgrade: archive is already populated by an earlier build's scan.
+    const firstCheckpoint = createCheckpointRepository({
+      dataDir: env.dataDir,
+    });
+    await runIngestion({
+      plugins: pluginsList,
+      archive,
+      checkpoint: firstCheckpoint,
+      env: { homeDir: env.homeDir },
+    });
+    const rawBefore = archive.db.select().from(rawMessages).all();
+    const msgBefore = archive.db.select().from(messages).all();
+    expect(rawBefore.length).toBeGreaterThan(0);
+    firstCheckpoint.close();
+
+    // Upgrade drops session_scan_state from archive.db; checkpoint.db starts
+    // empty. Model that with a fresh, empty Checkpoint store.
+    const freshDataDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "chat-logbook-fresh-checkpoint-")
+    );
+    const emptyCheckpoint = createCheckpointRepository({
+      dataDir: freshDataDir,
+    });
+    expect(emptyCheckpoint.getScanState("claude-code", "session-1")).toBe(
+      undefined
+    );
+
+    // The next Scan re-reads every file (no fast-path), but content-based
+    // idempotency makes it a no-op at the Raw layer.
+    const upgrade = await runIngestion({
+      plugins: pluginsList,
+      archive,
+      checkpoint: emptyCheckpoint,
+      env: { homeDir: env.homeDir },
+    });
+
+    expect(upgrade.skippedByMtime).toBe(0);
+    expect(upgrade.rawInserted).toBe(0);
+    expect(archive.db.select().from(rawMessages).all().length).toBe(
+      rawBefore.length
+    );
+    expect(archive.db.select().from(messages).all().length).toBe(
+      msgBefore.length
+    );
+    // The watermark is rebuilt in the new checkpoint store.
+    expect(
+      emptyCheckpoint.getScanState("claude-code", "session-1")
+    ).toBeDefined();
+
+    archive.close();
+    emptyCheckpoint.close();
+    fs.rmSync(freshDataDir, { recursive: true, force: true });
   });
 });

--- a/api/src/ingestion/ingest.ts
+++ b/api/src/ingestion/ingest.ts
@@ -2,12 +2,8 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import { and, eq } from "drizzle-orm";
 import type { ArchiveRepository } from "../archive/repository.js";
-import {
-  chats,
-  chatScanState,
-  messages,
-  rawMessages,
-} from "../archive/schema.js";
+import { chats, messages, rawMessages } from "../archive/schema.js";
+import type { CheckpointRepository } from "../checkpoint/repository.js";
 import type {
   AgentPlugin,
   NormalizedMessage,
@@ -17,6 +13,7 @@ import type {
 export interface IngestOptions {
   plugins: readonly AgentPlugin[];
   archive: ArchiveRepository;
+  checkpoint: CheckpointRepository;
   env: PluginEnv;
   now?: () => Date;
 }
@@ -42,16 +39,7 @@ export async function runIngestion(opts: IngestOptions): Promise<IngestResult> {
       result.scanned += 1;
 
       const stat = safeStat(ref.sourcePath);
-      const prior = opts.archive.db
-        .select()
-        .from(chatScanState)
-        .where(
-          and(
-            eq(chatScanState.agent, plugin.id),
-            eq(chatScanState.sourceId, ref.sourceId)
-          )
-        )
-        .get();
+      const prior = opts.checkpoint.getScanState(plugin.id, ref.sourceId);
 
       ensureChat(
         opts.archive,
@@ -126,12 +114,11 @@ export async function runIngestion(opts: IngestOptions): Promise<IngestResult> {
       }
 
       if (stat) {
-        recordScanState(
-          opts.archive,
+        opts.checkpoint.recordScanState(
           plugin.id,
           ref.sourceId,
           ref.sourcePath,
-          stat,
+          { mtimeMs: stat.mtimeMs, sizeBytes: stat.size },
           now()
         );
       }
@@ -146,48 +133,6 @@ function safeStat(p: string): fs.Stats | null {
     return fs.statSync(p);
   } catch {
     return null;
-  }
-}
-
-function recordScanState(
-  archive: ArchiveRepository,
-  agent: string,
-  sourceId: string,
-  sourcePath: string,
-  stat: fs.Stats,
-  scannedAt: Date
-): void {
-  const existing = archive.db
-    .select({ id: chatScanState.id })
-    .from(chatScanState)
-    .where(
-      and(eq(chatScanState.agent, agent), eq(chatScanState.sourceId, sourceId))
-    )
-    .get();
-
-  if (existing) {
-    archive.db
-      .update(chatScanState)
-      .set({
-        sourcePath,
-        lastMtimeMs: stat.mtimeMs,
-        lastSizeBytes: stat.size,
-        lastScannedAt: scannedAt,
-      })
-      .where(eq(chatScanState.id, existing.id))
-      .run();
-  } else {
-    archive.db
-      .insert(chatScanState)
-      .values({
-        agent,
-        sourceId,
-        sourcePath,
-        lastMtimeMs: stat.mtimeMs,
-        lastSizeBytes: stat.size,
-        lastScannedAt: scannedAt,
-      })
-      .run();
   }
 }
 

--- a/api/src/ingestion/watcher.test.ts
+++ b/api/src/ingestion/watcher.test.ts
@@ -9,6 +9,7 @@ import {
   rawMessages,
   chats,
 } from "../archive/schema.js";
+import { createCheckpointRepository } from "../checkpoint/repository.js";
 import { ClaudeCodePlugin } from "../plugins/claude-code/plugin.js";
 import { runIngestion } from "./ingest.js";
 import { startWatcher } from "./watcher.js";
@@ -51,15 +52,22 @@ describe("startWatcher", () => {
     { timeout: 20_000 },
     async () => {
       const archive = createArchiveRepository({ dataDir: env.dataDir });
+      const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
       const plugins = [new ClaudeCodePlugin()];
 
       // Seed archive via on-app-open scan first; watcher is for live updates.
-      await runIngestion({ plugins, archive, env: { homeDir: env.homeDir } });
+      await runIngestion({
+        plugins,
+        archive,
+        checkpoint,
+        env: { homeDir: env.homeDir },
+      });
       const rawBefore = archive.db.select().from(rawMessages).all().length;
 
       const watcher = startWatcher({
         plugins,
         archive,
+        checkpoint,
         env: { homeDir: env.homeDir },
         chokidarOptions: { usePolling: true, interval: 25 },
         debounceMs: 25,
@@ -109,9 +117,15 @@ describe("startWatcher", () => {
 
   it("records an unlink_observed audit row without deleting archive rows", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
     const plugins = [new ClaudeCodePlugin()];
 
-    await runIngestion({ plugins, archive, env: { homeDir: env.homeDir } });
+    await runIngestion({
+      plugins,
+      archive,
+      checkpoint,
+      env: { homeDir: env.homeDir },
+    });
     const rawBefore = archive.db.select().from(rawMessages).all().length;
     const msgBefore = archive.db.select().from(messages).all().length;
     const chatsBefore = archive.db.select().from(chats).all().length;
@@ -119,6 +133,7 @@ describe("startWatcher", () => {
     const watcher = startWatcher({
       plugins,
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
       chokidarOptions: { usePolling: true, interval: 25 },
       debounceMs: 25,
@@ -161,12 +176,19 @@ describe("startWatcher", () => {
 
   it("stops triggering ingest after close()", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
+    const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
     const plugins = [new ClaudeCodePlugin()];
-    await runIngestion({ plugins, archive, env: { homeDir: env.homeDir } });
+    await runIngestion({
+      plugins,
+      archive,
+      checkpoint,
+      env: { homeDir: env.homeDir },
+    });
 
     const watcher = startWatcher({
       plugins,
       archive,
+      checkpoint,
       env: { homeDir: env.homeDir },
       chokidarOptions: { usePolling: true, interval: 25 },
       debounceMs: 25,

--- a/api/src/ingestion/watcher.ts
+++ b/api/src/ingestion/watcher.ts
@@ -1,12 +1,14 @@
 import chokidar, { type FSWatcher, type ChokidarOptions } from "chokidar";
 import type { ArchiveRepository } from "../archive/repository.js";
 import { ingestionEvents } from "../archive/schema.js";
+import type { CheckpointRepository } from "../checkpoint/repository.js";
 import type { AgentPlugin, PluginEnv, ChatRef } from "../plugins/types.js";
 import { runIngestion } from "./ingest.js";
 
 export interface WatcherOptions {
   plugins: readonly AgentPlugin[];
   archive: ArchiveRepository;
+  checkpoint: CheckpointRepository;
   env: PluginEnv;
   debounceMs?: number;
   chokidarOptions?: ChokidarOptions;
@@ -96,6 +98,7 @@ export function startWatcher(opts: WatcherOptions): IngestionWatcher {
       void runIngestion({
         plugins: opts.plugins,
         archive: opts.archive,
+        checkpoint: opts.checkpoint,
         env: opts.env,
       }).catch((err) => onError(err));
     }, debounceMs);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,23 +4,28 @@
 
 ## Current state
 
-Today the codebase implements one store under `~/.chat-logbook/`:
+Today the codebase implements three stores under `~/.chat-logbook/`:
 
 - `metadata.db` — user-added metadata (titles, tags, soft-delete flags).
   Code lives in `api/src/metadata/`.
+- `archive.db` — derived snapshot of conversations read from source.
+  Code lives in `api/src/archive/`.
+- `checkpoint.db` — per-Source-file scan watermark.
+  Code lives in `api/src/checkpoint/`.
 
-`archive.db` and `index.db` described below are planned, not yet implemented. Source directories under `~/.claude/` are read directly while the app is running.
+`index.db` described below is planned, not yet implemented. Source directories under `~/.claude/` are read directly while the app is running.
 
-## Four stores (target architecture)
+## Five stores (target architecture)
 
-The product is designed around four separate stores. Do not merge them.
+The product is designed around five separate stores. Do not merge them.
 
-| Store   | Path                            | Backed up?            |
-| ------- | ------------------------------- | --------------------- |
-| Source  | `~/.claude/`, `~/.codex/`, etc. | Out of our hands      |
-| Data    | `~/.chat-logbook/metadata.db`   | Yes — back this up    |
-| Archive | `~/.chat-logbook/archive.db`    | Yes — back this up    |
-| Index   | `~/.chat-logbook/index.db`      | No — `rm` and rebuild |
+| Store      | Path                            | Backed up?            |
+| ---------- | ------------------------------- | --------------------- |
+| Source     | `~/.claude/`, `~/.codex/`, etc. | Out of our hands      |
+| Data       | `~/.chat-logbook/metadata.db`   | Yes — back this up    |
+| Archive    | `~/.chat-logbook/archive.db`    | Yes — back this up    |
+| Checkpoint | `~/.chat-logbook/checkpoint.db` | No — rebuilt by Scan  |
+| Index      | `~/.chat-logbook/index.db`      | No — `rm` and rebuild |
 
 1. **Source directories** (`~/.claude/`, `~/.codex/`, etc.) — read-only conversation data. Vendor-controlled. May be auto-cleaned by the vendor (Claude Code defaults to 30 days; Codex CLI has multiple retention windows).
 
@@ -35,7 +40,9 @@ The product is designed around four separate stores. Do not merge them.
    Backup-worthy: once vendors have cleaned up source, this is the only
    remaining copy. See the archive contract below.
 
-4. **`~/.chat-logbook/index.db`** — derived FTS5 search index, sourced from `archive.db.messages.text`. Freely rebuildable; tokenizer or schema upgrades are `rm index.db` + restart. Never put user data here, and never put index tables in `metadata.db` or `archive.db`.
+4. **`~/.chat-logbook/checkpoint.db`** — derived scan watermark (`chat_scan_state`: per-Source-file last mtime, size, and scan time) that lets a Scan skip unchanged files. Derived from Source and rebuildable: a full re-scan repopulates it, so it is never backed up. Kept out of `archive.db` (the public export format) and `index.db` (whose rebuild lifecycle is independent) — see ADR-0014.
+
+5. **`~/.chat-logbook/index.db`** — derived FTS5 search index, sourced from `archive.db.messages.text`. Freely rebuildable; tokenizer or schema upgrades are `rm index.db` + restart. Never put user data here, and never put index tables in `metadata.db` or `archive.db`.
 
 ## Plugin per agent
 


### PR DESCRIPTION
## Background (Why)

The ingestion scan watermark (`session_scan_state`: per-Source-file last mtime, size, and scan time) was living in `archive.db`, where it did two wrong things. It is an app-internal, rebuildable operational table sitting inside the schema ADR-0003 reserves as a clean, conversation-only public export format. And it is freely rebuildable state living in the one store whose job is to hold the irreplaceable copy once vendors clean up source.

ADR-0014 decided to move it into its own Checkpoint store, `checkpoint.db`, derived from Source and never backed up. This resolves the ADR-0003 smell and widens the four-store split (ADR-0001) to five.


## Approach (How)

- New Checkpoint store as a deep module: a small `CheckpointRepository` interface (`getScanState` / `recordScanState`) hides the SQL that previously sat inline in the ingest path.
- The store is created with the already-correct name `chat_scan_state` from birth, so this supersedes the in-archive rename that was the original scope of #95 — no interim rename migration in `archive.db`.
- No data-preserving migration. Because ingestion idempotency is content-based (ADR-0005), `checkpoint.db` starts empty and the old `session_scan_state` table is dropped from `archive.db` by a forward-only migration. The next Scan repopulates the checkpoint; the only cost is one full re-scan after upgrade, which is a safe no-op at the Raw layer.
- Built test-first (TDD), one vertical slice at a time: store creation → scan-state upsert → ingestion wiring → archive drop → upgrade path.

## Changes (What)

- [x] New `checkpoint.db` store: `api/src/checkpoint/` (schema, repository, tests), `drizzle/checkpoint/` migrations, `drizzle.checkpoint.config.ts`, and a `db:generate:checkpoint` script. Holds `chat_scan_state` with unique index `chat_scan_state_idx`.
- [x] Ingestion reads/writes the watermark from the Checkpoint store: `CheckpointRepository` threaded through `IngestOptions` and `WatcherOptions`; the ingest path no longer touches `archive.db` for scan state. `index.ts` creates and injects the checkpoint repo.
- [x] Forward-only archive migration `0007_drop_session_scan_state` drops `session_scan_state` and its index; the table is removed from the schema. No conversation data is touched.
- [x] Updated the stale `index.ts` comment that referenced `session_scan_state`.
- [x] `ARCHITECTURE.md` now describes five stores including Checkpoint (`~/.chat-logbook/checkpoint.db`, Backed up? = No), and corrects the stale "archive.db ... planned, not yet implemented" line.

### Test Verification

- [x] Checkpoint store creates `checkpoint.db` with the `chat_scan_state` table and `chat_scan_state_idx` index.
- [x] `recordScanState` round-trips via `getScanState`, and a second write for the same `(agent, source_id)` updates in place rather than appending a row.
- [x] Ingestion records the watermark in `checkpoint.db`, not `archive.db`; the mtime fast-path skip works against the new store.
- [x] Initial Scan, incremental Scan, and mtime fast-path skip all pass against the new store.
- [x] Upgrade path: an empty checkpoint with a populated archive rebuilds the watermark and is a no-op at the Raw layer (no duplicate raw or normalized rows).
- [x] Archive migration drops `session_scan_state` and its index on a v0.7.1 fixture; full suite green (api 127 + web 98).

## Additional Notes

`ingestion_events` is deliberately left in `archive.db`: it is a non-rebuildable audit trail (unlink, user-purge), so by the rebuildability axis it is Archive-class. Its own ADR-0003 tension is a separate question (see ADR-0014).

The v0.7.1 test fixture still seeds `session_scan_state` on purpose — it represents the old schema the migration must upgrade from.

## Related Links

- Closes #95