### PR TITLE
feat(web): freeze chat list sort order on background updates

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -1351,5 +1352,280 @@ describe("Tool call rendering (continued)", () => {
     expect(
       screen.queryByText("export function add(a, b) { return a + b; }")
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("Freeze sort order on background updates", () => {
+  type WireChat = {
+    id: string;
+    chatId: string;
+    agent: string;
+    title: string;
+    project: string;
+    projectPath: string | null;
+    sourceFilePath: string | null;
+    createdAt: number;
+    updatedAt: number;
+    deletedAt?: number | null;
+    isDeleted?: boolean;
+  };
+
+  // The active (non-deleted) chats in their default Updated-time-desc order:
+  // Fix database migration, Build a login page, Refactor utils, Untitled.
+  function activeChats(): WireChat[] {
+    return [
+      {
+        id: "chat-2",
+        chatId: "CHAT02",
+        agent: "claude-code",
+        title: "Fix database migration",
+        project: "backend-api",
+        projectPath: "/Users/test/backend-api",
+        sourceFilePath: null,
+        createdAt: 1700000100000,
+        updatedAt: 1700000300000,
+      },
+      {
+        id: "chat-1",
+        chatId: "CHAT01",
+        agent: "claude-code",
+        title: "Build a login page",
+        project: "my-web-app",
+        projectPath: "/Users/test/my-web-app",
+        sourceFilePath: null,
+        createdAt: 1700000000000,
+        updatedAt: 1700000200000,
+      },
+      {
+        id: "chat-3",
+        chatId: "CHAT03",
+        agent: "claude-code",
+        title: "Refactor utils",
+        project: "my-web-app",
+        projectPath: "/Users/test/my-web-app",
+        sourceFilePath: null,
+        createdAt: 1700000050000,
+        updatedAt: 1700000150000,
+      },
+      {
+        id: "chat-missing",
+        chatId: "CHATMI",
+        agent: "claude-code",
+        title: "Untitled",
+        project: "some-project",
+        projectPath: "/Users/test/some-project",
+        sourceFilePath: null,
+        createdAt: 1699999900000,
+        updatedAt: 1699999900000,
+      },
+    ];
+  }
+
+  // The deleted chats, kept stable so the Trash view stays populated across a
+  // simulated background ingest.
+  function trashedChats(): WireChat[] {
+    return [
+      {
+        id: "chat-deleted-1",
+        chatId: "CHATDE",
+        agent: "claude-code",
+        title: "Old prototype",
+        project: "my-web-app",
+        projectPath: "/Users/test/my-web-app",
+        sourceFilePath: null,
+        createdAt: 1699999000000,
+        updatedAt: 1699999500000,
+        deletedAt: 1700000200000,
+        isDeleted: true,
+      },
+      {
+        id: "chat-deleted-2",
+        chatId: "CHATD2",
+        agent: "claude-code",
+        title: "Newer experiment",
+        project: "my-web-app",
+        projectPath: "/Users/test/my-web-app",
+        sourceFilePath: null,
+        createdAt: 1699999100000,
+        updatedAt: 1699999800000,
+        deletedAt: 1700000100000,
+        isDeleted: true,
+      },
+    ];
+  }
+
+  // Serve a given active list (plus the stable deleted chats) on every
+  // subsequent /api/chats read — i.e. the background poll.
+  function serveBackground(active: WireChat[]): void {
+    const chats = [...active, ...trashedChats()];
+    server.use(http.get("/api/chats", () => HttpResponse.json({ chats })));
+  }
+
+  // Advance past one background poll interval and let the refetch settle.
+  async function flushBackgroundPoll(): Promise<void> {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+  }
+
+  it("keeps the selected row in place when a background refresh bumps its updatedAt", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    try {
+      render(<App />);
+
+      // Select "Build a login page" (chat-1), which sits at row index 1.
+      await user.click(await screen.findByText("Build a login page"));
+
+      const list = screen.getByTestId("chat-list");
+      let rows = within(list).getAllByTestId("chat-row");
+      expect(rows[0].textContent).toContain("Fix database migration");
+      expect(rows[1].textContent).toContain("Build a login page");
+
+      // Background ingest: chat-1 now has the newest updatedAt. A live re-sort
+      // would float it to the top.
+      const bumped = activeChats();
+      bumped[1].updatedAt = 1700000999000;
+      serveBackground(bumped);
+
+      await flushBackgroundPoll();
+
+      // Frozen: the selected row has not moved.
+      rows = within(list).getAllByTestId("chat-row");
+      expect(rows[0].textContent).toContain("Fix database migration");
+      expect(rows[1].textContent).toContain("Build a login page");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("applies the held-back order on the next sort change", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    try {
+      render(<App />);
+      await user.click(await screen.findByText("Build a login page"));
+      const list = screen.getByTestId("chat-list");
+
+      // Background ingest floats chat-1 to newest; the order stays frozen.
+      const bumped = activeChats();
+      bumped[1].updatedAt = 1700000999000;
+      serveBackground(bumped);
+      await flushBackgroundPoll();
+      let rows = within(list).getAllByTestId("chat-row");
+      expect(rows[1].textContent).toContain("Build a login page");
+
+      // Re-clicking the active Updated-time axis flips to Oldest first and
+      // re-sorts with the background data: chat-1 (now newest) sinks to bottom.
+      await user.click(within(list).getByRole("button", { name: /sort/i }));
+      const popover = await screen.findByTestId("chat-sort-popover");
+      await user.click(within(popover).getByText("Updated time"));
+
+      rows = within(list).getAllByTestId("chat-row");
+      expect(rows[0].textContent).toContain("Untitled");
+      expect(rows[3].textContent).toContain("Build a login page");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("applies the held-back order after switching views and back", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    try {
+      render(<App />);
+      await user.click(await screen.findByText("Build a login page"));
+      const list = screen.getByTestId("chat-list");
+
+      const bumped = activeChats();
+      bumped[1].updatedAt = 1700000999000;
+      serveBackground(bumped);
+      await flushBackgroundPoll();
+      const rows = within(list).getAllByTestId("chat-row");
+      expect(rows[1].textContent).toContain("Build a login page");
+
+      // Switch to Trash and back: the view switch flushes the frozen order.
+      await user.click(screen.getByTestId("trash-link"));
+      await screen.findByText("Old prototype");
+      await user.keyboard("{Escape}");
+
+      await waitFor(() => {
+        const r = within(screen.getByTestId("chat-list")).getAllByTestId(
+          "chat-row"
+        );
+        expect(r[0].textContent).toContain("Build a login page");
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("inserts a newly-appearing chat at its sorted position while holding the rest", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      render(<App />);
+      // No selection, so "Build a login page" appears only in the list.
+      await screen.findByText("Build a login page");
+      const list = screen.getByTestId("chat-list");
+
+      // A background ingest adds a brand-new chat whose updatedAt (1700000250000)
+      // places it between chat-2 (1700000300000) and chat-1 (1700000200000). No
+      // existing chat's time changes, so the held order is otherwise untouched.
+      const withNew = activeChats();
+      withNew.push({
+        id: "chat-new",
+        chatId: "CHATNW",
+        agent: "claude-code",
+        title: "Fresh ingest",
+        project: "my-web-app",
+        projectPath: "/Users/test/my-web-app",
+        sourceFilePath: null,
+        createdAt: 1700000250000,
+        updatedAt: 1700000250000,
+      });
+      serveBackground(withNew);
+      await flushBackgroundPoll();
+
+      const rows = within(list).getAllByTestId("chat-row");
+      // Existing chats keep their frozen relative order; the new chat slots into
+      // its sorted position between chat-2 and chat-1.
+      expect(rows[0].textContent).toContain("Fix database migration");
+      expect(rows[1].textContent).toContain("Fresh ingest");
+      expect(rows[2].textContent).toContain("Build a login page");
+      expect(rows[3].textContent).toContain("Refactor utils");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-sorts immediately when the user renames a chat", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByText("Build a login page");
+    const list = screen.getByTestId("chat-list");
+
+    // Sort by Title (A-Z) so a rename visibly changes order.
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+    const popover = await screen.findByTestId("chat-sort-popover");
+    await user.click(within(popover).getByText("Title"));
+    await user.keyboard("{Escape}");
+
+    let rows = within(list).getAllByTestId("chat-row");
+    expect(rows[0].textContent).toContain("Build a login page");
+
+    // Rename it to sort last; the list re-sorts immediately (a user action).
+    await user.click(within(list).getByText("Build a login page"));
+    await user.click(within(list).getByText("Build a login page"));
+    const input = within(list).getByRole("textbox", {
+      name: /chat title/i,
+    }) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Zzz renamed last" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(within(list).getByText("Zzz renamed last")).toBeInTheDocument();
+    });
+    rows = within(list).getAllByTestId("chat-row");
+    expect(rows[rows.length - 1].textContent).toContain("Zzz renamed last");
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useChats } from "@/hooks/useChats";
 import { useMessages } from "@/hooks/useMessages";
 import { useToast } from "@/hooks/useToast";
 import { useSortPreference } from "@/hooks/useSortPreference";
-import { sortChats } from "@/lib/sortChats";
+import { useFrozenSort } from "@/hooks/useFrozenSort";
 import {
   CHAT_DIRECTION_LABELS,
   CHAT_SORT_AXES,
@@ -24,7 +24,7 @@ import {
 } from "@/components/ui/resizable";
 
 function App() {
-  const { chats, softDelete, restore, setTitle } = useChats();
+  const { chats, sortEpoch, softDelete, restore, setTitle } = useChats();
   const handleRenameTitle = (id: string, title: string) => {
     void setTitle(id, title);
   };
@@ -35,23 +35,31 @@ function App() {
   const { toast, showToast, dismissToast } = useToast();
   const sort = useSortPreference(CHAT_SORT_CONFIG);
   const trashSort = useSortPreference(TRASH_SORT_CONFIG);
-  const mainChats = useMemo(
-    () =>
-      sortChats(
-        chats.filter((c) => !c.isDeleted),
-        sort.field,
-        sort.direction
-      ),
-    [chats, sort.field, sort.direction]
+
+  // Switching views (Chat List <-> Trash) flushes any held-back background order
+  // by counting as a re-sort. A monotonic generation bumps on every view switch
+  // and feeds the frozen-sort key, so returning to a view re-sorts with the
+  // latest data rather than reviving the order it had on the way out.
+  const [viewGen, setViewGen] = useState(0);
+  const switchMode = (next: "main" | "trash") => {
+    setMode(next);
+    setViewGen((g) => g + 1);
+  };
+
+  // sortEpoch (user data actions) and viewGen (view switches) both flush the
+  // frozen order; sort field/direction changes flush it inside useFrozenSort.
+  const resortKey = `${sortEpoch}:${viewGen}`;
+  const mainChats = useFrozenSort(
+    chats.filter((c) => !c.isDeleted),
+    sort.field,
+    sort.direction,
+    resortKey
   );
-  const deletedChats = useMemo(
-    () =>
-      sortChats(
-        chats.filter((c) => c.isDeleted),
-        trashSort.field,
-        trashSort.direction
-      ),
-    [chats, trashSort.field, trashSort.direction]
+  const deletedChats = useFrozenSort(
+    chats.filter((c) => c.isDeleted),
+    trashSort.field,
+    trashSort.direction,
+    resortKey
   );
   const visibleChats = mode === "trash" ? deletedChats : mainChats;
   const activeSort = mode === "trash" ? trashSort : sort;
@@ -69,7 +77,7 @@ function App() {
       message: "Chat restored.",
       actionLabel: "View",
       onAction: () => {
-        setMode("main");
+        switchMode("main");
         setSelectedId(id);
       },
     });
@@ -101,7 +109,7 @@ function App() {
 
       if (e.key === "Escape" && mode === "trash") {
         e.preventDefault();
-        setMode("main");
+        switchMode("main");
         return;
       }
 
@@ -141,7 +149,7 @@ function App() {
         <ResizablePanel defaultSize={15} minSize={10}>
           <FilterPanel
             deletedCount={deletedChats.length}
-            onOpenTrash={() => setMode("trash")}
+            onOpenTrash={() => switchMode("trash")}
           />
         </ResizablePanel>
         <ResizableHandle />
@@ -156,9 +164,9 @@ function App() {
             onDelete={handleDelete}
             onRestore={handleRestore}
             onRenameTitle={handleRenameTitle}
-            onBack={() => setMode("main")}
+            onBack={() => switchMode("main")}
             deletedCount={deletedChats.length}
-            onOpenTrash={() => setMode("trash")}
+            onOpenTrash={() => switchMode("trash")}
             sortSignature={`${mode}:${activeSort.field}:${activeSort.direction}`}
             sortControl={
               mode === "trash" ? (

--- a/web/src/hooks/useChats.ts
+++ b/web/src/hooks/useChats.ts
@@ -1,9 +1,19 @@
 import { useCallback, useEffect, useState } from "react";
 import type { Chat } from "@/types";
 
+// How often the UI re-reads the chat list while running, so file-watcher
+// ingestion (new chats, bumped `updatedAt`) shows up without a manual reload.
+// These background refreshes deliberately do NOT bump `sortEpoch`, so the sort
+// order stays frozen under the user until they next act on it (see App).
+const BACKGROUND_REFRESH_MS = 4000;
+
 interface UseChatsResult {
   chats: Chat[];
   loading: boolean;
+  // Increments on user-initiated changes (rename, delete, restore) only.
+  // Background refreshes leave it untouched. App keys its frozen sort order on
+  // this so background updates never re-sort the list under the user.
+  sortEpoch: number;
   softDelete: (id: string) => Promise<void>;
   restore: (id: string) => Promise<void>;
   setTitle: (id: string, title: string) => Promise<void>;
@@ -12,12 +22,27 @@ interface UseChatsResult {
 export function useChats(): UseChatsResult {
   const [chats, setChats] = useState<Chat[]>([]);
   const [loading, setLoading] = useState(true);
+  const [sortEpoch, setSortEpoch] = useState(0);
 
-  const fetchChats = useCallback(async () => {
-    const res = await fetch("/api/chats?includeTrashed=true");
-    const data = (await res.json()) as { chats: Chat[] };
-    setChats(data.chats);
+  const bumpEpoch = useCallback(() => setSortEpoch((e) => e + 1), []);
+
+  // A background refresh: pull the latest list but leave sortEpoch alone, so the
+  // frozen order holds.
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/chats?includeTrashed=true");
+      const data = (await res.json()) as { chats: Chat[] };
+      setChats(data.chats);
+    } catch {
+      // Ignore transient failures; the next interval tick retries.
+    }
   }, []);
+
+  // A user-initiated refresh: same fetch, but re-sort afterwards.
+  const reload = useCallback(async () => {
+    await refresh();
+    bumpEpoch();
+  }, [refresh, bumpEpoch]);
 
   useEffect(() => {
     let cancelled = false;
@@ -35,30 +60,45 @@ export function useChats(): UseChatsResult {
     };
   }, []);
 
-  const softDelete = useCallback(async (id: string) => {
-    // Mirror the server contract optimistically so the Trash view sorts by a
-    // real Deleted time immediately, before any refetch.
-    const now = Date.now();
-    setChats((prev) =>
-      prev.map((c) =>
-        c.id === id ? { ...c, isDeleted: true, deletedAt: now } : c
-      )
-    );
-    await fetch(`/api/chats/${encodeURIComponent(id)}`, {
-      method: "DELETE",
-    });
-  }, []);
+  useEffect(() => {
+    const id = setInterval(() => {
+      void refresh();
+    }, BACKGROUND_REFRESH_MS);
+    return () => clearInterval(id);
+  }, [refresh]);
 
-  const restore = useCallback(async (id: string) => {
-    setChats((prev) =>
-      prev.map((c) =>
-        c.id === id ? { ...c, isDeleted: false, deletedAt: null } : c
-      )
-    );
-    await fetch(`/api/chats/${encodeURIComponent(id)}/restore`, {
-      method: "POST",
-    });
-  }, []);
+  const softDelete = useCallback(
+    async (id: string) => {
+      // Mirror the server contract optimistically so the Trash view sorts by a
+      // real Deleted time immediately, before any refetch.
+      const now = Date.now();
+      setChats((prev) =>
+        prev.map((c) =>
+          c.id === id ? { ...c, isDeleted: true, deletedAt: now } : c
+        )
+      );
+      bumpEpoch();
+      await fetch(`/api/chats/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+      });
+    },
+    [bumpEpoch]
+  );
+
+  const restore = useCallback(
+    async (id: string) => {
+      setChats((prev) =>
+        prev.map((c) =>
+          c.id === id ? { ...c, isDeleted: false, deletedAt: null } : c
+        )
+      );
+      bumpEpoch();
+      await fetch(`/api/chats/${encodeURIComponent(id)}/restore`, {
+        method: "POST",
+      });
+    },
+    [bumpEpoch]
+  );
 
   const setTitle = useCallback(
     async (id: string, title: string) => {
@@ -67,6 +107,7 @@ export function useChats(): UseChatsResult {
         setChats((prev) =>
           prev.map((c) => (c.id === id ? { ...c, title: trimmed } : c))
         );
+        bumpEpoch();
       }
       await fetch(`/api/chats/${encodeURIComponent(id)}/title`, {
         method: "PATCH",
@@ -74,11 +115,11 @@ export function useChats(): UseChatsResult {
         body: JSON.stringify({ title }),
       });
       if (trimmed.length === 0) {
-        await fetchChats();
+        await reload();
       }
     },
-    [fetchChats]
+    [bumpEpoch, reload]
   );
 
-  return { chats, loading, softDelete, restore, setTitle };
+  return { chats, loading, sortEpoch, softDelete, restore, setTitle };
 }

--- a/web/src/hooks/useFrozenSort.ts
+++ b/web/src/hooks/useFrozenSort.ts
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import type { Chat } from "@/types";
+import { applyHeldOrder } from "@/lib/freezeSortOrder";
+import { sortChats, type SortDirection, type SortField } from "@/lib/sortChats";
+
+interface Anchor {
+  key: string;
+  ids: string[];
+}
+
+// Sort `chats`, but freeze the resulting row order across background data
+// changes. The order is anchored when `resortKey` (or the sort field/direction)
+// changes — a user-driven sort change, view switch, or data action — and held
+// otherwise: background changes never move existing rows, while newly-appearing
+// chats are slotted into their sorted position relative to the anchor (see
+// applyHeldOrder).
+export function useFrozenSort(
+  chats: Chat[],
+  field: SortField,
+  direction: SortDirection,
+  resortKey: string
+): Chat[] {
+  const fresh = sortChats(chats, field, direction);
+  const key = `${field}:${direction}:${resortKey}`;
+
+  // Store the anchored order in state and re-anchor when the key changes. This
+  // is React's sanctioned "adjust state during render" pattern: setting state
+  // during render bails out and re-renders immediately, so the freshly-sorted
+  // order shows without a one-frame flicker.
+  const [anchor, setAnchor] = useState<Anchor>(() => ({
+    key,
+    ids: fresh.map((c) => c.id),
+  }));
+
+  // Re-anchor on a key change, or when the current anchor is empty — the latter
+  // covers the initial load, where the first render anchors before the fetch has
+  // populated `chats`. Until a non-empty anchor is captured, freezing is a no-op.
+  const needsAnchor = anchor.key !== key || anchor.ids.length === 0;
+  if (needsAnchor) {
+    const ids = fresh.map((c) => c.id);
+    if (anchor.key !== key || ids.length !== anchor.ids.length) {
+      setAnchor({ key, ids });
+    }
+    return fresh;
+  }
+
+  return applyHeldOrder(fresh, anchor.ids);
+}

--- a/web/src/lib/freezeSortOrder.test.ts
+++ b/web/src/lib/freezeSortOrder.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import type { Chat } from "@/types";
+import { applyHeldOrder } from "./freezeSortOrder";
+
+function chat(id: string): Chat {
+  return {
+    id,
+    chatId: id.toUpperCase(),
+    agent: "claude-code",
+    title: id,
+    project: "p",
+    projectPath: null,
+    sourceFilePath: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function ids(chats: Chat[]): string[] {
+  return chats.map((c) => c.id);
+}
+
+describe("applyHeldOrder", () => {
+  it("keeps known chats in the held order, ignoring the fresh sort order", () => {
+    const held = ["a", "b", "c"];
+    // A background ingest re-sorted the fresh list, but membership is unchanged.
+    const fresh = [chat("c"), chat("a"), chat("b")];
+
+    expect(ids(applyHeldOrder(fresh, held))).toEqual(["a", "b", "c"]);
+  });
+
+  it("inserts a newly-appearing chat just before the held chat it precedes in the fresh sort", () => {
+    const held = ["a", "b", "c"];
+    // "x" is new and the fresh sort places it between b and c.
+    const fresh = [chat("a"), chat("b"), chat("x"), chat("c")];
+
+    expect(ids(applyHeldOrder(fresh, held))).toEqual(["a", "b", "x", "c"]);
+  });
+
+  it("appends a new chat that sorts after every held chat at the end", () => {
+    const held = ["a", "b"];
+    const fresh = [chat("a"), chat("b"), chat("z")];
+
+    expect(ids(applyHeldOrder(fresh, held))).toEqual(["a", "b", "z"]);
+  });
+
+  it("drops held chats that are no longer present in the fresh list", () => {
+    const held = ["a", "b", "c"];
+    // "b" disappeared from the fresh list.
+    const fresh = [chat("c"), chat("a")];
+
+    expect(ids(applyHeldOrder(fresh, held))).toEqual(["a", "c"]);
+  });
+});

--- a/web/src/lib/freezeSortOrder.ts
+++ b/web/src/lib/freezeSortOrder.ts
@@ -1,0 +1,44 @@
+import type { Chat } from "@/types";
+
+// Reorder a freshly-sorted list so that chats already known in `heldOrder` keep
+// their held positions, ignoring the fresh sort. Background data changes (e.g. a
+// bumped `updatedAt`) therefore never move rows under the user.
+//
+// Newly-appearing chats (present in `sortedFresh` but absent from `heldOrder`)
+// are slotted in at the position the fresh sort gives them: each new chat lands
+// just before the first held chat that follows it in the fresh order, and any
+// new chats sorting after every held chat are appended at the end.
+export function applyHeldOrder(
+  sortedFresh: Chat[],
+  heldOrder: string[]
+): Chat[] {
+  const byId = new Map(sortedFresh.map((c) => [c.id, c]));
+  const heldSet = new Set(heldOrder);
+
+  // Group new chats by the held chat they immediately precede in the fresh sort.
+  const newBefore = new Map<string, Chat[]>();
+  const trailing: Chat[] = [];
+  let pending: Chat[] = [];
+  for (const c of sortedFresh) {
+    if (heldSet.has(c.id)) {
+      if (pending.length > 0) {
+        newBefore.set(c.id, pending);
+        pending = [];
+      }
+    } else {
+      pending.push(c);
+    }
+  }
+  trailing.push(...pending);
+
+  const result: Chat[] = [];
+  for (const id of heldOrder) {
+    const c = byId.get(id);
+    if (!c) continue; // chat was removed since the order was frozen
+    const inserts = newBefore.get(id);
+    if (inserts) result.push(...inserts);
+    result.push(c);
+  }
+  result.push(...trailing);
+  return result;
+}


### PR DESCRIPTION
## Background (Why)

While the app is running, the file watcher keeps ingesting source changes. Those background updates — most commonly a bumped `updatedAt` — would re-sort the Chat List under the user, making rows jump and the selected chat slide away mid-read. This implements #83: background changes are held; only the user re-sorts.

## Approach (How)

Distinguish **user-driven** state changes from **background ingestion-driven** ones, and freeze the sort order's snapshot for the latter.

- A pure `applyHeldOrder()` merges a frozen id order with a freshly-sorted list: known chats keep their held positions, newly-appearing chats are slotted into their sorted slot, and removed chats drop out.
- `useFrozenSort()` anchors the displayed order in state and re-anchors only when its key changes (sort field/direction, `sortEpoch`, or `viewGen`) — using React's "adjust state during render" pattern, so a flush re-sorts with no one-frame flicker. It also re-anchors while the anchor is empty, covering the initial-load race before the first fetch resolves.
- `useChats` gains a 4s background poll (`refresh()`, which never bumps `sortEpoch`) as the channel that delivers background updates, plus a `sortEpoch` counter that only rename/delete/restore bump.
- `App` wires a `switchMode()` that bumps `viewGen`, so leaving and returning to a view re-sorts with the latest data instead of reviving the order it had on the way out.

## Changes (What)

- [x] `lib/freezeSortOrder.ts` — pure `applyHeldOrder()` (held order, insertion, trailing append, removal)
- [x] `hooks/useFrozenSort.ts` — anchor the order, re-anchor on key change / empty anchor
- [x] `hooks/useChats.ts` — background poll + user-only `sortEpoch`
- [x] `App.tsx` — replace the two `useMemo(sortChats)` with `useFrozenSort`; `switchMode()` for view-switch flush

### Test Verification

- [x] Pure: held order preserved, new chat inserted at sorted slot, trailing new chat appended, removed chat dropped
- [x] Background `updatedAt` bump on the selected chat → row stays put (no jump)
- [x] Held order flushes and re-sorts on the next sort-axis/direction change
- [x] Held order flushes on view switch (Chat List ↔ Trash) and back
- [x] Newly-appearing chat inserted at its sorted position while the rest hold
- [x] User rename re-sorts immediately
- [x] Full suite green (web 107, api 127)

## Additional Notes

The 4s poll is the minimal channel to make background updates observable in the UI (no watcher→UI push existed before). Optimistic user edits are awaited before their PATCH/DELETE resolves, so the poll-overwrite window is negligible; a future SSE/push channel could replace polling without touching the freeze logic.

## Related Links

- Closes #83
- Builds on the sort machinery from #81