### PR TITLE
refactor(web): introduce useChatOrder deep hook for chat-list ordering

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -94,6 +94,12 @@ _Avoid_: delete, hard-delete (in prose), wipe
 Whether a Chat appears, decided at read time from Metadata — never by changing the Archive or the Index.
 _Avoid_: filtering, access
 
+### List ordering
+
+**Frozen order**:
+The Chat list holds its existing row order across a background refresh — existing rows never move, and only a newly-appearing Chat slots into its sorted position. The order re-sorts only on a user action: changing the sort, switching view (Chat list ⇄ Trash), or a Trash/Restore. Owned by the `useChatOrder` hook per view.
+_Avoid_: pinned order, locked order, sticky sort
+
 ## Flagged ambiguities
 
 - **Chat, not session.** "Chat" is canonical since the v0.8.0 rename. "session" still lingers in `docs/PRD.md` — that is term debt to repay, not an alias to keep. Use "session" only when you mean the _Agent's own_ unit (which is why the field is `source id`, once `source_session_id`).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,16 +2,7 @@ import { useEffect, useState } from "react";
 import { useChats } from "@/chat/useChats";
 import { useMessages } from "@/conversation/useMessages";
 import { useToast } from "@/shared/useToast";
-import { useSortPreference } from "@/chat/sort/useSortPreference";
-import { useFrozenSort } from "@/chat/sort/useFrozenSort";
-import {
-  CHAT_DIRECTION_LABELS,
-  CHAT_SORT_AXES,
-  CHAT_SORT_CONFIG,
-  TRASH_DIRECTION_LABELS,
-  TRASH_SORT_AXES,
-  TRASH_SORT_CONFIG,
-} from "@/chat/sort/sortConfig";
+import { useChatOrder } from "@/chat/sort/useChatOrder";
 import { FilterPanel } from "@/chat/FilterPanel";
 import { ChatList } from "@/chat/ChatList";
 import { SortControl } from "@/chat/sort/SortControl";
@@ -33,8 +24,6 @@ function App() {
   const [editingTitleId, setEditingTitleId] = useState<string | null>(null);
   const { messages, error } = useMessages(selectedId);
   const { toast, showToast, dismissToast } = useToast();
-  const sort = useSortPreference(CHAT_SORT_CONFIG);
-  const trashSort = useSortPreference(TRASH_SORT_CONFIG);
 
   // Switching views (Chat List <-> Trash) flushes any held-back background order
   // by counting as a re-sort. A monotonic generation bumps on every view switch
@@ -47,22 +36,14 @@ function App() {
   };
 
   // sortEpoch (user data actions) and viewGen (view switches) both flush the
-  // frozen order; sort field/direction changes flush it inside useFrozenSort.
+  // frozen order; sort field/direction changes flush it inside the hook.
   const resortKey = `${sortEpoch}:${viewGen}`;
-  const mainChats = useFrozenSort(
-    chats.filter((c) => !c.isDeleted),
-    sort.field,
-    sort.direction,
-    resortKey
-  );
-  const deletedChats = useFrozenSort(
-    chats.filter((c) => c.isDeleted),
-    trashSort.field,
-    trashSort.direction,
-    resortKey
-  );
-  const visibleChats = mode === "trash" ? deletedChats : mainChats;
-  const activeSort = mode === "trash" ? trashSort : sort;
+  const mainOrder = useChatOrder("main", chats, resortKey);
+  const trashOrder = useChatOrder("trash", chats, resortKey);
+  const order = mode === "trash" ? trashOrder : mainOrder;
+  const mainChats = mainOrder.orderedChats;
+  const deletedChats = trashOrder.orderedChats;
+  const visibleChats = order.orderedChats;
   const selectedChat = chats.find((c) => c.id === selectedId) ?? null;
 
   const handleRestore = (id: string) => {
@@ -167,32 +148,8 @@ function App() {
             onBack={() => switchMode("main")}
             deletedCount={deletedChats.length}
             onOpenTrash={() => switchMode("trash")}
-            sortSignature={`${mode}:${activeSort.field}:${activeSort.direction}`}
-            sortControl={
-              mode === "trash" ? (
-                <SortControl
-                  testId="trash-sort-popover"
-                  axes={TRASH_SORT_AXES}
-                  field={trashSort.field}
-                  direction={trashSort.direction}
-                  isDefault={trashSort.isDefault}
-                  directionLabels={TRASH_DIRECTION_LABELS}
-                  onSelectField={trashSort.selectField}
-                  onToggleDirection={trashSort.toggleDirection}
-                />
-              ) : (
-                <SortControl
-                  testId="chat-sort-popover"
-                  axes={CHAT_SORT_AXES}
-                  field={sort.field}
-                  direction={sort.direction}
-                  isDefault={sort.isDefault}
-                  directionLabels={CHAT_DIRECTION_LABELS}
-                  onSelectField={sort.selectField}
-                  onToggleDirection={sort.toggleDirection}
-                />
-              )
-            }
+            sortSignature={`${mode}:${order.sortControlProps.field}:${order.sortControlProps.direction}`}
+            sortControl={<SortControl {...order.sortControlProps} />}
           />
         </ResizablePanel>
         <ResizableHandle />

--- a/web/src/chat/sort/SortControl.tsx
+++ b/web/src/chat/sort/SortControl.tsx
@@ -4,7 +4,7 @@ import type { DirectionLabels, SortAxis } from "@/chat/sort/sortConfig";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { cn } from "@/shared/utils";
 
-interface SortControlProps<F extends string> {
+export interface SortControlProps<F extends string> {
   axes: SortAxis<F>[];
   field: F;
   direction: SortDirection;

--- a/web/src/chat/sort/useChatOrder.test.tsx
+++ b/web/src/chat/sort/useChatOrder.test.tsx
@@ -1,0 +1,143 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import type { Chat } from "@/types";
+import { useChatOrder } from "@/chat/sort/useChatOrder";
+
+function chat(id: string, fields: Partial<Chat> = {}): Chat {
+  return {
+    id,
+    chatId: id.toUpperCase(),
+    agent: "claude-code",
+    title: id,
+    project: "p",
+    projectPath: null,
+    sourceFilePath: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...fields,
+  };
+}
+
+function ids(chats: Chat[]): string[] {
+  return chats.map((c) => c.id);
+}
+
+// Active (non-deleted) chats in no particular order; updatedAt drives the
+// default Chats-list sort (Updated time, newest first).
+function activeChats(): Chat[] {
+  return [
+    chat("a", { updatedAt: 100 }),
+    chat("b", { updatedAt: 300 }),
+    chat("c", { updatedAt: 200 }),
+  ];
+}
+
+// Deleted chats; deletedAt drives the default Trash sort (newest deleted first).
+function deletedChats(): Chat[] {
+  return [
+    chat("x", { isDeleted: true, deletedAt: 100, updatedAt: 50 }),
+    chat("y", { isDeleted: true, deletedAt: 300, updatedAt: 70 }),
+  ];
+}
+
+describe("useChatOrder", () => {
+  it("orders the main view by the default preference and excludes deleted chats", () => {
+    const chats = [...activeChats(), ...deletedChats()];
+    const { result } = renderHook(() => useChatOrder("main", chats, "0:0"));
+
+    // Default Chats sort: Updated time, newest first. Deleted chats excluded.
+    expect(ids(result.current.orderedChats)).toEqual(["b", "c", "a"]);
+    expect(result.current.sortControlProps.field).toBe("updatedAt");
+    expect(result.current.sortControlProps.isDefault).toBe(true);
+    expect(result.current.sortControlProps.testId).toBe("chat-sort-popover");
+  });
+
+  it("orders the trash view by deletedAt and includes only deleted chats", () => {
+    const chats = [...activeChats(), ...deletedChats()];
+    const { result } = renderHook(() => useChatOrder("trash", chats, "0:0"));
+
+    // Default Trash sort: Deleted time, newest first. Active chats excluded.
+    expect(ids(result.current.orderedChats)).toEqual(["y", "x"]);
+    expect(result.current.sortControlProps.field).toBe("deletedAt");
+    expect(result.current.sortControlProps.testId).toBe("trash-sort-popover");
+    // Trash axes carry the Deleted time axis that the main view omits.
+    expect(result.current.sortControlProps.axes.map((a) => a.field)).toContain(
+      "deletedAt"
+    );
+  });
+
+  it("freezes the row order across a background change under the same signal", () => {
+    const { result, rerender } = renderHook(
+      ({ chats, signal }) => useChatOrder("main", chats, signal),
+      { initialProps: { chats: activeChats(), signal: "0:0" } }
+    );
+
+    // Anchored order: b (300), c (200), a (100).
+    expect(ids(result.current.orderedChats)).toEqual(["b", "c", "a"]);
+
+    // Background ingest bumps "a" to the newest updatedAt under the SAME signal.
+    // A live re-sort would float "a" to the top; the frozen order must not.
+    const bumped = [
+      chat("a", { updatedAt: 999 }),
+      chat("b", { updatedAt: 300 }),
+      chat("c", { updatedAt: 200 }),
+    ];
+    rerender({ chats: bumped, signal: "0:0" });
+
+    expect(ids(result.current.orderedChats)).toEqual(["b", "c", "a"]);
+  });
+
+  it("slots a newly-appearing chat into its sorted position while holding the rest", () => {
+    const { result, rerender } = renderHook(
+      ({ chats, signal }) => useChatOrder("main", chats, signal),
+      { initialProps: { chats: activeChats(), signal: "0:0" } }
+    );
+    expect(ids(result.current.orderedChats)).toEqual(["b", "c", "a"]);
+
+    // A background ingest adds "d" (updatedAt 250), which sorts between b (300)
+    // and c (200). No existing chat moves; only the new chat appears.
+    const withNew = [...activeChats(), chat("d", { updatedAt: 250 })];
+    rerender({ chats: withNew, signal: "0:0" });
+
+    expect(ids(result.current.orderedChats)).toEqual(["b", "d", "c", "a"]);
+  });
+
+  it("re-sorts when the user changes the sort field via sortControlProps", () => {
+    const { result } = renderHook(() =>
+      useChatOrder("main", activeChats(), "0:0")
+    );
+
+    // Default Updated-time order.
+    expect(ids(result.current.orderedChats)).toEqual(["b", "c", "a"]);
+
+    // Selecting Title (A-Z) is a user action: the order re-sorts immediately.
+    // Titles default to the id, so A-Z is a, b, c.
+    act(() => {
+      result.current.sortControlProps.onSelectField("title");
+    });
+
+    expect(result.current.sortControlProps.field).toBe("title");
+    expect(ids(result.current.orderedChats)).toEqual(["a", "b", "c"]);
+  });
+
+  it("re-sorts with the latest data when the flush signal changes", () => {
+    const { result, rerender } = renderHook(
+      ({ chats, signal }) => useChatOrder("main", chats, signal),
+      { initialProps: { chats: activeChats(), signal: "0:0" } }
+    );
+
+    // Background bump "a" to newest under the same signal: order stays frozen.
+    const bumped = [
+      chat("a", { updatedAt: 999 }),
+      chat("b", { updatedAt: 300 }),
+      chat("c", { updatedAt: 200 }),
+    ];
+    rerender({ chats: bumped, signal: "0:0" });
+    expect(ids(result.current.orderedChats)).toEqual(["b", "c", "a"]);
+
+    // A new flush signal (e.g. a data action or view switch) re-sorts with the
+    // latest data: "a" floats to the top.
+    rerender({ chats: bumped, signal: "1:0" });
+    expect(ids(result.current.orderedChats)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/web/src/chat/sort/useChatOrder.ts
+++ b/web/src/chat/sort/useChatOrder.ts
@@ -1,0 +1,76 @@
+import type { Chat } from "@/types";
+import type { SortField } from "@/chat/sort/sortChats";
+import type { SortControlProps } from "@/chat/sort/SortControl";
+import {
+  CHAT_DIRECTION_LABELS,
+  CHAT_SORT_AXES,
+  CHAT_SORT_CONFIG,
+  TRASH_DIRECTION_LABELS,
+  TRASH_SORT_AXES,
+  TRASH_SORT_CONFIG,
+} from "@/chat/sort/sortConfig";
+import { useSortPreference } from "@/chat/sort/useSortPreference";
+import { useFrozenSort } from "@/chat/sort/useFrozenSort";
+
+export type ChatView = "main" | "trash";
+
+export interface ChatOrder {
+  orderedChats: Chat[];
+  sortControlProps: SortControlProps<SortField>;
+}
+
+// Per-view sort vocabulary: which config drives the preference, which axes and
+// direction labels the SortControl shows, which test id the popover carries,
+// and which chats the view contains. This mapping — "which view uses which
+// config + filter" — is the knowledge that had no home when it lived inline in
+// App.tsx; useChatOrder owns it.
+const VIEWS = {
+  main: {
+    config: CHAT_SORT_CONFIG,
+    axes: CHAT_SORT_AXES,
+    directionLabels: CHAT_DIRECTION_LABELS,
+    testId: "chat-sort-popover",
+    includes: (c: Chat) => !c.isDeleted,
+  },
+  trash: {
+    config: TRASH_SORT_CONFIG,
+    axes: TRASH_SORT_AXES,
+    directionLabels: TRASH_DIRECTION_LABELS,
+    testId: "trash-sort-popover",
+    includes: (c: Chat) => Boolean(c.isDeleted),
+  },
+} as const;
+
+// Owns Chat-list ordering for one view: it composes the sort preference, the
+// frozen-order anchor, and the flush signal behind a thin interface. App calls
+// it once per view (main, trash). `flushSignal` is passed in — the hook is a
+// pure function of (view, chats, flushSignal) and does not know the signal is
+// itself composed of a data-action epoch and a view-switch generation.
+export function useChatOrder(
+  view: ChatView,
+  chats: Chat[],
+  flushSignal: string
+): ChatOrder {
+  const { config, axes, directionLabels, testId, includes } = VIEWS[view];
+  const pref = useSortPreference(config);
+  const orderedChats = useFrozenSort(
+    chats.filter(includes),
+    pref.field,
+    pref.direction,
+    flushSignal
+  );
+
+  return {
+    orderedChats,
+    sortControlProps: {
+      testId,
+      axes,
+      field: pref.field,
+      direction: pref.direction,
+      isDefault: pref.isDefault,
+      directionLabels,
+      onSelectField: pref.selectField,
+      onToggleDirection: pref.toggleDirection,
+    },
+  };
+}


### PR DESCRIPTION
## Background (Why)

Chat-list ordering — "what order do rows end up in, given a sort preference, a frozen anchor, a data-action epoch, and a view switch" — was assembled by hand in `App.tsx` from six shallow, individually-tested helpers. That composition had no module and no home: it was reachable only through a full `App` render, so the bugs that actually bite (does the order freeze under background refresh; does a view switch re-sort) had no test surface of their own. This moves the seam from `App.tsx` up to one hook.

## Approach (How)

Introduce a deep `useChatOrder(view, chats, flushSignal)` hook that owns Chat-list ordering for one view behind a thin `{ orderedChats, sortControlProps }` interface.

- **Owns, not just composes** — internally calls `useSortPreference` + `useFrozenSort`; the preference/freeze/flush wiring is hidden behind the interface.
- **`view` resolves config + filter internally** — the "which view uses which sort config + row filter" mapping (the knowledge that had no home) now lives in one place; the hook takes the full `chats` array and filters by `isDeleted` itself.
- **`flushSignal` passed in** — the hook stays a pure function of (view, chats, flushSignal); `App` keeps computing the combined `${sortEpoch}:${viewGen}` signal and `viewGen` stays in `App` (the view switch is an app concern — it also drives `selectedId`).
- The six pure helpers stay as the hook's internal seams (no file merges). No ordering behaviour changes.

## Changes (What)

- [x] Add `useChatOrder` deep hook in `web/src/chat/sort/` returning `{ orderedChats, sortControlProps }`, resolving config + `isDeleted` filter from `view`.
- [x] Collapse `App.tsx` ordering wiring (two `useSortPreference`, two `useFrozenSort`, inline filters, two-branch `<SortControl>` JSX) into two `useChatOrder` calls + a single `<SortControl {...order.sortControlProps} />` (App.tsx -54 lines net).
- [x] Export `SortControlProps` from `SortControl.tsx` as the single source of truth for the control's prop shape.
- [x] Name "Frozen order" in `CONTEXT.md` (List ordering) — the held-order behaviour the hook owns.

### Test Verification

- [x] New `useChatOrder.test.tsx` (`renderHook`) — the integration that previously had no test surface: initial load sorted by preference + deleted excluded; trash view resolves filter + config; order frozen across a background change under the same signal; newly-appearing chat slots into sorted position while the rest hold; user sort change re-sorts; flush-signal change re-sorts with latest data.
- [x] Existing `App.test.tsx` freeze/flush integration tests retained as regression guard — 113 web unit tests pass.
- [x] `pnpm typecheck`, `pnpm lint`, and the Playwright e2e all pass.

## Additional Notes

A pure `nextSortState` reducer extraction from `useFrozenSort` is deliberately **out of scope** — tracked as a conditional fast-follow in #112, to be done only if the `renderHook` freeze-edge tests prove painful or freeze logic grows. They did not, so it is not triggered here.

## Related Links

- Closes #111
- Fast-follow: #112