### PR TITLE
refactor(api): give ChatReader a read seam on ArchiveRepository

### DIFF
--- a/api/src/archive/read-seam.ts
+++ b/api/src/archive/read-seam.ts
@@ -1,0 +1,139 @@
+import { and, asc, eq, sql } from "drizzle-orm";
+import type { ArchiveDb } from "./repository.js";
+import { chats, messages, rawMessages } from "./schema.js";
+
+/**
+ * The Archive read seam: the deliberate, read-oriented face onto the archive
+ * tables that the Chat read path goes through instead of the raw drizzle
+ * handle. Named query primitives — not a relabeled query builder — so the raw
+ * handle can become private without the read path losing access. ChatReader
+ * owns the derivation (titles, ts fallback, visibility); this owns the SQL.
+ */
+
+export type ChatRow = typeof chats.$inferSelect;
+export type MessageRow = typeof messages.$inferSelect;
+
+/** Per `(agent, source_id)` first/last message timestamps for a chat. */
+export interface ChatTsRange {
+  agent: string;
+  sourceId: string;
+  minTs: number | null;
+  maxTs: number | null;
+}
+
+/** The source file path of the most-recently-ingested raw row for a chat. */
+export interface LatestRawSourcePath {
+  agent: string;
+  sourceId: string;
+  sourcePath: string;
+}
+
+/** The earliest user message text for a chat, by message timestamp. */
+export interface FirstUserText {
+  agent: string;
+  sourceId: string;
+  text: string;
+}
+
+export interface ArchiveReadSeam {
+  /** Every chat row, in insertion order. */
+  listChatRows(): ChatRow[];
+  /** Resolve a chat by its source id; null when absent. */
+  findChatBySourceId(sourceId: string): ChatRow | null;
+  /** Messages for one `(agent, source_id)` chat, ordered by ascending ts. */
+  listMessagesByChat(agent: string, sourceId: string): MessageRow[];
+  /**
+   * One grouped row per `(agent, source_id)` with the min/max message ts.
+   * A single grouped query — constant query count regardless of chat count.
+   */
+  listChatTsRanges(): ChatTsRange[];
+  /**
+   * The latest-ingested raw source path per `(agent, source_id)`, resolved
+   * with a windowed query so listing N chats stays a constant query count.
+   */
+  listLatestRawSourcePaths(): LatestRawSourcePath[];
+  /**
+   * The earliest user message text per `(agent, source_id)`, resolved with a
+   * windowed query so listing N chats stays a constant query count.
+   */
+  listFirstUserTexts(): FirstUserText[];
+}
+
+export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
+  return {
+    listChatRows() {
+      return db.select().from(chats).all();
+    },
+    findChatBySourceId(sourceId) {
+      return (
+        db.select().from(chats).where(eq(chats.sourceId, sourceId)).get() ??
+        null
+      );
+    },
+    listMessagesByChat(agent, sourceId) {
+      return db
+        .select()
+        .from(messages)
+        .where(and(eq(messages.agent, agent), eq(messages.sourceId, sourceId)))
+        .orderBy(asc(messages.ts))
+        .all();
+    },
+    listChatTsRanges() {
+      return db
+        .select({
+          agent: messages.agent,
+          sourceId: messages.sourceId,
+          minTs: sql<number | null>`min(${messages.ts})`,
+          maxTs: sql<number | null>`max(${messages.ts})`,
+        })
+        .from(messages)
+        .groupBy(messages.agent, messages.sourceId)
+        .all();
+    },
+    listLatestRawSourcePaths() {
+      const ranked = db
+        .select({
+          agent: rawMessages.agent,
+          sourceId: rawMessages.sourceId,
+          sourcePath: rawMessages.sourcePath,
+          rn: sql<number>`row_number() over (partition by ${rawMessages.agent}, ${rawMessages.sourceId} order by ${rawMessages.ingestedAt} desc)`.as(
+            "rn"
+          ),
+        })
+        .from(rawMessages)
+        .as("ranked_raw");
+      return db
+        .select({
+          agent: ranked.agent,
+          sourceId: ranked.sourceId,
+          sourcePath: ranked.sourcePath,
+        })
+        .from(ranked)
+        .where(eq(ranked.rn, 1))
+        .all();
+    },
+    listFirstUserTexts() {
+      const ranked = db
+        .select({
+          agent: messages.agent,
+          sourceId: messages.sourceId,
+          text: messages.text,
+          rn: sql<number>`row_number() over (partition by ${messages.agent}, ${messages.sourceId} order by ${messages.ts} asc)`.as(
+            "rn"
+          ),
+        })
+        .from(messages)
+        .where(eq(messages.role, "user"))
+        .as("ranked_user");
+      return db
+        .select({
+          agent: ranked.agent,
+          sourceId: ranked.sourceId,
+          text: ranked.text,
+        })
+        .from(ranked)
+        .where(eq(ranked.rn, 1))
+        .all();
+    },
+  };
+}

--- a/api/src/archive/repository.ts
+++ b/api/src/archive/repository.ts
@@ -19,6 +19,7 @@ import {
   schemaVersion,
 } from "./schema.js";
 import { generateChatId } from "./chat-id.js";
+import { createArchiveReadSeam, type ArchiveReadSeam } from "./read-seam.js";
 
 export type ArchiveDb = BetterSQLite3Database<typeof schema>;
 
@@ -87,6 +88,12 @@ export interface AppliedMigration {
 
 export interface ArchiveRepository {
   readonly db: ArchiveDb;
+  /**
+   * The read seam for the Chat read path. Named read primitives the reader
+   * composes into the public Chat/Message JSON, so the read path never touches
+   * the raw drizzle handle.
+   */
+  readonly read: ArchiveReadSeam;
   getArchiveUuid(): string;
   getAppliedMigrations(): AppliedMigration[];
   generateChatId(): string;
@@ -181,6 +188,7 @@ export function createArchiveRepository({
 
   return {
     db,
+    read: createArchiveReadSeam(db),
     getArchiveUuid() {
       const row = db.select().from(archiveMeta).get();
       if (!row) {

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -1,21 +1,17 @@
-import { and, asc, eq, sql } from "drizzle-orm";
 import type { ArchiveRepository } from "./archive/repository.js";
-import {
-  chats as archiveChats,
-  messages as archiveMessages,
-  rawMessages as archiveRawMessages,
-} from "./archive/schema.js";
+import type { ChatRow } from "./archive/read-seam.js";
 import type { MetadataRepository } from "./metadata/repository.js";
 import { loadChatVisibility } from "./visibility.js";
 
 /**
  * The Chat read face. At read time it composes Archive + Metadata into the
  * outward Chat/Message shapes the API serves — a read-time derivation, not a
- * materialized store. Owns every query that turns Archive rows into the
- * public Chat/Message JSON, so the HTTP layer never writes drizzle.
+ * materialized store. Owns the derivation that turns Archive rows into the
+ * public Chat/Message JSON; the raw queries live behind `archive.read`, the
+ * Archive read seam, so this never touches the drizzle handle.
  */
 
-export type ChatRecord = typeof archiveChats.$inferSelect;
+export type ChatRecord = ChatRow;
 
 export interface ChatResponse {
   id: string;
@@ -84,13 +80,7 @@ export function createChatReader({
   metadata,
 }: ChatReaderDeps): ChatReader {
   function findChat(id: string): ChatRecord | null {
-    return (
-      archive.db
-        .select()
-        .from(archiveChats)
-        .where(eq(archiveChats.sourceId, id))
-        .get() ?? null
-    );
+    return archive.read.findChatBySourceId(id);
   }
 
   function deriveTitle(
@@ -114,72 +104,25 @@ export function createChatReader({
     includeTrashed: boolean;
   }): ChatResponse[] {
     const visibility = loadChatVisibility(metadata, { includeTrashed });
-    const rows = archive.db.select().from(archiveChats).all();
+    const rows = archive.read.listChatRows();
 
     // One grouped/windowed query per derived field, assembled in memory keyed
     // by (agent, source_id) — so listing N chats stays a constant query count
     // rather than ~3 per row. See issue #106.
-    const tsRangeRows = archive.db
-      .select({
-        agent: archiveMessages.agent,
-        sourceId: archiveMessages.sourceId,
-        minTs: sql<number | null>`min(${archiveMessages.ts})`,
-        maxTs: sql<number | null>`max(${archiveMessages.ts})`,
-      })
-      .from(archiveMessages)
-      .groupBy(archiveMessages.agent, archiveMessages.sourceId)
-      .all();
     const tsRangeByKey = new Map(
-      tsRangeRows.map((r) => [key(r.agent, r.sourceId), r])
+      archive.read.listChatTsRanges().map((r) => [key(r.agent, r.sourceId), r])
     );
 
-    const rankedRaw = archive.db
-      .select({
-        agent: archiveRawMessages.agent,
-        sourceId: archiveRawMessages.sourceId,
-        sourcePath: archiveRawMessages.sourcePath,
-        rn: sql<number>`row_number() over (partition by ${archiveRawMessages.agent}, ${archiveRawMessages.sourceId} order by ${archiveRawMessages.ingestedAt} desc)`.as(
-          "rn"
-        ),
-      })
-      .from(archiveRawMessages)
-      .as("ranked_raw");
-    const latestRawRows = archive.db
-      .select({
-        agent: rankedRaw.agent,
-        sourceId: rankedRaw.sourceId,
-        sourcePath: rankedRaw.sourcePath,
-      })
-      .from(rankedRaw)
-      .where(eq(rankedRaw.rn, 1))
-      .all();
     const sourcePathByKey = new Map(
-      latestRawRows.map((r) => [key(r.agent, r.sourceId), r.sourcePath])
+      archive.read
+        .listLatestRawSourcePaths()
+        .map((r) => [key(r.agent, r.sourceId), r.sourcePath])
     );
 
-    const rankedUser = archive.db
-      .select({
-        agent: archiveMessages.agent,
-        sourceId: archiveMessages.sourceId,
-        text: archiveMessages.text,
-        rn: sql<number>`row_number() over (partition by ${archiveMessages.agent}, ${archiveMessages.sourceId} order by ${archiveMessages.ts} asc)`.as(
-          "rn"
-        ),
-      })
-      .from(archiveMessages)
-      .where(eq(archiveMessages.role, "user"))
-      .as("ranked_user");
-    const firstUserRows = archive.db
-      .select({
-        agent: rankedUser.agent,
-        sourceId: rankedUser.sourceId,
-        text: rankedUser.text,
-      })
-      .from(rankedUser)
-      .where(eq(rankedUser.rn, 1))
-      .all();
     const firstUserTextByKey = new Map(
-      firstUserRows.map((r) => [key(r.agent, r.sourceId), r.text])
+      archive.read
+        .listFirstUserTexts()
+        .map((r) => [key(r.agent, r.sourceId), r.text])
     );
 
     const customTitleById = metadata.listCustomTitles();
@@ -224,17 +167,7 @@ export function createChatReader({
     const visibility = loadChatVisibility(metadata, { includeTrashed });
     if (!visibility.isVisible(row.id)) return null;
 
-    const rows = archive.db
-      .select()
-      .from(archiveMessages)
-      .where(
-        and(
-          eq(archiveMessages.agent, row.agent),
-          eq(archiveMessages.sourceId, row.sourceId)
-        )
-      )
-      .orderBy(asc(archiveMessages.ts))
-      .all();
+    const rows = archive.read.listMessagesByChat(row.agent, row.sourceId);
 
     return rows.map((m) => ({
       role: m.role as "user" | "assistant",


### PR DESCRIPTION
## Background (Why)

After #107 the write paths go through `ArchiveRepository` write methods and no longer touch `archive.db`. The read path still did: `ChatReader` reached straight through the raw drizzle handle for the windowed/grouped `listChats` queries, plus `getMessages` and `findChat`. While `ChatReader` owns the raw query builder, `ArchiveRepository`'s real read surface is "the entire query builder" — a shallow seam, and the unfinished read-side tail of the #105 ChatReader extraction.

This gives `ChatReader` a deliberate, read-oriented seam so its production code stops reaching through `archive.db`. It also unblocks making the raw handle private later (#107).

## Approach (How)

A named-method read seam, not a relabeled handle. A relabeled `{ db }` handle is still the whole query builder — the shallow seam this set out to kill, and it would leave `.db` impossible to make private. Named primitives are what let the raw handle go private later.

- New `ArchiveReadSeam` interface in `api/src/archive/read-seam.ts`, built by `createArchiveReadSeam(db)`, exposing the exact read primitives the Chat read path needs.
- `ArchiveRepository` exposes `readonly read: ArchiveReadSeam`; the windowed/grouped SQL moves into the seam. Per the issue scope, `readonly db` stays on the interface for now.
- `ChatReader` keeps the derivation it owns per `docs/ARCHITECTURE.md` (title fallback, ts fallback, `(agent, source_id)` keying, visibility join) and composes the seam instead of writing drizzle.

## Changes (What)

- [x] Add `api/src/archive/read-seam.ts`: `ArchiveReadSeam` with `listChatRows`, `findChatBySourceId`, `listMessagesByChat`, `listChatTsRanges`, `listLatestRawSourcePaths`, `listFirstUserTexts`.
- [x] `ArchiveRepository` exposes `readonly read` wired to `createArchiveReadSeam(db)`.
- [x] `ChatReader` reads through `archive.read.*`; drops all `drizzle-orm` and schema imports; `ChatRecord` is aliased from the seam's `ChatRow`.

### Test Verification

Behavior-preserving refactor driven under the existing green suite (no test changes).

- [x] Existing read-path tests pass unchanged (`chat-reader.test.ts`, 24 tests).
- [x] `listChats` keeps constant-query-count behavior (the #106 batching test stays green).
- [x] `getMessages` / `findChat` 404 + visibility semantics unchanged (`app.test.ts`).
- [x] Full `api` suite green: 139/139. `pnpm typecheck` clean.

## Additional Notes

`readonly db` is intentionally still on the `ArchiveRepository` interface — making it private is the next slice (#107). Some tests still read `archive.db` for seeding/assertions; migrating those is also a later slice.

## Related Links

- Closes #114
- Parent: #107
- Follows #105 (ChatReader extraction), #106 (listChats batching)