### PR TITLE
perf(api): batch the N+1 queries behind ChatReader.listChats

### DIFF
--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -605,3 +605,214 @@ describe("ChatReader is agent-agnostic", () => {
     ]);
   });
 });
+
+/**
+ * Count how many SQLite statements execute on the archive connection while
+ * `fn` runs. Wraps `prepare` so every returned statement's all/get/run is
+ * tallied — this measures real query volume, independent of drizzle's
+ * statement caching.
+ */
+function countArchiveQueries(
+  archive: ReturnType<typeof createArchiveRepository>,
+  fn: () => void
+): number {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = (archive.db as any).$client;
+  const originalPrepare = client.prepare.bind(client);
+  let count = 0;
+  client.prepare = (source: string) => {
+    const stmt = originalPrepare(source);
+    for (const method of ["all", "get", "run"] as const) {
+      const original = stmt[method]?.bind(stmt);
+      if (!original) continue;
+      stmt[method] = (...args: unknown[]) => {
+        count += 1;
+        return original(...args);
+      };
+    }
+    return stmt;
+  };
+  try {
+    fn();
+  } finally {
+    client.prepare = originalPrepare;
+  }
+  return count;
+}
+
+function seedFullChat(
+  archive: ReturnType<typeof createArchiveRepository>,
+  metadata: ReturnType<typeof createMetadataRepository>,
+  index: number
+): void {
+  // chat_id is derived from internalId.slice(0, 6) by seedChat, so the first
+  // six characters must be unique per chat to avoid a UNIQUE collision.
+  const internalId = `c${String(index).padStart(5, "0")}`;
+  const sourceId = `session-${index}`;
+  seedChat(archive, {
+    internalId,
+    sourceId,
+    firstSeenAt: new Date(1700000000000 + index),
+  });
+  seedMessage(archive, {
+    sourceId,
+    messageId: `m-user-${index}`,
+    role: "user",
+    ts: new Date(1700000100000 + index),
+    text: `Question ${index}`,
+    blocks: [{ type: "text", text: `Question ${index}` }],
+  });
+  seedMessage(archive, {
+    sourceId,
+    messageId: `m-assistant-${index}`,
+    role: "assistant",
+    ts: new Date(1700000500000 + index),
+    text: `Answer ${index}`,
+    blocks: [{ type: "text", text: `Answer ${index}` }],
+  });
+  seedRawMessage(archive, {
+    sourceId,
+    sourcePath: `/path/${index}.jsonl`,
+    payloadHash: `hash-${index}`,
+    ingestedAt: new Date(1700000900000 + index),
+  });
+  if (index % 2 === 0) {
+    metadata.setCustomTitle(internalId, `Custom title ${index}`);
+  }
+}
+
+describe("ChatReader.listChats query batching", () => {
+  it("runs a constant number of archive queries regardless of chat count", () => {
+    const archiveSmall = createArchiveRepository({ dataDir });
+    const metadataSmall = createMetadataRepository({ dataDir });
+    seedFullChat(archiveSmall, metadataSmall, 1);
+    const readerSmall = createChatReader({
+      archive: archiveSmall,
+      metadata: metadataSmall,
+    });
+    const smallCount = countArchiveQueries(archiveSmall, () => {
+      readerSmall.listChats({ includeTrashed: false });
+    });
+
+    const bigDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "chat-logbook-reader-test-big-")
+    );
+    try {
+      const archiveBig = createArchiveRepository({ dataDir: bigDir });
+      const metadataBig = createMetadataRepository({ dataDir: bigDir });
+      for (let i = 1; i <= 20; i += 1) {
+        seedFullChat(archiveBig, metadataBig, i);
+      }
+      const readerBig = createChatReader({
+        archive: archiveBig,
+        metadata: metadataBig,
+      });
+      const bigCount = countArchiveQueries(archiveBig, () => {
+        readerBig.listChats({ includeTrashed: false });
+      });
+
+      expect(bigCount).toBe(smallCount);
+    } finally {
+      fs.rmSync(bigDir, { recursive: true, force: true });
+    }
+  });
+
+  it("assembles per-chat title, ts-range, and source path correctly across multiple chats", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    // Chat A: derives its title from the first user message, has two raw rows
+    // (newest path wins) and a two-message ts-range.
+    seedChat(archive, {
+      internalId: "aaaaaa-uuid",
+      sourceId: "session-a",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-a",
+      messageId: "a-user",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "Title from A",
+      blocks: [{ type: "text", text: "Title from A" }],
+    });
+    seedMessage(archive, {
+      sourceId: "session-a",
+      messageId: "a-assistant",
+      role: "assistant",
+      ts: new Date(1700000800000),
+      text: "ok",
+      blocks: [{ type: "text", text: "ok" }],
+    });
+    seedRawMessage(archive, {
+      sourceId: "session-a",
+      sourcePath: "/a/old.jsonl",
+      payloadHash: "a-old",
+      ingestedAt: new Date(1700000100000),
+    });
+    seedRawMessage(archive, {
+      sourceId: "session-a",
+      sourcePath: "/a/new.jsonl",
+      payloadHash: "a-new",
+      ingestedAt: new Date(1700000900000),
+    });
+
+    // Chat B: a custom title overrides its first user message.
+    seedChat(archive, {
+      internalId: "bbbbbb-uuid",
+      sourceId: "session-b",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-b",
+      messageId: "b-user",
+      role: "user",
+      ts: new Date(1700000200000),
+      text: "Derived B title",
+      blocks: [{ type: "text", text: "Derived B title" }],
+    });
+    seedRawMessage(archive, {
+      sourceId: "session-b",
+      sourcePath: "/b/only.jsonl",
+      payloadHash: "b-only",
+      ingestedAt: new Date(1700000300000),
+    });
+    metadata.setCustomTitle("bbbbbb-uuid", "Custom B title");
+
+    // Chat C: no messages, no raw rows — falls back to Untitled, null path,
+    // and firstSeenAt for both timestamps.
+    seedChat(archive, {
+      internalId: "cccccc-uuid",
+      sourceId: "session-c",
+      firstSeenAt: new Date(1700000050000),
+    });
+
+    const reader = createChatReader({ archive, metadata });
+    const chats = reader.listChats({ includeTrashed: false });
+
+    // Ordering mirrors the chat-row insertion order.
+    expect(chats.map((c) => c.id)).toEqual([
+      "session-a",
+      "session-b",
+      "session-c",
+    ]);
+
+    const a = chats.find((c) => c.id === "session-a")!;
+    expect(a.title).toBe("Title from A");
+    expect(a.sourceFilePath).toBe("/a/new.jsonl");
+    expect(a.createdAt).toBe(1700000100000);
+    expect(a.updatedAt).toBe(1700000800000);
+
+    const b = chats.find((c) => c.id === "session-b")!;
+    expect(b.title).toBe("Custom B title");
+    expect(b.sourceFilePath).toBe("/b/only.jsonl");
+    expect(b.createdAt).toBe(1700000200000);
+    expect(b.updatedAt).toBe(1700000200000);
+
+    const c = chats.find((c) => c.id === "session-c")!;
+    expect(c.title).toBe("Untitled");
+    expect(c.sourceFilePath).toBeNull();
+    expect(c.createdAt).toBe(1700000050000);
+    expect(c.updatedAt).toBe(1700000050000);
+  });
+});

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, sql } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 import type { ArchiveRepository } from "./archive/repository.js";
 import {
   chats as archiveChats,
@@ -93,26 +93,19 @@ export function createChatReader({
     );
   }
 
-  function deriveTitle(row: ChatRecord): string {
-    const custom = metadata.getCustomTitle(row.id);
-    if (custom && custom.trim()) return custom;
-
-    const firstUser = archive.db
-      .select({ text: archiveMessages.text })
-      .from(archiveMessages)
-      .where(
-        and(
-          eq(archiveMessages.agent, row.agent),
-          eq(archiveMessages.sourceId, row.sourceId),
-          eq(archiveMessages.role, "user")
-        )
-      )
-      .orderBy(asc(archiveMessages.ts))
-      .limit(1)
-      .get();
-
-    const text = firstUser?.text?.trim().split("\n")[0]?.trim();
+  function deriveTitle(
+    customTitle: string | undefined,
+    firstUserText: string | undefined
+  ): string {
+    if (customTitle && customTitle.trim()) return customTitle;
+    const text = firstUserText?.trim().split("\n")[0]?.trim();
     return text && text.length > 0 ? text : "Untitled";
+  }
+
+  // Archive rows are keyed by (agent, source_id); NUL joins the pair into a
+  // single Map key that can't collide with any value either field can hold.
+  function key(agent: string, sourceId: string): string {
+    return [agent, sourceId].join("\u0000");
   }
 
   function listChats({
@@ -122,48 +115,94 @@ export function createChatReader({
   }): ChatResponse[] {
     const visibility = loadChatVisibility(metadata, { includeTrashed });
     const rows = archive.db.select().from(archiveChats).all();
-    const chats: ChatResponse[] = [];
 
+    // One grouped/windowed query per derived field, assembled in memory keyed
+    // by (agent, source_id) — so listing N chats stays a constant query count
+    // rather than ~3 per row. See issue #106.
+    const tsRangeRows = archive.db
+      .select({
+        agent: archiveMessages.agent,
+        sourceId: archiveMessages.sourceId,
+        minTs: sql<number | null>`min(${archiveMessages.ts})`,
+        maxTs: sql<number | null>`max(${archiveMessages.ts})`,
+      })
+      .from(archiveMessages)
+      .groupBy(archiveMessages.agent, archiveMessages.sourceId)
+      .all();
+    const tsRangeByKey = new Map(
+      tsRangeRows.map((r) => [key(r.agent, r.sourceId), r])
+    );
+
+    const rankedRaw = archive.db
+      .select({
+        agent: archiveRawMessages.agent,
+        sourceId: archiveRawMessages.sourceId,
+        sourcePath: archiveRawMessages.sourcePath,
+        rn: sql<number>`row_number() over (partition by ${archiveRawMessages.agent}, ${archiveRawMessages.sourceId} order by ${archiveRawMessages.ingestedAt} desc)`.as(
+          "rn"
+        ),
+      })
+      .from(archiveRawMessages)
+      .as("ranked_raw");
+    const latestRawRows = archive.db
+      .select({
+        agent: rankedRaw.agent,
+        sourceId: rankedRaw.sourceId,
+        sourcePath: rankedRaw.sourcePath,
+      })
+      .from(rankedRaw)
+      .where(eq(rankedRaw.rn, 1))
+      .all();
+    const sourcePathByKey = new Map(
+      latestRawRows.map((r) => [key(r.agent, r.sourceId), r.sourcePath])
+    );
+
+    const rankedUser = archive.db
+      .select({
+        agent: archiveMessages.agent,
+        sourceId: archiveMessages.sourceId,
+        text: archiveMessages.text,
+        rn: sql<number>`row_number() over (partition by ${archiveMessages.agent}, ${archiveMessages.sourceId} order by ${archiveMessages.ts} asc)`.as(
+          "rn"
+        ),
+      })
+      .from(archiveMessages)
+      .where(eq(archiveMessages.role, "user"))
+      .as("ranked_user");
+    const firstUserRows = archive.db
+      .select({
+        agent: rankedUser.agent,
+        sourceId: rankedUser.sourceId,
+        text: rankedUser.text,
+      })
+      .from(rankedUser)
+      .where(eq(rankedUser.rn, 1))
+      .all();
+    const firstUserTextByKey = new Map(
+      firstUserRows.map((r) => [key(r.agent, r.sourceId), r.text])
+    );
+
+    const customTitleById = metadata.listCustomTitles();
+
+    const chats: ChatResponse[] = [];
     for (const row of rows) {
       if (!visibility.isVisible(row.id)) continue;
       const isDeleted = visibility.isTrashed(row.id);
 
-      const latestRaw = archive.db
-        .select({ sourcePath: archiveRawMessages.sourcePath })
-        .from(archiveRawMessages)
-        .where(
-          and(
-            eq(archiveRawMessages.agent, row.agent),
-            eq(archiveRawMessages.sourceId, row.sourceId)
-          )
-        )
-        .orderBy(desc(archiveRawMessages.ingestedAt))
-        .limit(1)
-        .get();
-
-      const tsRange = archive.db
-        .select({
-          minTs: sql<number | null>`min(${archiveMessages.ts})`,
-          maxTs: sql<number | null>`max(${archiveMessages.ts})`,
-        })
-        .from(archiveMessages)
-        .where(
-          and(
-            eq(archiveMessages.agent, row.agent),
-            eq(archiveMessages.sourceId, row.sourceId)
-          )
-        )
-        .get();
-
+      const rowKey = key(row.agent, row.sourceId);
+      const tsRange = tsRangeByKey.get(rowKey);
       const firstSeenAtMs = row.firstSeenAt.getTime();
       const chat: ChatResponse = {
         id: row.sourceId,
         chatId: row.chatId,
         agent: row.agent,
-        title: deriveTitle(row),
+        title: deriveTitle(
+          customTitleById.get(row.id),
+          firstUserTextByKey.get(rowKey)
+        ),
         project: row.project ?? "",
         projectPath: row.projectPath ?? null,
-        sourceFilePath: latestRaw?.sourcePath ?? null,
+        sourceFilePath: sourcePathByKey.get(rowKey) ?? null,
         createdAt: tsRange?.minTs ?? firstSeenAtMs,
         updatedAt: tsRange?.maxTs ?? firstSeenAtMs,
         deletedAt: visibility.deletedAt(row.id),

--- a/api/src/metadata/repository.ts
+++ b/api/src/metadata/repository.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
-import { eq } from "drizzle-orm";
+import { eq, isNotNull } from "drizzle-orm";
 import {
   drizzle,
   type BetterSQLite3Database,
@@ -48,6 +48,9 @@ export interface MetadataRepository {
   getDeletedAt(internalId: string): Date | null;
   listDeleted(): Array<{ id: string; deletedAt: Date | null }>;
   getCustomTitle(internalId: string): string | null;
+  /** Every chat with a custom title, keyed by internal id. Lets read paths
+   * resolve titles in one query instead of one per chat. */
+  listCustomTitles(): Map<string, string>;
   setCustomTitle(internalId: string, title: string | null): void;
 }
 
@@ -141,6 +144,19 @@ export function createMetadataRepository({
         .where(eq(chatsMeta.id, internalId))
         .get();
       return row?.customTitle ?? null;
+    },
+
+    listCustomTitles() {
+      const rows = db
+        .select({ id: chatsMeta.id, customTitle: chatsMeta.customTitle })
+        .from(chatsMeta)
+        .where(isNotNull(chatsMeta.customTitle))
+        .all();
+      const byId = new Map<string, string>();
+      for (const row of rows) {
+        if (row.customTitle !== null) byId.set(row.id, row.customTitle);
+      }
+      return byId;
     },
 
     setCustomTitle(internalId, title) {


### PR DESCRIPTION
## Background (Why)

`ChatReader.listChats` ran roughly three queries per chat row — latest raw source path, the ts-range (min/max), and the first-user-message title derivation — so listing N chats cost ~3N queries. Now that the read logic sits behind the `ChatReader` interface (issue #105), batching it is a local change behind a tested seam. This is the depth payoff of that extraction: the optimization is invisible to callers and fully covered by the reader's tests.

## Approach (How)

Collapse the per-row work into a constant number of set-based queries, assembled in memory keyed by `(agent, source_id)`:

- **ts-range** — one `GROUP BY agent, source_id` over `min/max(ts)`.
- **latest source path** — one `row_number() over (partition by agent, source_id order by ingested_at desc)` subquery, picking `rn = 1`.
- **first-user title** — one `row_number() over (partition by agent, source_id order by ts asc)` subquery (restricted to `role = 'user'`), picking `rn = 1`.
- **custom titles** — a new `MetadataRepository.listCustomTitles()` fetches them in one query, so the metadata side stays constant too.

`deriveTitle` becomes a pure function (no longer issues its own query). `listChats` goes from `1 + ~3N` queries to a fixed handful regardless of N. The `ChatReader` interface and `ChatResponse` output are unchanged.

## Changes (What)

- [x] `api/src/chat-reader.ts` — batch the per-row queries into grouped/windowed queries assembled in memory; make `deriveTitle` pure.
- [x] `api/src/metadata/repository.ts` — add `listCustomTitles(): Map<string, string>`.
- [x] `api/src/chat-reader.test.ts` — add a query-count constancy test and a multi-chat equivalence test.

### Test Verification

- [x] Archive query count stays constant for 1 vs 20 chats (was `51`, now `4`).
- [x] Multi-chat list: per-chat derived title, custom-title override, Untitled fallback, ts-range, latest source path, and ordering all correct.
- [x] All existing `chat-reader.test.ts` assertions pass without modification.
- [x] Full api suite (133) + web suite (107) green; `pnpm typecheck` passes.

## Additional Notes

The query-count test wraps the underlying better-sqlite3 connection (`archive.db.$client`) to tally statement executions — slightly implementation-coupled, but it pins the performance contract the issue asks for. No interface or response-shape change, so existing callers are untouched.

## Related Links

- Closes #106
- Builds on #105 (ChatReader extraction)