### PR TITLE
fix(watcher): make unlink-audit test deterministic to stop DBMOVED stderr

### DIFF
--- a/api/src/ingestion/watcher.test.ts
+++ b/api/src/ingestion/watcher.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createArchiveRepository } from "../archive/repository.js";
 import {
   ingestionEvents,
@@ -126,6 +126,17 @@ describe("startWatcher", () => {
     }
   });
 
+  // Same flaky stage as the change-event test above: under parallel-suite
+  // contention chokidar's polling can miss the unlink entirely, so the test
+  // would await an audit row that never arrives, time out, and — because a
+  // timed-out vitest test abandons its `finally` — leak a still-open watcher +
+  // archive into `afterEach`'s tmpdir teardown. The leaked watcher then fires
+  // `recordUnlink` against the just-removed `archive.db`, writing a
+  // `SQLITE_READONLY_DBMOVED` to stderr (#100). We remove the dependency on
+  // chokidar's unreliable detection while keeping the real "unlink" handler →
+  // `recordUnlink` → audit write: unlink the file, then drive the event through
+  // the watcher's own `notifyUnlink`. Real polling stays dormant (large
+  // interval), so the test is deterministic with no wall-clock race.
   it("records an unlink_observed audit row without deleting archive rows", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
     const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
@@ -146,7 +157,9 @@ describe("startWatcher", () => {
       archive,
       checkpoint,
       env: { homeDir: env.homeDir },
-      chokidarOptions: { usePolling: true, interval: 25 },
+      // Large interval keeps real polling dormant within the test, so the only
+      // unlink driver is the deterministic notifyUnlink call below.
+      chokidarOptions: { usePolling: true, interval: 60_000 },
       debounceMs: 25,
     });
     await watcher.ready;
@@ -161,18 +174,15 @@ describe("startWatcher", () => {
       );
       fs.unlinkSync(sourceFile);
 
-      await vi.waitFor(
-        () => {
-          const events = archive.db
-            .select()
-            .from(ingestionEvents)
-            .all()
-            .filter((e) => e.eventType === "unlink_observed");
-          expect(events.length).toBeGreaterThan(0);
-          expect(events.some((e) => e.sourcePath === sourceFile)).toBe(true);
-        },
-        { timeout: 5000, interval: 50 }
-      );
+      watcher.notifyUnlink(sourceFile);
+
+      const events = archive.db
+        .select()
+        .from(ingestionEvents)
+        .all()
+        .filter((e) => e.eventType === "unlink_observed");
+      expect(events.length).toBeGreaterThan(0);
+      expect(events.some((e) => e.sourcePath === sourceFile)).toBe(true);
 
       expect(archive.db.select().from(rawMessages).all().length).toBe(
         rawBefore

--- a/api/src/ingestion/watcher.ts
+++ b/api/src/ingestion/watcher.ts
@@ -32,6 +32,14 @@ export interface IngestionWatcher {
    * `ready` resolves.
    */
   notifyChange(path: string): void;
+  /**
+   * Drive an unlink for `path` through the same handler chokidar's "unlink"
+   * event triggers — real `recordUnlink` → audit write. The unlink counterpart
+   * of `notifyChange`: lets callers (and tests) record an unlink_observed audit
+   * row deterministically, without depending on chokidar's filesystem polling
+   * to notice the removal. No-op until `ready` resolves.
+   */
+  notifyUnlink(path: string): void;
 }
 
 interface PathBinding {
@@ -128,6 +136,12 @@ export function startWatcher(opts: WatcherOptions): IngestionWatcher {
       // fall back to the handler directly if the watcher isn't up yet.
       if (watcher) watcher.emit("change", path);
       else scheduleIngest(path);
+    },
+    notifyUnlink(path: string) {
+      // Route through chokidar's own emitter so the real "unlink" wiring runs;
+      // fall back to the handler directly if the watcher isn't up yet.
+      if (watcher) watcher.emit("unlink", path);
+      else recordUnlink(path);
     },
     async close() {
       closed = true;


### PR DESCRIPTION
## Background (Why)

Under the pre-commit hook's concurrent `pnpm -r run test`, the `startWatcher` > "records an unlink_observed audit row without deleting archive rows" test wrote `SqliteError: attempt to write a readonly database` (`SQLITE_READONLY_DBMOVED`) to stderr from `recordUnlink`'s `archive.db` insert (#100). The test still reported green, so it was deterministic noise polluting CI/hook output, pointing at a real lifecycle race.

The unlink test was the **last** watcher test still relying on chokidar's real polling to detect a filesystem change — #99 already removed that dependency from the change-event test via the `notifyChange` seam, and the "after close()" test does not rely on detection.

## Approach (How)

Diagnosed the exact mechanism with deterministic probes rather than brute-force timing (it would not reproduce on this machine under heavy load — the window stays shut):

1. `SQLITE_READONLY_DBMOVED` requires an **open** connection whose db **file is gone** — closing first yields a different error (`The database connection is not open`). So the stderr proved an audit write reached an open archive after its `archive.db` was already removed.
2. A vitest test that **times out** while awaiting **abandons its `try/finally`** — `watcher.close()` / `archive.close()` never run.
3. A never-closed watcher (`closed=false`) writing to a removed `archive.db` reproduces the warning.

Chain: chokidar polling is starved under worker-pool contention (the #92/#99 finding) → the unlink is never detected → the test times out → `finally` is skipped → the leaked, still-open watcher keeps polling into `afterEach`'s tmpdir teardown → `recordUnlink` fires against the just-removed `archive.db` → DBMOVED.

Fix mirrors the proven #99 pattern: add an optional, production-safe `notifyUnlink(path)` seam (the unlink counterpart of `notifyChange`) that drives the real `recordUnlink` handler through chokidar's own emitter, then rewrite the test to keep real polling dormant and call it. The test can no longer time out, so the watcher can no longer leak past teardown — the root cause is removed at the source, not by suppressing stderr.

No deterministic regression seam exists for the actual bug (it needs a forced timeout under contention, inherently flaky); making detection deterministic *is* the fix, and the rewritten test — which can no longer time out — is the regression protection. An "after close()" guard test was tried and removed: mutation testing showed it passed even with the guard neutered (chokidar removes listeners on `close()`), so it gave false confidence.

## Changes (What)

- [x] `api/src/ingestion/watcher.ts`: add optional `notifyUnlink(path)` seam mirroring `notifyChange` — routes through chokidar's own "unlink" emitter to run the real `recordUnlink` → audit write, bypassing only the unreliable OS polling detection. No production behavior change.
- [x] `api/src/ingestion/watcher.test.ts`: rewrite the unlink-audit test to be deterministic — keep polling dormant (interval 60s), `fs.unlinkSync` then `notifyUnlink`, assert synchronously. Removed the `vi.waitFor` that could time out and leak the watcher. Audit-row and preserved-archive-rows assertions are unchanged.

### Test Verification

- [x] `pnpm --filter @chat-logbook/api run typecheck` clean
- [x] Full api suite green (127 tests); watcher.test.ts 3/3 green and now deterministic (no wall-clock wait)
- [x] 6× concurrent `pnpm -r run test` (the exact pre-commit condition): 0 DBMOVED, 0 failed runs
- [x] Probes confirming the mechanism: open-connection-file-gone → DBMOVED; closed-connection → different error; vitest timeout skips `finally`; never-closed watcher + removed db → DBMOVED

## Related Links

- Closes #100