### PR TITLE
refactor(api): give ingestion a write seam on ArchiveRepository

### DIFF
--- a/api/src/archive/repository-write.test.ts
+++ b/api/src/archive/repository-write.test.ts
@@ -1,0 +1,240 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createArchiveRepository } from "./repository.js";
+import { chats, ingestionEvents, messages, rawMessages } from "./schema.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "chat-logbook-archive-write-")
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("ArchiveRepository write seam", () => {
+  it("insertRawMessage inserts once and dedupes a repeat (agent, source_id, payload_hash)", () => {
+    const repo = createArchiveRepository({ dataDir });
+    const input = {
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/src/session-1.jsonl",
+      sourceLocator: "line:1",
+      payload: { role: "user", content: "hello" },
+      ingestedAt: new Date(),
+    };
+
+    const first = repo.insertRawMessage(input);
+    expect(first.inserted).toBe(true);
+    expect(first.id).toBeTypeOf("number");
+
+    const second = repo.insertRawMessage(input);
+    expect(second.inserted).toBe(false);
+    expect(second.id).toBe(first.id);
+
+    repo.close();
+  });
+
+  it("insertRawMessage appends a new row when the payload differs", () => {
+    const repo = createArchiveRepository({ dataDir });
+    const base = {
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/src/session-1.jsonl",
+      sourceLocator: "line:1",
+      ingestedAt: new Date(),
+    };
+
+    const first = repo.insertRawMessage({
+      ...base,
+      payload: { role: "user", content: "hello" },
+    });
+    const second = repo.insertRawMessage({
+      ...base,
+      payload: { role: "user", content: "goodbye" },
+    });
+
+    expect(first.inserted).toBe(true);
+    expect(second.inserted).toBe(true);
+    expect(second.id).not.toBe(first.id);
+
+    repo.close();
+  });
+
+  it("upsertNormalizedMessage inserts a message when none exists for the canonical key", () => {
+    const repo = createArchiveRepository({ dataDir });
+    const raw = repo.insertRawMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/src/session-1.jsonl",
+      sourceLocator: "line:1",
+      payload: { role: "user", content: "hello" },
+      ingestedAt: new Date(),
+    });
+
+    const upserted = repo.upsertNormalizedMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      message: {
+        messageId: "m1",
+        role: "user",
+        ts: "2024-01-01T00:00:00Z",
+        text: "hello",
+        blocks: [{ type: "text", text: "hello" }],
+      },
+      rawId: raw.id,
+    });
+
+    expect(upserted).toBe(true);
+
+    const rows = repo.db.select().from(messages).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].messageId).toBe("m1");
+    expect(rows[0].text).toBe("hello");
+    expect(rows[0].ts.getTime()).toBe(
+      new Date("2024-01-01T00:00:00Z").getTime()
+    );
+
+    repo.close();
+  });
+
+  it("upsertNormalizedMessage is last-write-wins: a newer ts overwrites, an older ts is dropped", () => {
+    const repo = createArchiveRepository({ dataDir });
+    const raw = repo.insertRawMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/src/session-1.jsonl",
+      sourceLocator: "line:1",
+      payload: { role: "user", content: "v1" },
+      ingestedAt: new Date(),
+    });
+
+    const base = {
+      agent: "claude-code",
+      sourceId: "session-1",
+      rawId: raw.id,
+    };
+
+    repo.upsertNormalizedMessage({
+      ...base,
+      message: {
+        messageId: "m1",
+        role: "user",
+        ts: "2024-01-01T00:00:00Z",
+        text: "v1",
+        blocks: [{ type: "text", text: "v1" }],
+      },
+    });
+
+    // Newer ts wins.
+    const newer = repo.upsertNormalizedMessage({
+      ...base,
+      message: {
+        messageId: "m1",
+        role: "user",
+        ts: "2024-01-02T00:00:00Z",
+        text: "v2",
+        blocks: [{ type: "text", text: "v2" }],
+      },
+    });
+    expect(newer).toBe(true);
+
+    // Older ts is dropped.
+    const older = repo.upsertNormalizedMessage({
+      ...base,
+      message: {
+        messageId: "m1",
+        role: "user",
+        ts: "2023-12-31T00:00:00Z",
+        text: "stale",
+        blocks: [{ type: "text", text: "stale" }],
+      },
+    });
+    expect(older).toBe(false);
+
+    const rows = repo.db.select().from(messages).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text).toBe("v2");
+    expect(rows[0].ts.getTime()).toBe(
+      new Date("2024-01-02T00:00:00Z").getTime()
+    );
+
+    repo.close();
+  });
+
+  it("ensureChat returns a stable id and back-fills project/projectPath on a later call", () => {
+    const repo = createArchiveRepository({ dataDir });
+
+    // First seen with no project info.
+    const id = repo.ensureChat("claude-code", "session-1", new Date());
+    expect(id).toBeTypeOf("string");
+
+    const beforeRow = repo.db
+      .select()
+      .from(chats)
+      .where(eq(chats.id, id))
+      .get();
+    expect(beforeRow?.project).toBeNull();
+    expect(beforeRow?.chatId).toHaveLength(6);
+
+    // Later scan resolves the project: same id, fields filled in.
+    const again = repo.ensureChat(
+      "claude-code",
+      "session-1",
+      new Date(),
+      "project-a",
+      "/Users/test/project-a"
+    );
+    expect(again).toBe(id);
+
+    const afterRow = repo.db.select().from(chats).where(eq(chats.id, id)).get();
+    expect(afterRow?.project).toBe("project-a");
+    expect(afterRow?.projectPath).toBe("/Users/test/project-a");
+
+    // Still a single chat row for the canonical (agent, source_id).
+    expect(repo.db.select().from(chats).all()).toHaveLength(1);
+
+    repo.close();
+  });
+
+  it("recordIngestionEvent writes an audit row and never deletes archive rows", () => {
+    const repo = createArchiveRepository({ dataDir });
+
+    // An existing raw row that must survive an unlink audit (ADR-0002).
+    const raw = repo.insertRawMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/src/session-1.jsonl",
+      sourceLocator: "line:1",
+      payload: { role: "user", content: "hello" },
+      ingestedAt: new Date(),
+    });
+
+    repo.recordIngestionEvent({
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/src/session-1.jsonl",
+      eventType: "unlink_observed",
+      detail: { path: "/src/session-1.jsonl" },
+    });
+
+    const events = repo.db.select().from(ingestionEvents).all();
+    expect(events).toHaveLength(1);
+    expect(events[0].eventType).toBe("unlink_observed");
+    expect(events[0].sourceId).toBe("session-1");
+    expect(events[0].detail).toEqual({ path: "/src/session-1.jsonl" });
+
+    // The unlink audit leaves the archive rows untouched.
+    const rawRows = repo.db.select().from(rawMessages).all();
+    expect(rawRows).toHaveLength(1);
+    expect(rawRows[0].id).toBe(raw.id);
+
+    repo.close();
+  });
+});

--- a/api/src/archive/repository.ts
+++ b/api/src/archive/repository.ts
@@ -8,12 +8,64 @@ import {
   type BetterSQLite3Database,
 } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import * as schema from "./schema.js";
-import { archiveMeta, chats, schemaVersion } from "./schema.js";
+import {
+  archiveMeta,
+  chats,
+  ingestionEvents,
+  messages,
+  rawMessages,
+  schemaVersion,
+} from "./schema.js";
 import { generateChatId } from "./chat-id.js";
 
 export type ArchiveDb = BetterSQLite3Database<typeof schema>;
+
+export interface InsertRawMessageInput {
+  agent: string;
+  sourceId: string;
+  sourcePath: string;
+  sourceLocator: string;
+  payload: unknown;
+  ingestedAt: Date;
+}
+
+export interface InsertRawMessageResult {
+  id: number;
+  inserted: boolean;
+}
+
+/**
+ * The normalized fields the Archive persists for one message. Mirrors a
+ * plugin's normalized output without coupling the store to the plugin layer.
+ * `ts` arrives as an ISO string and is parsed here so the last-write-wins
+ * comparison stays inside the repository.
+ */
+export interface NormalizedMessageInput {
+  messageId: string;
+  role: string;
+  ts: string;
+  text: string;
+  blocks: unknown;
+}
+
+export interface UpsertNormalizedMessageInput {
+  agent: string;
+  sourceId: string;
+  message: NormalizedMessageInput;
+  rawId: number;
+}
+
+export interface IngestionEventInput {
+  agent: string;
+  sourceId: string;
+  sourcePath: string;
+  eventType: string;
+  detail: unknown;
+  /** Defaults to now when omitted. */
+  observedAt?: Date;
+}
 
 function resolveMigrationsFolder(): string {
   const here = path.dirname(fileURLToPath(import.meta.url));
@@ -38,6 +90,37 @@ export interface ArchiveRepository {
   getArchiveUuid(): string;
   getAppliedMigrations(): AppliedMigration[];
   generateChatId(): string;
+  /**
+   * Ensure a chat row exists for the canonical key `(agent, source_id)` and
+   * return its internal id. On a row that already exists, fills in `project`
+   * and `projectPath` when a later scan resolves values the first scan lacked.
+   */
+  ensureChat(
+    agent: string,
+    sourceId: string,
+    firstSeenAt: Date,
+    project?: string,
+    projectPath?: string
+  ): string;
+  /**
+   * Append a raw message, idempotent on the content key
+   * `(agent, source_id, payload_hash)`. Returns the row id and whether this
+   * call inserted it (`false` when an identical payload was already stored).
+   * The payload hash is computed here so the idempotency key stays internal.
+   */
+  insertRawMessage(input: InsertRawMessageInput): InsertRawMessageResult;
+  /**
+   * Insert or overwrite the normalized message for the canonical key
+   * `(agent, source_id, message_id)`, last-write-wins by `ts`. Returns `true`
+   * when the row was written (inserted, or overwritten because the incoming
+   * `ts` is at least the stored one) and `false` when an older `ts` is dropped.
+   */
+  upsertNormalizedMessage(input: UpsertNormalizedMessageInput): boolean;
+  /**
+   * Append an ingestion audit row (e.g. `unlink_observed`). Audit only — it
+   * never deletes archive rows. See ADR-0002.
+   */
+  recordIngestionEvent(event: IngestionEventInput): void;
   close(): void;
 }
 
@@ -48,6 +131,12 @@ interface DrizzleMigrationRow {
 
 interface RepositoryOptions {
   dataDir: string;
+}
+
+function parseTs(ts: string): Date {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return new Date(0);
+  return d;
 }
 
 export function createArchiveRepository({
@@ -79,6 +168,17 @@ export function createArchiveRepository({
       .run();
   }
 
+  function nextChatId(): string {
+    return generateChatId({
+      isTaken: (candidate) =>
+        db
+          .select({ id: chats.id })
+          .from(chats)
+          .where(eq(chats.chatId, candidate))
+          .get() !== undefined,
+    });
+  }
+
   return {
     db,
     getArchiveUuid() {
@@ -96,14 +196,138 @@ export function createArchiveRepository({
         .map((r) => ({ version: r.version, appliedAt: r.appliedAt }));
     },
     generateChatId() {
-      return generateChatId({
-        isTaken: (candidate) =>
-          db
-            .select({ id: chats.id })
-            .from(chats)
-            .where(eq(chats.chatId, candidate))
-            .get() !== undefined,
-      });
+      return nextChatId();
+    },
+    ensureChat(agent, sourceId, firstSeenAt, project, projectPath) {
+      const existingChat = db
+        .select()
+        .from(chats)
+        .where(and(eq(chats.agent, agent), eq(chats.sourceId, sourceId)))
+        .get();
+      if (existingChat) {
+        const updates: { project?: string; projectPath?: string } = {};
+        if (project && existingChat.project !== project) {
+          updates.project = project;
+        }
+        if (projectPath && existingChat.projectPath !== projectPath) {
+          updates.projectPath = projectPath;
+        }
+        if (Object.keys(updates).length > 0) {
+          db.update(chats)
+            .set(updates)
+            .where(eq(chats.id, existingChat.id))
+            .run();
+        }
+        return existingChat.id;
+      }
+
+      const id = crypto.randomUUID();
+      db.insert(chats)
+        .values({
+          id,
+          chatId: nextChatId(),
+          agent,
+          sourceId,
+          firstSeenAt,
+          project: project ?? null,
+          projectPath: projectPath ?? null,
+        })
+        .run();
+      return id;
+    },
+    insertRawMessage(input) {
+      const payloadJson = JSON.stringify(input.payload);
+      const payloadHash = crypto
+        .createHash("sha256")
+        .update(payloadJson)
+        .digest("hex");
+
+      const existing = db
+        .select({ id: rawMessages.id })
+        .from(rawMessages)
+        .where(
+          and(
+            eq(rawMessages.agent, input.agent),
+            eq(rawMessages.sourceId, input.sourceId),
+            eq(rawMessages.payloadHash, payloadHash)
+          )
+        )
+        .get();
+      if (existing) return { id: existing.id, inserted: false };
+
+      const inserted = db
+        .insert(rawMessages)
+        .values({
+          agent: input.agent,
+          sourceId: input.sourceId,
+          sourcePath: input.sourcePath,
+          sourceLocator: input.sourceLocator,
+          rawPayload: payloadJson,
+          payloadHash,
+          ingestedAt: input.ingestedAt,
+        })
+        .returning({ id: rawMessages.id })
+        .get();
+      return { id: inserted.id, inserted: true };
+    },
+    upsertNormalizedMessage({ agent, sourceId, message, rawId }) {
+      const existing = db
+        .select()
+        .from(messages)
+        .where(
+          and(
+            eq(messages.agent, agent),
+            eq(messages.sourceId, sourceId),
+            eq(messages.messageId, message.messageId)
+          )
+        )
+        .get();
+
+      const ts = parseTs(message.ts);
+
+      if (!existing) {
+        db.insert(messages)
+          .values({
+            agent,
+            sourceId,
+            messageId: message.messageId,
+            role: message.role,
+            ts,
+            text: message.text,
+            blocks: message.blocks,
+            rawId,
+          })
+          .run();
+        return true;
+      }
+
+      if (ts.getTime() >= existing.ts.getTime()) {
+        db.update(messages)
+          .set({
+            role: message.role,
+            ts,
+            text: message.text,
+            blocks: message.blocks,
+            rawId,
+          })
+          .where(eq(messages.id, existing.id))
+          .run();
+        return true;
+      }
+
+      return false;
+    },
+    recordIngestionEvent(event) {
+      db.insert(ingestionEvents)
+        .values({
+          agent: event.agent,
+          sourceId: event.sourceId,
+          sourcePath: event.sourcePath,
+          eventType: event.eventType,
+          detail: event.detail,
+          observedAt: event.observedAt ?? new Date(),
+        })
+        .run();
     },
     close() {
       sqlite.close();

--- a/api/src/ingestion/ingest.ts
+++ b/api/src/ingestion/ingest.ts
@@ -1,14 +1,7 @@
-import crypto from "node:crypto";
 import fs from "node:fs";
-import { and, eq } from "drizzle-orm";
 import type { ArchiveRepository } from "../archive/repository.js";
-import { chats, messages, rawMessages } from "../archive/schema.js";
 import type { CheckpointRepository } from "../checkpoint/repository.js";
-import type {
-  AgentPlugin,
-  NormalizedMessage,
-  PluginEnv,
-} from "../plugins/types.js";
+import type { AgentPlugin, PluginEnv } from "../plugins/types.js";
 
 export interface IngestOptions {
   plugins: readonly AgentPlugin[];
@@ -41,8 +34,7 @@ export async function runIngestion(opts: IngestOptions): Promise<IngestResult> {
       const stat = safeStat(ref.sourcePath);
       const prior = opts.checkpoint.getScanState(plugin.id, ref.sourceId);
 
-      ensureChat(
-        opts.archive,
+      opts.archive.ensureChat(
         plugin.id,
         ref.sourceId,
         now(),
@@ -61,55 +53,25 @@ export async function runIngestion(opts: IngestOptions): Promise<IngestResult> {
       }
 
       for await (const raw of plugin.extractRaw(ref)) {
-        const payloadJson = JSON.stringify(raw.payload);
-        const payloadHash = crypto
-          .createHash("sha256")
-          .update(payloadJson)
-          .digest("hex");
-
-        const existing = opts.archive.db
-          .select({ id: rawMessages.id })
-          .from(rawMessages)
-          .where(
-            and(
-              eq(rawMessages.agent, plugin.id),
-              eq(rawMessages.sourceId, ref.sourceId),
-              eq(rawMessages.payloadHash, payloadHash)
-            )
-          )
-          .get();
-
-        let rawId: number;
-        if (existing) {
-          rawId = existing.id;
-        } else {
-          const inserted = opts.archive.db
-            .insert(rawMessages)
-            .values({
-              agent: plugin.id,
-              sourceId: ref.sourceId,
-              sourcePath: raw.sourcePath,
-              sourceLocator: raw.sourceLocator,
-              rawPayload: payloadJson,
-              payloadHash,
-              ingestedAt: now(),
-            })
-            .returning({ id: rawMessages.id })
-            .get();
-          rawId = inserted.id;
-          result.rawInserted += 1;
-        }
+        const { id: rawId, inserted } = opts.archive.insertRawMessage({
+          agent: plugin.id,
+          sourceId: ref.sourceId,
+          sourcePath: raw.sourcePath,
+          sourceLocator: raw.sourceLocator,
+          payload: raw.payload,
+          ingestedAt: now(),
+        });
+        if (inserted) result.rawInserted += 1;
 
         const normalized = plugin.normalize(raw);
         if (!normalized) continue;
 
-        const upserted = upsertNormalized(
-          opts.archive,
-          plugin.id,
-          ref.sourceId,
-          normalized,
-          rawId
-        );
+        const upserted = opts.archive.upsertNormalizedMessage({
+          agent: plugin.id,
+          sourceId: ref.sourceId,
+          message: normalized,
+          rawId,
+        });
         if (upserted) result.normalizedUpserted += 1;
       }
 
@@ -134,112 +96,4 @@ function safeStat(p: string): fs.Stats | null {
   } catch {
     return null;
   }
-}
-
-function ensureChat(
-  archive: ArchiveRepository,
-  agent: string,
-  sourceId: string,
-  firstSeenAt: Date,
-  project: string | undefined,
-  projectPath: string | undefined
-): string {
-  const existing = archive.db
-    .select()
-    .from(chats)
-    .where(and(eq(chats.agent, agent), eq(chats.sourceId, sourceId)))
-    .get();
-  if (existing) {
-    const updates: { project?: string; projectPath?: string } = {};
-    if (project && existing.project !== project) updates.project = project;
-    if (projectPath && existing.projectPath !== projectPath) {
-      updates.projectPath = projectPath;
-    }
-    if (Object.keys(updates).length > 0) {
-      archive.db
-        .update(chats)
-        .set(updates)
-        .where(eq(chats.id, existing.id))
-        .run();
-    }
-    return existing.id;
-  }
-
-  const id = crypto.randomUUID();
-  const chatId = archive.generateChatId();
-  archive.db
-    .insert(chats)
-    .values({
-      id,
-      chatId,
-      agent,
-      sourceId,
-      firstSeenAt,
-      project: project ?? null,
-      projectPath: projectPath ?? null,
-    })
-    .run();
-  return id;
-}
-
-function upsertNormalized(
-  archive: ArchiveRepository,
-  agent: string,
-  sourceId: string,
-  msg: NormalizedMessage,
-  rawId: number
-): boolean {
-  const existing = archive.db
-    .select()
-    .from(messages)
-    .where(
-      and(
-        eq(messages.agent, agent),
-        eq(messages.sourceId, sourceId),
-        eq(messages.messageId, msg.messageId)
-      )
-    )
-    .get();
-
-  const ts = parseTs(msg.ts);
-
-  if (!existing) {
-    archive.db
-      .insert(messages)
-      .values({
-        agent,
-        sourceId,
-        messageId: msg.messageId,
-        role: msg.role,
-        ts,
-        text: msg.text,
-        blocks: msg.blocks,
-        rawId,
-      })
-      .run();
-    return true;
-  }
-
-  if (ts.getTime() >= existing.ts.getTime()) {
-    archive.db
-      .update(messages)
-      .set({
-        role: msg.role,
-        ts,
-        text: msg.text,
-        blocks: msg.blocks,
-        rawId,
-      })
-      .where(eq(messages.id, existing.id))
-      .run();
-    return true;
-  }
-
-  return false;
-}
-
-function parseTs(ts: string): Date {
-  const d = new Date(ts);
-  if (Number.isNaN(d.getTime())) return new Date(0);
-  return d;
 }

--- a/api/src/ingestion/watcher.ts
+++ b/api/src/ingestion/watcher.ts
@@ -1,6 +1,5 @@
 import chokidar, { type FSWatcher, type ChokidarOptions } from "chokidar";
 import type { ArchiveRepository } from "../archive/repository.js";
-import { ingestionEvents } from "../archive/schema.js";
 import type { CheckpointRepository } from "../checkpoint/repository.js";
 import type { AgentPlugin, PluginEnv, ChatRef } from "../plugins/types.js";
 import { runIngestion, type IngestResult } from "./ingest.js";
@@ -95,17 +94,14 @@ export function startWatcher(opts: WatcherOptions): IngestionWatcher {
     const binding = pathBindings.get(removedPath);
     if (!binding) return;
     try {
-      opts.archive.db
-        .insert(ingestionEvents)
-        .values({
-          agent: binding.plugin.id,
-          sourceId: binding.ref.sourceId,
-          sourcePath: removedPath,
-          eventType: "unlink_observed",
-          detail: { path: removedPath },
-          observedAt: new Date(),
-        })
-        .run();
+      opts.archive.recordIngestionEvent({
+        agent: binding.plugin.id,
+        sourceId: binding.ref.sourceId,
+        sourcePath: removedPath,
+        eventType: "unlink_observed",
+        detail: { path: removedPath },
+        observedAt: new Date(),
+      });
     } catch (err) {
       onError(err);
     }


### PR DESCRIPTION
## Background (Why)

`ArchiveRepository` exposed `readonly db`, an escape hatch onto the raw drizzle handle. While `.db` was public the archive interface was shallow — its real surface was "the entire query builder", and the ingestion invariants (content-hash idempotency, last-write-wins, never-delete-on-unlink) lived scattered in `ingest.ts`/`watcher.ts` rather than behind the store.

This PR addresses the write side of #107: give ingestion a write-oriented seam so those invariants concentrate in one module and the raw handle can eventually go private.

## Approach (How)

Deepen `ArchiveRepository` into a small write interface over the SQLite/drizzle implementation. The existing helper bodies (`ensureChat`, raw insert/dedup, `upsertNormalized`, the unlink audit insert) move behind named methods on the repository; `ingest.ts` and `watcher.ts` become thin callers.

The repository keeps its own vocabulary instead of importing the plugin layer's `NormalizedMessage` — `upsertNormalizedMessage` takes a small local input type — so the store stays ignorant of plugins. `ts` parsing and the last-write-wins comparison stay inside the method.

Scoped as **Option A**: land the write seam now, defer making `db` private. `ChatReader` is still a heavy reader of `archive.db` (the windowed `listChats` queries, `getMessages`, `findChat`), so `readonly db` stays on the interface until the read path is migrated — the unfinished tail of #105, tracked in #114 / #115.

## Changes (What)

- [x] Add `ensureChat(agent, sourceId, firstSeenAt, project?, projectPath?) → internalId` — including project/projectPath back-fill on later scans
- [x] Add `insertRawMessage(input) → { id, inserted }` — content-hash idempotency on `(agent, source_id, payload_hash)` stays inside
- [x] Add `upsertNormalizedMessage(input) → boolean` — last-write-wins by `ts` stays inside
- [x] Add `recordIngestionEvent(event)` — append-only audit, never deletes (ADR-0002)
- [x] Rewire `ingest.ts` and `watcher.ts` onto the methods; neither references `archive.db` anymore
- [ ] Remove `readonly db` from the interface — **deferred to #115** (read path still needs it)

### Test Verification

New `api/src/archive/repository-write.test.ts` (6 tests) pins the invariants at the new interface:

- [x] `insertRawMessage` inserts once, dedupes an identical repeat (same id, `inserted: false`)
- [x] `insertRawMessage` appends a new row when the payload differs
- [x] `upsertNormalizedMessage` inserts when no row exists for the canonical key
- [x] `upsertNormalizedMessage` last-write-wins — newer `ts` overwrites, older `ts` is dropped
- [x] `ensureChat` returns a stable id and back-fills project/projectPath on a later call
- [x] `recordIngestionEvent` writes an audit row and leaves archive rows untouched (ADR-0002)
- [x] Full suite green — api 139, web 107; `tsc --noEmit` clean (run by the pre-commit hook)

## Additional Notes

Criterion 3 of #107 (remove `readonly db`, make the handle private) is intentionally **not** in this PR. It can only land once every production caller is off the raw handle, which means giving `ChatReader` a read seam first. Split into two follow-up slices:

- #114 — give ChatReader a read seam (unblocks the rest)
- #115 — make `archive.db` private + migrate test assertions off the raw handle (blocked by #114)

## Related Links

- Implements #107 (write seam: criteria 1, 2, 4, 5)
- Follow-ups: #114, #115