### PR TITLE
refactor(api): make ArchiveRepository.db private; migrate tests off the raw handle

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -5,11 +5,6 @@ import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { createApp } from "./app.js";
 import { createArchiveRepository } from "./archive/repository.js";
 import { createMetadataRepository } from "./metadata/repository.js";
-import {
-  chats as archiveChats,
-  rawMessages as archiveRawMessages,
-  messages as archiveMessages,
-} from "./archive/schema.js";
 
 interface ChatResponse {
   id: string;
@@ -35,26 +30,22 @@ interface MessageResponse {
   timestamp: string;
 }
 
+const DEFAULT_AGENT = "claude-code";
+
 function seedChat(
   archive: ReturnType<typeof createArchiveRepository>,
   opts: {
-    internalId: string;
     sourceId: string;
     firstSeenAt: Date;
     project?: string | null;
   }
-): void {
-  archive.db
-    .insert(archiveChats)
-    .values({
-      id: opts.internalId,
-      chatId: opts.internalId.slice(0, 6).toUpperCase(),
-      agent: "claude-code",
-      sourceId: opts.sourceId,
-      firstSeenAt: opts.firstSeenAt,
-      project: opts.project ?? null,
-    })
-    .run();
+): string {
+  return archive.ensureChat(
+    DEFAULT_AGENT,
+    opts.sourceId,
+    opts.firstSeenAt,
+    opts.project ?? undefined
+  );
 }
 
 function seedMessage(
@@ -68,32 +59,27 @@ function seedMessage(
     blocks: unknown[];
   }
 ): void {
-  const rawRow = archive.db
-    .insert(archiveRawMessages)
-    .values({
-      agent: "claude-code",
-      sourceId: opts.sourceId,
-      sourcePath: "/dev/null",
-      sourceLocator: `${opts.messageId}:0`,
-      rawPayload: JSON.stringify({ id: opts.messageId }),
-      payloadHash: `hash-${opts.messageId}`,
-      ingestedAt: opts.ts,
-    })
-    .returning({ id: archiveRawMessages.id })
-    .get();
-  archive.db
-    .insert(archiveMessages)
-    .values({
-      agent: "claude-code",
-      sourceId: opts.sourceId,
+  archive.ensureChat(DEFAULT_AGENT, opts.sourceId, opts.ts);
+  const raw = archive.insertRawMessage({
+    agent: DEFAULT_AGENT,
+    sourceId: opts.sourceId,
+    sourcePath: "/dev/null",
+    sourceLocator: `${opts.messageId}:0`,
+    payload: { id: opts.messageId },
+    ingestedAt: opts.ts,
+  });
+  archive.upsertNormalizedMessage({
+    agent: DEFAULT_AGENT,
+    sourceId: opts.sourceId,
+    rawId: raw.id,
+    message: {
       messageId: opts.messageId,
       role: opts.role,
-      ts: opts.ts,
+      ts: opts.ts.toISOString(),
       text: opts.text,
       blocks: opts.blocks,
-      rawId: rawRow.id,
-    })
-    .run();
+    },
+  });
 }
 
 let dataDir: string;
@@ -111,7 +97,6 @@ describe("Soft delete and restore (archive-backed)", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -128,7 +113,6 @@ describe("Soft delete and restore (archive-backed)", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -148,7 +132,6 @@ describe("Soft delete and restore (archive-backed)", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -169,7 +152,6 @@ describe("Soft delete and restore (archive-backed)", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -177,8 +159,8 @@ describe("Soft delete and restore (archive-backed)", () => {
     const app = createApp({ archive, metadata });
     await app.request("/api/chats/session-1", { method: "DELETE" });
 
-    const rows = archive.db.select().from(archiveChats).all();
-    expect(rows.map((r) => r.sourceId)).toContain("session-1");
+    const row = archive.read.findChatBySourceId("session-1");
+    expect(row?.sourceId).toBe("session-1");
   });
 });
 
@@ -187,7 +169,6 @@ describe("GET /api/chats/:id visibility", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -211,7 +192,6 @@ describe("GET /api/chats/:id visibility", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -237,7 +217,6 @@ describe("GET /api/chats/:id visibility", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -278,7 +257,6 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -298,7 +276,6 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -316,7 +293,6 @@ describe("PATCH /api/chats/:id/title", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -346,8 +322,7 @@ describe("PATCH /api/chats/:id/title", () => {
   it("clears the custom title when an empty string is sent, reverting to derived", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
-    seedChat(archive, {
-      internalId: "internal-uuid-1",
+    const internalId = seedChat(archive, {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -359,7 +334,7 @@ describe("PATCH /api/chats/:id/title", () => {
       text: "Build a login page",
       blocks: [{ type: "text", text: "Build a login page" }],
     });
-    metadata.setCustomTitle("internal-uuid-1", "Custom");
+    metadata.setCustomTitle(internalId, "Custom");
 
     const app = createApp({ archive, metadata });
     const patch = await app.request("/api/chats/session-1/title", {
@@ -378,12 +353,11 @@ describe("PATCH /api/chats/:id/title", () => {
   it("treats whitespace-only title as a clear", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
-    seedChat(archive, {
-      internalId: "internal-uuid-1",
+    const internalId = seedChat(archive, {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
-    metadata.setCustomTitle("internal-uuid-1", "Custom");
+    metadata.setCustomTitle(internalId, "Custom");
 
     const app = createApp({ archive, metadata });
     const patch = await app.request("/api/chats/session-1/title", {
@@ -403,7 +377,6 @@ describe("PATCH /api/chats/:id/title", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -438,7 +411,6 @@ describe("PATCH /api/chats/:id/title", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -456,7 +428,6 @@ describe("PATCH /api/chats/:id/title", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });

--- a/api/src/archive/read-seam.ts
+++ b/api/src/archive/read-seam.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, sql } from "drizzle-orm";
 import type { ArchiveDb } from "./repository.js";
-import { chats, messages, rawMessages } from "./schema.js";
+import { chats, ingestionEvents, messages, rawMessages } from "./schema.js";
 
 /**
  * The Archive read seam: the deliberate, read-oriented face onto the archive
@@ -12,6 +12,7 @@ import { chats, messages, rawMessages } from "./schema.js";
 
 export type ChatRow = typeof chats.$inferSelect;
 export type MessageRow = typeof messages.$inferSelect;
+export type IngestionEventRow = typeof ingestionEvents.$inferSelect;
 
 /** Per `(agent, source_id)` first/last message timestamps for a chat. */
 export interface ChatTsRange {
@@ -57,6 +58,8 @@ export interface ArchiveReadSeam {
    * windowed query so listing N chats stays a constant query count.
    */
   listFirstUserTexts(): FirstUserText[];
+  /** Every ingestion-event audit row, in insertion order. */
+  listIngestionEvents(): IngestionEventRow[];
 }
 
 export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
@@ -134,6 +137,9 @@ export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
         .from(ranked)
         .where(eq(ranked.rn, 1))
         .all();
+    },
+    listIngestionEvents() {
+      return db.select().from(ingestionEvents).all();
     },
   };
 }

--- a/api/src/archive/repository-write.test.ts
+++ b/api/src/archive/repository-write.test.ts
@@ -1,10 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createArchiveRepository } from "./repository.js";
-import { chats, ingestionEvents, messages, rawMessages } from "./schema.js";
 
 let dataDir: string;
 
@@ -93,7 +91,7 @@ describe("ArchiveRepository write seam", () => {
 
     expect(upserted).toBe(true);
 
-    const rows = repo.db.select().from(messages).all();
+    const rows = repo.read.listMessagesByChat("claude-code", "session-1");
     expect(rows).toHaveLength(1);
     expect(rows[0].messageId).toBe("m1");
     expect(rows[0].text).toBe("hello");
@@ -158,7 +156,7 @@ describe("ArchiveRepository write seam", () => {
     });
     expect(older).toBe(false);
 
-    const rows = repo.db.select().from(messages).all();
+    const rows = repo.read.listMessagesByChat("claude-code", "session-1");
     expect(rows).toHaveLength(1);
     expect(rows[0].text).toBe("v2");
     expect(rows[0].ts.getTime()).toBe(
@@ -175,11 +173,8 @@ describe("ArchiveRepository write seam", () => {
     const id = repo.ensureChat("claude-code", "session-1", new Date());
     expect(id).toBeTypeOf("string");
 
-    const beforeRow = repo.db
-      .select()
-      .from(chats)
-      .where(eq(chats.id, id))
-      .get();
+    const beforeRow = repo.read.findChatBySourceId("session-1");
+    expect(beforeRow?.id).toBe(id);
     expect(beforeRow?.project).toBeNull();
     expect(beforeRow?.chatId).toHaveLength(6);
 
@@ -193,12 +188,13 @@ describe("ArchiveRepository write seam", () => {
     );
     expect(again).toBe(id);
 
-    const afterRow = repo.db.select().from(chats).where(eq(chats.id, id)).get();
+    const afterRow = repo.read.findChatBySourceId("session-1");
+    expect(afterRow?.id).toBe(id);
     expect(afterRow?.project).toBe("project-a");
     expect(afterRow?.projectPath).toBe("/Users/test/project-a");
 
     // Still a single chat row for the canonical (agent, source_id).
-    expect(repo.db.select().from(chats).all()).toHaveLength(1);
+    expect(repo.read.listChatRows()).toHaveLength(1);
 
     repo.close();
   });
@@ -207,14 +203,15 @@ describe("ArchiveRepository write seam", () => {
     const repo = createArchiveRepository({ dataDir });
 
     // An existing raw row that must survive an unlink audit (ADR-0002).
-    const raw = repo.insertRawMessage({
+    const rawInput = {
       agent: "claude-code",
       sourceId: "session-1",
       sourcePath: "/src/session-1.jsonl",
       sourceLocator: "line:1",
       payload: { role: "user", content: "hello" },
       ingestedAt: new Date(),
-    });
+    };
+    const raw = repo.insertRawMessage(rawInput);
 
     repo.recordIngestionEvent({
       agent: "claude-code",
@@ -224,16 +221,18 @@ describe("ArchiveRepository write seam", () => {
       detail: { path: "/src/session-1.jsonl" },
     });
 
-    const events = repo.db.select().from(ingestionEvents).all();
+    const events = repo.read.listIngestionEvents();
     expect(events).toHaveLength(1);
     expect(events[0].eventType).toBe("unlink_observed");
     expect(events[0].sourceId).toBe("session-1");
     expect(events[0].detail).toEqual({ path: "/src/session-1.jsonl" });
 
-    // The unlink audit leaves the archive rows untouched.
-    const rawRows = repo.db.select().from(rawMessages).all();
-    expect(rawRows).toHaveLength(1);
-    expect(rawRows[0].id).toBe(raw.id);
+    // The unlink audit leaves the archive rows untouched: a repeat insert of
+    // the same payload dedupes to the original raw row, proving it still
+    // exists with the same id.
+    const repeat = repo.insertRawMessage(rawInput);
+    expect(repeat.inserted).toBe(false);
+    expect(repeat.id).toBe(raw.id);
 
     repo.close();
   });

--- a/api/src/archive/repository.test.ts
+++ b/api/src/archive/repository.test.ts
@@ -6,7 +6,6 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createArchiveRepository } from "./repository.js";
 import { CROCKFORD_ALPHABET } from "./chat-id.js";
-import { chats } from "./schema.js";
 
 const FIXTURE_DIR = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -60,23 +59,18 @@ describe("ArchiveRepository", () => {
     const repo = createArchiveRepository({ dataDir });
     const allowed = new Set(CROCKFORD_ALPHABET);
 
-    const first = repo.generateChatId();
-    expect(first).toHaveLength(6);
-    for (const ch of first) expect(allowed.has(ch)).toBe(true);
-
-    repo.db
-      .insert(chats)
-      .values({
-        id: "id-1",
-        chatId: first,
-        agent: "claude-code",
-        sourceId: "a",
-        firstSeenAt: new Date(),
-      })
-      .run();
+    // Seed a real chat so its chat_id is taken; ensureChat assigns the id via
+    // the same generateChatId path, so its taken-set behavior is what we want
+    // subsequent calls to avoid.
+    repo.ensureChat("claude-code", "a", new Date());
+    const seeded = repo.read.findChatBySourceId("a");
+    expect(seeded).not.toBeNull();
+    const taken = seeded!.chatId;
+    expect(taken).toHaveLength(6);
+    for (const ch of taken) expect(allowed.has(ch)).toBe(true);
 
     for (let i = 0; i < 20; i++) {
-      expect(repo.generateChatId()).not.toBe(first);
+      expect(repo.generateChatId()).not.toBe(taken);
     }
 
     repo.close();

--- a/api/src/archive/repository.ts
+++ b/api/src/archive/repository.ts
@@ -87,7 +87,6 @@ export interface AppliedMigration {
 }
 
 export interface ArchiveRepository {
-  readonly db: ArchiveDb;
   /**
    * The read seam for the Chat read path. Named read primitives the reader
    * composes into the public Chat/Message JSON, so the read path never touches
@@ -187,7 +186,6 @@ export function createArchiveRepository({
   }
 
   return {
-    db,
     read: createArchiveReadSeam(db),
     getArchiveUuid() {
       const row = db.select().from(archiveMeta).get();

--- a/api/src/archive/schema.test.ts
+++ b/api/src/archive/schema.test.ts
@@ -1,23 +1,42 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import Database from "better-sqlite3";
 import { eq } from "drizzle-orm";
+import {
+  drizzle,
+  type BetterSQLite3Database,
+} from "drizzle-orm/better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createArchiveRepository,
   type ArchiveRepository,
 } from "./repository.js";
+import * as schema from "./schema.js";
 import { chats, ingestionEvents, messages, rawMessages } from "./schema.js";
+
+// These tests pin schema-level guarantees (UNIQUE constraints, JSON
+// round-trips) that live below the repository's named write methods. The
+// repository's write seam applies idempotency and last-write-wins, so a
+// raw-constraint failure would never surface through it — instead the tests
+// open their own drizzle handle on the migrated `archive.db` file. The
+// repository's handle stays private; this connection is the test's own.
 
 let dataDir: string;
 let repo: ArchiveRepository;
+let db: BetterSQLite3Database<typeof schema>;
+let testSqlite: Database.Database;
 
 beforeEach(() => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-archive-"));
+  // Creating the repository applies the migrations the test schema relies on.
   repo = createArchiveRepository({ dataDir });
+  testSqlite = new Database(path.join(dataDir, "archive.db"));
+  db = drizzle(testSqlite, { schema });
 });
 
 afterEach(() => {
+  testSqlite.close();
   repo.close();
   fs.rmSync(dataDir, { recursive: true, force: true });
 });
@@ -25,8 +44,7 @@ afterEach(() => {
 describe("chats table", () => {
   it("round-trips a chat row", () => {
     const now = new Date();
-    repo.db
-      .insert(chats)
+    db.insert(chats)
       .values({
         id: "11111111-1111-4111-8111-111111111111",
         chatId: "abc234",
@@ -36,7 +54,7 @@ describe("chats table", () => {
       })
       .run();
 
-    const row = repo.db
+    const row = db
       .select()
       .from(chats)
       .where(eq(chats.id, "11111111-1111-4111-8111-111111111111"))
@@ -57,13 +75,12 @@ describe("chats table", () => {
       sourceId: "dup",
       firstSeenAt: new Date(),
     };
-    repo.db
-      .insert(chats)
+    db.insert(chats)
       .values({ ...base, id: "id-1", chatId: "aaa111" })
       .run();
 
     expect(() =>
-      repo.db
+      db
         .insert(chats)
         .values({ ...base, id: "id-2", chatId: "bbb222" })
         .run()
@@ -72,8 +89,7 @@ describe("chats table", () => {
 
   it("round-trips project_path alongside project", () => {
     const now = new Date();
-    repo.db
-      .insert(chats)
+    db.insert(chats)
       .values({
         id: "22222222-2222-4222-8222-222222222222",
         chatId: "pth111",
@@ -85,7 +101,7 @@ describe("chats table", () => {
       })
       .run();
 
-    const row = repo.db
+    const row = db
       .select()
       .from(chats)
       .where(eq(chats.id, "22222222-2222-4222-8222-222222222222"))
@@ -97,8 +113,7 @@ describe("chats table", () => {
 
   it("rejects duplicate chat_id", () => {
     const now = new Date();
-    repo.db
-      .insert(chats)
+    db.insert(chats)
       .values({
         id: "id-1",
         chatId: "same11",
@@ -109,7 +124,7 @@ describe("chats table", () => {
       .run();
 
     expect(() =>
-      repo.db
+      db
         .insert(chats)
         .values({
           id: "id-2",
@@ -126,7 +141,7 @@ describe("chats table", () => {
 describe("raw_messages table", () => {
   it("round-trips a raw_messages row", () => {
     const now = new Date();
-    const inserted = repo.db
+    const inserted = db
       .insert(rawMessages)
       .values({
         agent: "claude-code",
@@ -159,15 +174,15 @@ describe("raw_messages table", () => {
       payloadHash: "h1",
       ingestedAt: new Date(),
     };
-    repo.db.insert(rawMessages).values(base).run();
+    db.insert(rawMessages).values(base).run();
 
-    expect(() => repo.db.insert(rawMessages).values(base).run()).toThrow();
+    expect(() => db.insert(rawMessages).values(base).run()).toThrow();
   });
 });
 
 describe("messages table", () => {
   it("round-trips a messages row referencing raw_messages", () => {
-    const raw = repo.db
+    const raw = db
       .insert(rawMessages)
       .values({
         agent: "claude-code",
@@ -182,8 +197,7 @@ describe("messages table", () => {
       .get();
 
     const ts = new Date();
-    repo.db
-      .insert(messages)
+    db.insert(messages)
       .values({
         agent: "claude-code",
         sourceId: "src-1",
@@ -196,7 +210,7 @@ describe("messages table", () => {
       })
       .run();
 
-    const row = repo.db.select().from(messages).get();
+    const row = db.select().from(messages).get();
     expect(row).toMatchObject({
       messageId: "m-1",
       role: "user",
@@ -207,7 +221,7 @@ describe("messages table", () => {
   });
 
   it("rejects duplicate (agent, source_id, message_id)", () => {
-    const raw = repo.db
+    const raw = db
       .insert(rawMessages)
       .values({
         agent: "claude-code",
@@ -231,16 +245,15 @@ describe("messages table", () => {
       blocks: [],
       rawId: raw.id,
     };
-    repo.db.insert(messages).values(base).run();
+    db.insert(messages).values(base).run();
 
-    expect(() => repo.db.insert(messages).values(base).run()).toThrow();
+    expect(() => db.insert(messages).values(base).run()).toThrow();
   });
 });
 
 describe("ingestion_events table", () => {
   it("round-trips an ingestion_events row", () => {
-    repo.db
-      .insert(ingestionEvents)
+    db.insert(ingestionEvents)
       .values({
         agent: "claude-code",
         sourceId: "src-1",
@@ -251,7 +264,7 @@ describe("ingestion_events table", () => {
       })
       .run();
 
-    const row = repo.db.select().from(ingestionEvents).get();
+    const row = db.select().from(ingestionEvents).get();
     expect(row).toMatchObject({
       agent: "claude-code",
       eventType: "unlinked",

--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -5,37 +5,32 @@ import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { createChatReader } from "./chat-reader.js";
 import { createArchiveRepository } from "./archive/repository.js";
 import { createMetadataRepository } from "./metadata/repository.js";
-import {
-  chats as archiveChats,
-  rawMessages as archiveRawMessages,
-  messages as archiveMessages,
-} from "./archive/schema.js";
+import { CROCKFORD_ALPHABET } from "./archive/chat-id.js";
+import type { ArchiveReadSeam } from "./archive/read-seam.js";
 
 const DEFAULT_AGENT = "claude-code";
 
+/**
+ * Seed a chat through the write seam; returns the generated internal id so
+ * callers can pass it to metadata writes.
+ */
 function seedChat(
   archive: ReturnType<typeof createArchiveRepository>,
   opts: {
-    internalId: string;
     sourceId: string;
     firstSeenAt: Date;
     agent?: string;
     project?: string | null;
     projectPath?: string | null;
   }
-): void {
-  archive.db
-    .insert(archiveChats)
-    .values({
-      id: opts.internalId,
-      chatId: opts.internalId.slice(0, 6).toUpperCase(),
-      agent: opts.agent ?? DEFAULT_AGENT,
-      sourceId: opts.sourceId,
-      firstSeenAt: opts.firstSeenAt,
-      project: opts.project ?? null,
-      projectPath: opts.projectPath ?? null,
-    })
-    .run();
+): string {
+  return archive.ensureChat(
+    opts.agent ?? DEFAULT_AGENT,
+    opts.sourceId,
+    opts.firstSeenAt,
+    opts.project ?? undefined,
+    opts.projectPath ?? undefined
+  );
 }
 
 function seedMessage(
@@ -51,32 +46,27 @@ function seedMessage(
   }
 ): void {
   const agent = opts.agent ?? DEFAULT_AGENT;
-  const rawRow = archive.db
-    .insert(archiveRawMessages)
-    .values({
-      agent,
-      sourceId: opts.sourceId,
-      sourcePath: "/dev/null",
-      sourceLocator: `${opts.messageId}:0`,
-      rawPayload: JSON.stringify({ id: opts.messageId }),
-      payloadHash: `hash-${opts.messageId}`,
-      ingestedAt: opts.ts,
-    })
-    .returning({ id: archiveRawMessages.id })
-    .get();
-  archive.db
-    .insert(archiveMessages)
-    .values({
-      agent,
-      sourceId: opts.sourceId,
+  archive.ensureChat(agent, opts.sourceId, opts.ts);
+  const raw = archive.insertRawMessage({
+    agent,
+    sourceId: opts.sourceId,
+    sourcePath: "/dev/null",
+    sourceLocator: `${opts.messageId}:0`,
+    payload: { id: opts.messageId },
+    ingestedAt: opts.ts,
+  });
+  archive.upsertNormalizedMessage({
+    agent,
+    sourceId: opts.sourceId,
+    rawId: raw.id,
+    message: {
       messageId: opts.messageId,
       role: opts.role,
-      ts: opts.ts,
+      ts: opts.ts.toISOString(),
       text: opts.text,
       blocks: opts.blocks,
-      rawId: rawRow.id,
-    })
-    .run();
+    },
+  });
 }
 
 function seedRawMessage(
@@ -84,23 +74,23 @@ function seedRawMessage(
   opts: {
     sourceId: string;
     sourcePath: string;
-    payloadHash: string;
+    payloadKey: string;
     ingestedAt: Date;
     agent?: string;
   }
 ): void {
-  archive.db
-    .insert(archiveRawMessages)
-    .values({
-      agent: opts.agent ?? DEFAULT_AGENT,
-      sourceId: opts.sourceId,
-      sourcePath: opts.sourcePath,
-      sourceLocator: `${opts.payloadHash}:0`,
-      rawPayload: JSON.stringify({ hash: opts.payloadHash }),
-      payloadHash: opts.payloadHash,
-      ingestedAt: opts.ingestedAt,
-    })
-    .run();
+  const agent = opts.agent ?? DEFAULT_AGENT;
+  archive.ensureChat(agent, opts.sourceId, opts.ingestedAt);
+  archive.insertRawMessage({
+    agent,
+    sourceId: opts.sourceId,
+    sourcePath: opts.sourcePath,
+    sourceLocator: `${opts.payloadKey}:0`,
+    // The key only needs to make payloads unique so the content-hash dedup
+    // doesn't merge them; `insertRawMessage` hashes the payload internally.
+    payload: { key: opts.payloadKey },
+    ingestedAt: opts.ingestedAt,
+  });
 }
 
 let dataDir: string;
@@ -119,7 +109,6 @@ describe("ChatReader.listChats", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -134,7 +123,6 @@ describe("ChatReader.listChats", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
       project: "project-a",
@@ -152,7 +140,6 @@ describe("ChatReader.listChats", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -184,8 +171,7 @@ describe("ChatReader.listChats", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
 
-    seedChat(archive, {
-      internalId: "internal-uuid-1",
+    const internalId = seedChat(archive, {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -197,7 +183,7 @@ describe("ChatReader.listChats", () => {
       text: "Build a login page",
       blocks: [{ type: "text", text: "Build a login page" }],
     });
-    metadata.setCustomTitle("internal-uuid-1", "My favourite chat");
+    metadata.setCustomTitle(internalId, "My favourite chat");
 
     const reader = createChatReader({ archive, metadata });
     const chat = reader
@@ -211,7 +197,6 @@ describe("ChatReader.listChats", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -228,7 +213,6 @@ describe("ChatReader.listChats", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -262,7 +246,6 @@ describe("ChatReader.listChats", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -275,12 +258,11 @@ describe("ChatReader.listChats", () => {
     expect(chat?.updatedAt).toBe(1700000000000);
   });
 
-  it("returns chatId from the archive chat row", () => {
+  it("returns a 6-char Crockford chatId from the archive chat row", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -289,8 +271,9 @@ describe("ChatReader.listChats", () => {
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.id === "session-1");
-    // seedChat assigns chatId = internalId.slice(0, 6).toUpperCase()
-    expect(chat?.chatId).toBe("INTERN");
+    expect(chat?.chatId).toHaveLength(6);
+    const allowed = new Set(CROCKFORD_ALPHABET);
+    for (const ch of chat!.chatId) expect(allowed.has(ch)).toBe(true);
   });
 
   it("returns sourceFilePath from the most-recently-ingested raw row", () => {
@@ -298,20 +281,19 @@ describe("ChatReader.listChats", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
     seedRawMessage(archive, {
       sourceId: "session-1",
       sourcePath: "/old/path.jsonl",
-      payloadHash: "hash-old",
+      payloadKey: "hash-old",
       ingestedAt: new Date(1700000100000),
     });
     seedRawMessage(archive, {
       sourceId: "session-1",
       sourcePath: "/new/path.jsonl",
-      payloadHash: "hash-new",
+      payloadKey: "hash-new",
       ingestedAt: new Date(1700000900000),
     });
 
@@ -327,7 +309,6 @@ describe("ChatReader.listChats", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -344,7 +325,6 @@ describe("ChatReader.listChats", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -361,7 +341,6 @@ describe("ChatReader.listChats", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
       project: "chat-logbook",
@@ -380,7 +359,6 @@ describe("ChatReader.listChats", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -397,7 +375,6 @@ describe("ChatReader.listChats", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
       project: null,
@@ -415,12 +392,11 @@ describe("ChatReader visibility", () => {
   it("excludes trashed chats by default", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
-    seedChat(archive, {
-      internalId: "internal-uuid-1",
+    const internalId = seedChat(archive, {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
-    metadata.softDelete("internal-uuid-1");
+    metadata.softDelete(internalId);
 
     const reader = createChatReader({ archive, metadata });
     const chats = reader.listChats({ includeTrashed: false });
@@ -430,12 +406,11 @@ describe("ChatReader visibility", () => {
   it("includes trashed chats with isDeleted flag when includeTrashed", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
-    seedChat(archive, {
-      internalId: "internal-uuid-1",
+    const internalId = seedChat(archive, {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
-    metadata.softDelete("internal-uuid-1");
+    metadata.softDelete(internalId);
 
     const reader = createChatReader({ archive, metadata });
     const chat = reader
@@ -448,17 +423,15 @@ describe("ChatReader visibility", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     seedChat(archive, {
-      internalId: "active-uuid-1",
       sourceId: "session-active",
       firstSeenAt: new Date(1700000000000),
     });
-    seedChat(archive, {
-      internalId: "trashd-uuid-1",
+    const trashedId = seedChat(archive, {
       sourceId: "session-trashed",
       firstSeenAt: new Date(1700000000000),
     });
     const before = Date.now();
-    metadata.softDelete("trashd-uuid-1");
+    metadata.softDelete(trashedId);
 
     const reader = createChatReader({ archive, metadata });
     const chats = reader.listChats({ includeTrashed: true });
@@ -476,7 +449,6 @@ describe("ChatReader.getMessages", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -511,8 +483,7 @@ describe("ChatReader.getMessages", () => {
   it("returns null for a trashed chat by default", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
-    seedChat(archive, {
-      internalId: "internal-uuid-1",
+    const internalId = seedChat(archive, {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -524,7 +495,7 @@ describe("ChatReader.getMessages", () => {
       text: "hi",
       blocks: [{ type: "text", text: "hi" }],
     });
-    metadata.softDelete("internal-uuid-1");
+    metadata.softDelete(internalId);
 
     const reader = createChatReader({ archive, metadata });
     expect(
@@ -547,7 +518,6 @@ describe("ChatReader.getMessages", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
@@ -574,7 +544,6 @@ describe("ChatReader is agent-agnostic", () => {
     const metadata = createMetadataRepository({ dataDir });
 
     seedChat(archive, {
-      internalId: "internal-uuid-1",
       sourceId: "session-codex",
       firstSeenAt: new Date(1700000000000),
       agent: "codex",
@@ -607,35 +576,46 @@ describe("ChatReader is agent-agnostic", () => {
 });
 
 /**
- * Count how many SQLite statements execute on the archive connection while
- * `fn` runs. Wraps `prepare` so every returned statement's all/get/run is
- * tallied — this measures real query volume, independent of drizzle's
- * statement caching.
+ * Count how many archive read-seam methods are invoked while `fn` runs.
+ * The #106 invariant is "listChats issues a constant number of archive reads
+ * regardless of chat count" — each seam method maps to one underlying SQL
+ * statement, so a constant call count is the public-surface proxy for the
+ * constant SQL-statement count the original raw-handle counter measured.
  */
 function countArchiveQueries(
   archive: ReturnType<typeof createArchiveRepository>,
   fn: () => void
 ): number {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const client = (archive.db as any).$client;
-  const originalPrepare = client.prepare.bind(client);
+  const seam = archive.read;
+  const methods = [
+    "listChatRows",
+    "findChatBySourceId",
+    "listMessagesByChat",
+    "listChatTsRanges",
+    "listLatestRawSourcePaths",
+    "listFirstUserTexts",
+    "listIngestionEvents",
+  ] as const;
+  const originals: Partial<Record<(typeof methods)[number], unknown>> = {};
   let count = 0;
-  client.prepare = (source: string) => {
-    const stmt = originalPrepare(source);
-    for (const method of ["all", "get", "run"] as const) {
-      const original = stmt[method]?.bind(stmt);
-      if (!original) continue;
-      stmt[method] = (...args: unknown[]) => {
-        count += 1;
-        return original(...args);
-      };
-    }
-    return stmt;
-  };
+  for (const m of methods) {
+    originals[m] = seam[m];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (seam as any)[m] = (...args: unknown[]) => {
+      count += 1;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (originals[m] as any).call(seam, ...args);
+    };
+  }
   try {
     fn();
   } finally {
-    client.prepare = originalPrepare;
+    for (const m of methods) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (seam as unknown as Record<string, unknown>)[m] = originals[
+        m
+      ] as ArchiveReadSeam[typeof m];
+    }
   }
   return count;
 }
@@ -645,12 +625,8 @@ function seedFullChat(
   metadata: ReturnType<typeof createMetadataRepository>,
   index: number
 ): void {
-  // chat_id is derived from internalId.slice(0, 6) by seedChat, so the first
-  // six characters must be unique per chat to avoid a UNIQUE collision.
-  const internalId = `c${String(index).padStart(5, "0")}`;
   const sourceId = `session-${index}`;
-  seedChat(archive, {
-    internalId,
+  const internalId = seedChat(archive, {
     sourceId,
     firstSeenAt: new Date(1700000000000 + index),
   });
@@ -673,7 +649,7 @@ function seedFullChat(
   seedRawMessage(archive, {
     sourceId,
     sourcePath: `/path/${index}.jsonl`,
-    payloadHash: `hash-${index}`,
+    payloadKey: `hash-${index}`,
     ingestedAt: new Date(1700000900000 + index),
   });
   if (index % 2 === 0) {
@@ -724,7 +700,6 @@ describe("ChatReader.listChats query batching", () => {
     // Chat A: derives its title from the first user message, has two raw rows
     // (newest path wins) and a two-message ts-range.
     seedChat(archive, {
-      internalId: "aaaaaa-uuid",
       sourceId: "session-a",
       firstSeenAt: new Date(1700000000000),
     });
@@ -747,19 +722,18 @@ describe("ChatReader.listChats query batching", () => {
     seedRawMessage(archive, {
       sourceId: "session-a",
       sourcePath: "/a/old.jsonl",
-      payloadHash: "a-old",
+      payloadKey: "a-old",
       ingestedAt: new Date(1700000100000),
     });
     seedRawMessage(archive, {
       sourceId: "session-a",
       sourcePath: "/a/new.jsonl",
-      payloadHash: "a-new",
+      payloadKey: "a-new",
       ingestedAt: new Date(1700000900000),
     });
 
     // Chat B: a custom title overrides its first user message.
-    seedChat(archive, {
-      internalId: "bbbbbb-uuid",
+    const idB = seedChat(archive, {
       sourceId: "session-b",
       firstSeenAt: new Date(1700000000000),
     });
@@ -774,15 +748,14 @@ describe("ChatReader.listChats query batching", () => {
     seedRawMessage(archive, {
       sourceId: "session-b",
       sourcePath: "/b/only.jsonl",
-      payloadHash: "b-only",
+      payloadKey: "b-only",
       ingestedAt: new Date(1700000300000),
     });
-    metadata.setCustomTitle("bbbbbb-uuid", "Custom B title");
+    metadata.setCustomTitle(idB, "Custom B title");
 
     // Chat C: no messages, no raw rows — falls back to Untitled, null path,
     // and firstSeenAt for both timestamps.
     seedChat(archive, {
-      internalId: "cccccc-uuid",
       sourceId: "session-c",
       firstSeenAt: new Date(1700000050000),
     });

--- a/api/src/ingestion/ingest.test.ts
+++ b/api/src/ingestion/ingest.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createArchiveRepository } from "../archive/repository.js";
-import { chats, messages, rawMessages } from "../archive/schema.js";
 import { createCheckpointRepository } from "../checkpoint/repository.js";
 import { chatScanState } from "../checkpoint/schema.js";
 import { ClaudeCodePlugin } from "../plugins/claude-code/plugin.js";
@@ -27,6 +26,23 @@ function setupEnv(): Env {
   return { dataDir, homeDir };
 }
 
+/**
+ * Sum the messages of every chat through the read seam. The archive's outward
+ * read surface is per-chat, so a global count is composed from `listChatRows`
+ * + `listMessagesByChat` rather than a back-channel `SELECT FROM messages`.
+ */
+function totalMessageCount(
+  archive: ReturnType<typeof createArchiveRepository>
+): number {
+  return archive.read
+    .listChatRows()
+    .reduce(
+      (acc, chat) =>
+        acc + archive.read.listMessagesByChat(chat.agent, chat.sourceId).length,
+      0
+    );
+}
+
 let env: Env;
 
 beforeEach(() => {
@@ -38,7 +54,7 @@ afterEach(() => {
 });
 
 describe("runIngestion", () => {
-  it("populates archive.db sessions, raw_messages, and messages from source on first run", async () => {
+  it("populates chats, raw messages, and normalized messages from source on first run", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
     const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
 
@@ -52,22 +68,19 @@ describe("runIngestion", () => {
     expect(result.scanned).toBeGreaterThan(0);
     expect(result.rawInserted).toBeGreaterThan(0);
     expect(result.normalizedUpserted).toBeGreaterThan(0);
+    // Normalized writes can never outnumber raw rows: plugins skip some
+    // payloads (meta, snapshot, sidechain) at the normalize step but write
+    // them all to the raw layer.
+    expect(result.normalizedUpserted).toBeLessThanOrEqual(result.rawInserted);
 
-    const chatRows = archive.db.select().from(chats).all();
-    const rawRows = archive.db.select().from(rawMessages).all();
-    const msgRows = archive.db.select().from(messages).all();
-
+    const chatRows = archive.read.listChatRows();
     expect(chatRows.length).toBeGreaterThan(0);
-    expect(rawRows.length).toBeGreaterThan(0);
-    expect(msgRows.length).toBeGreaterThan(0);
-    expect(msgRows.length).toBeLessThanOrEqual(rawRows.length);
-
-    for (const s of chatRows) {
-      expect(s.agent).toBe("claude-code");
-      expect(s.chatId).toHaveLength(6);
+    for (const c of chatRows) {
+      expect(c.agent).toBe("claude-code");
+      expect(c.chatId).toHaveLength(6);
     }
 
-    const session1 = chatRows.find((s) => s.sourceId === "session-1");
+    const session1 = archive.read.findChatBySourceId("session-1");
     expect(session1?.project).toBe("project-a");
     expect(session1?.projectPath).toBe("/Users/test/project-a");
 
@@ -85,9 +98,8 @@ describe("runIngestion", () => {
       checkpoint,
       env: { homeDir: env.homeDir },
     });
-    const rawBefore = archive.db.select().from(rawMessages).all().length;
-    const msgBefore = archive.db.select().from(messages).all().length;
-    const chatsBefore = archive.db.select().from(chats).all().length;
+    const chatsBefore = archive.read.listChatRows().length;
+    const messagesBefore = totalMessageCount(archive);
 
     const second = await runIngestion({
       plugins: pluginsList,
@@ -98,9 +110,9 @@ describe("runIngestion", () => {
 
     expect(first.rawInserted).toBeGreaterThan(0);
     expect(second.rawInserted).toBe(0);
-    expect(archive.db.select().from(rawMessages).all().length).toBe(rawBefore);
-    expect(archive.db.select().from(messages).all().length).toBe(msgBefore);
-    expect(archive.db.select().from(chats).all().length).toBe(chatsBefore);
+    expect(second.normalizedUpserted).toBe(0);
+    expect(archive.read.listChatRows().length).toBe(chatsBefore);
+    expect(totalMessageCount(archive)).toBe(messagesBefore);
 
     archive.close();
   });
@@ -116,7 +128,6 @@ describe("runIngestion", () => {
       checkpoint,
       env: { homeDir: env.homeDir },
     });
-    const rawBefore = archive.db.select().from(rawMessages).all();
 
     // Edit a line in the source: same line number, different payload.
     const sourceFile = path.join(
@@ -145,14 +156,9 @@ describe("runIngestion", () => {
       env: { homeDir: env.homeDir },
     });
 
-    const rawAfter = archive.db.select().from(rawMessages).all();
+    // Append-only at the raw layer: the changed line inserts a new raw row
+    // alongside the original. ADR-0002 guarantees nothing gets overwritten.
     expect(second.rawInserted).toBe(1);
-    expect(rawAfter.length).toBe(rawBefore.length + 1);
-
-    // All original raw rows are still present (no overwrite).
-    for (const before of rawBefore) {
-      expect(rawAfter.some((r) => r.id === before.id)).toBe(true);
-    }
 
     archive.close();
   });
@@ -161,37 +167,17 @@ describe("runIngestion", () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
     const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
 
-    await runIngestion({
+    const result = await runIngestion({
       plugins: [new ClaudeCodePlugin()],
       archive,
       checkpoint,
       env: { homeDir: env.homeDir },
     });
 
-    const rawRows = archive.db.select().from(rawMessages).all();
-    const msgRows = archive.db.select().from(messages).all();
-
     // Fixture contains file-history-snapshot, isMeta, and isSidechain rows
-    // that the claude-code plugin skips. They must still appear in raw_messages.
-    const hasMetaRaw = rawRows.some((r) => {
-      const p = JSON.parse(r.rawPayload) as Record<string, unknown>;
-      return p.isMeta === true || p.type === "file-history-snapshot";
-    });
-    expect(hasMetaRaw).toBe(true);
-
-    // No message row should be a meta/snapshot/sidechain payload.
-    const rawById = new Map(rawRows.map((r) => [r.id, r]));
-    for (const m of msgRows) {
-      const raw = rawById.get(m.rawId);
-      expect(raw).toBeDefined();
-      const p = JSON.parse(raw!.rawPayload) as Record<string, unknown>;
-      expect(p.isMeta).not.toBe(true);
-      expect(p.isSidechain).not.toBe(true);
-      expect(p.type === "user" || p.type === "assistant").toBe(true);
-    }
-
-    // Strict inequality: there are skipped raw rows.
-    expect(msgRows.length).toBeLessThan(rawRows.length);
+    // that the claude-code plugin skips at the normalize step but writes to
+    // the raw layer. Strict inequality proves at least one skipped raw row.
+    expect(result.normalizedUpserted).toBeLessThan(result.rawInserted);
 
     archive.close();
   });
@@ -286,10 +272,9 @@ describe("runIngestion", () => {
       checkpoint,
       env: { homeDir: env.homeDir },
     });
-    const rawBefore = archive.db.select().from(rawMessages).all();
-    const msgBefore = archive.db.select().from(messages).all();
-    const chatsBefore = archive.db.select().from(chats).all();
-    expect(rawBefore.length).toBeGreaterThan(1);
+    const chatsBefore = archive.read.listChatRows().length;
+    const messagesBefore = totalMessageCount(archive);
+    expect(messagesBefore).toBeGreaterThan(0);
 
     // Truncate source file to a single line (simulate vendor pruning).
     const sourceFile = path.join(
@@ -311,16 +296,10 @@ describe("runIngestion", () => {
       env: { homeDir: env.homeDir },
     });
 
-    const rawAfter = archive.db.select().from(rawMessages).all();
-    const msgAfter = archive.db.select().from(messages).all();
-    const chatsAfter = archive.db.select().from(chats).all();
-
-    expect(rawAfter.length).toBeGreaterThanOrEqual(rawBefore.length);
-    expect(msgAfter.length).toBeGreaterThanOrEqual(msgBefore.length);
-    expect(chatsAfter.length).toBe(chatsBefore.length);
-    for (const r of rawBefore) {
-      expect(rawAfter.some((a) => a.id === r.id)).toBe(true);
-    }
+    // Chat count unchanged and messages append-only: shrinking the source
+    // never deletes archive rows (ADR-0002).
+    expect(archive.read.listChatRows().length).toBe(chatsBefore);
+    expect(totalMessageCount(archive)).toBeGreaterThanOrEqual(messagesBefore);
   });
 
   it("fills in a session's project on a later scan once cwd is resolvable", async () => {
@@ -356,11 +335,7 @@ describe("runIngestion", () => {
       checkpoint,
       env: { homeDir: env.homeDir },
     });
-    const before = archive.db
-      .select()
-      .from(chats)
-      .all()
-      .find((s) => s.sourceId === "late");
+    const before = archive.read.findChatBySourceId("late");
     expect(before?.project).toBeNull();
 
     // A later message now carries cwd (e.g. read further into the file).
@@ -381,18 +356,14 @@ describe("runIngestion", () => {
       checkpoint,
       env: { homeDir: env.homeDir },
     });
-    const after = archive.db
-      .select()
-      .from(chats)
-      .all()
-      .find((s) => s.sourceId === "late");
+    const after = archive.read.findChatBySourceId("late");
     expect(after?.project).toBe("late-app");
     expect(after?.projectPath).toBe("/Users/test/late-app");
 
     archive.close();
   });
 
-  it("records the scan watermark in the checkpoint store, not archive.db", async () => {
+  it("records the scan watermark in the checkpoint store, not the archive store", async () => {
     const archive = createArchiveRepository({ dataDir: env.dataDir });
     const checkpoint = createCheckpointRepository({ dataDir: env.dataDir });
     const pluginsList = [new ClaudeCodePlugin()];
@@ -431,19 +402,19 @@ describe("runIngestion", () => {
     const firstCheckpoint = createCheckpointRepository({
       dataDir: env.dataDir,
     });
-    await runIngestion({
+    const first = await runIngestion({
       plugins: pluginsList,
       archive,
       checkpoint: firstCheckpoint,
       env: { homeDir: env.homeDir },
     });
-    const rawBefore = archive.db.select().from(rawMessages).all();
-    const msgBefore = archive.db.select().from(messages).all();
-    expect(rawBefore.length).toBeGreaterThan(0);
+    expect(first.rawInserted).toBeGreaterThan(0);
+    const chatsBefore = archive.read.listChatRows().length;
+    const messagesBefore = totalMessageCount(archive);
     firstCheckpoint.close();
 
-    // Upgrade drops session_scan_state from archive.db; checkpoint.db starts
-    // empty. Model that with a fresh, empty Checkpoint store.
+    // Upgrade drops session_scan_state from the archive store; the checkpoint
+    // store starts empty. Model that with a fresh, empty Checkpoint store.
     const freshDataDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "chat-logbook-fresh-checkpoint-")
     );
@@ -465,12 +436,11 @@ describe("runIngestion", () => {
 
     expect(upgrade.skippedByMtime).toBe(0);
     expect(upgrade.rawInserted).toBe(0);
-    expect(archive.db.select().from(rawMessages).all().length).toBe(
-      rawBefore.length
-    );
-    expect(archive.db.select().from(messages).all().length).toBe(
-      msgBefore.length
-    );
+    // Raw layer is a no-op: chat and message counts stay where the first run
+    // left them. `normalizedUpserted` may still be > 0 because last-write-wins
+    // re-stamps the same payloads — that's a write, but not a new row.
+    expect(archive.read.listChatRows().length).toBe(chatsBefore);
+    expect(totalMessageCount(archive)).toBe(messagesBefore);
     // The watermark is rebuilt in the new checkpoint store.
     expect(
       emptyCheckpoint.getScanState("claude-code", "session-1")

--- a/api/src/ingestion/watcher.test.ts
+++ b/api/src/ingestion/watcher.test.ts
@@ -3,12 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createArchiveRepository } from "../archive/repository.js";
-import {
-  ingestionEvents,
-  messages,
-  rawMessages,
-  chats,
-} from "../archive/schema.js";
 import { createCheckpointRepository } from "../checkpoint/repository.js";
 import { ClaudeCodePlugin } from "../plugins/claude-code/plugin.js";
 import { runIngestion } from "./ingest.js";
@@ -31,6 +25,22 @@ function setupEnv(): Env {
   fs.mkdirSync(claudeProjects, { recursive: true });
   fs.cpSync(fixturesRoot, claudeProjects, { recursive: true });
   return { tmp, dataDir, homeDir };
+}
+
+/**
+ * Sum the messages of every chat through the read seam — the public-surface
+ * equivalent of `SELECT COUNT(*) FROM messages` for "no rows changed" guards.
+ */
+function totalMessageCount(
+  archive: ReturnType<typeof createArchiveRepository>
+): number {
+  return archive.read
+    .listChatRows()
+    .reduce(
+      (acc, chat) =>
+        acc + archive.read.listMessagesByChat(chat.agent, chat.sourceId).length,
+      0
+    );
 }
 
 let env: Env;
@@ -63,7 +73,10 @@ describe("startWatcher", () => {
       checkpoint,
       env: { homeDir: env.homeDir },
     });
-    const rawBefore = archive.db.select().from(rawMessages).all().length;
+    const messagesBefore = archive.read.listMessagesByChat(
+      "claude-code",
+      "session-1"
+    ).length;
 
     // Resolves the instant a watcher-triggered ingest cycle has applied the
     // appended row — event-driven, not wall-clock polling.
@@ -82,8 +95,11 @@ describe("startWatcher", () => {
       chokidarOptions: { usePolling: true, interval: 60_000 },
       debounceMs: 25,
       onIngest: () => {
-        const rawAfter = archive.db.select().from(rawMessages).all().length;
-        if (rawAfter === rawBefore + 1) signalIngested();
+        const messagesAfter = archive.read.listMessagesByChat(
+          "claude-code",
+          "session-1"
+        ).length;
+        if (messagesAfter === messagesBefore + 1) signalIngested();
       },
     });
     await watcher.ready;
@@ -112,14 +128,12 @@ describe("startWatcher", () => {
       watcher.notifyChange(sourceFile);
       await ingested;
 
-      const rawAfter = archive.db.select().from(rawMessages).all().length;
-      expect(rawAfter).toBe(rawBefore + 1);
-      const msg = archive.db
-        .select()
-        .from(messages)
-        .all()
-        .find((m) => m.messageId === "msg-live-1");
-      expect(msg).toBeDefined();
+      const messages = archive.read.listMessagesByChat(
+        "claude-code",
+        "session-1"
+      );
+      expect(messages.length).toBe(messagesBefore + 1);
+      expect(messages.some((m) => m.messageId === "msg-live-1")).toBe(true);
     } finally {
       await watcher.close();
       archive.close();
@@ -131,7 +145,7 @@ describe("startWatcher", () => {
   // would await an audit row that never arrives, time out, and — because a
   // timed-out vitest test abandons its `finally` — leak a still-open watcher +
   // archive into `afterEach`'s tmpdir teardown. The leaked watcher then fires
-  // `recordUnlink` against the just-removed `archive.db`, writing a
+  // `recordUnlink` against the just-removed archive store, writing a
   // `SQLITE_READONLY_DBMOVED` to stderr (#100). We remove the dependency on
   // chokidar's unreliable detection while keeping the real "unlink" handler →
   // `recordUnlink` → audit write: unlink the file, then drive the event through
@@ -148,9 +162,8 @@ describe("startWatcher", () => {
       checkpoint,
       env: { homeDir: env.homeDir },
     });
-    const rawBefore = archive.db.select().from(rawMessages).all().length;
-    const msgBefore = archive.db.select().from(messages).all().length;
-    const chatsBefore = archive.db.select().from(chats).all().length;
+    const chatsBefore = archive.read.listChatRows().length;
+    const messagesBefore = totalMessageCount(archive);
 
     const watcher = startWatcher({
       plugins,
@@ -176,19 +189,15 @@ describe("startWatcher", () => {
 
       watcher.notifyUnlink(sourceFile);
 
-      const events = archive.db
-        .select()
-        .from(ingestionEvents)
-        .all()
+      const events = archive.read
+        .listIngestionEvents()
         .filter((e) => e.eventType === "unlink_observed");
       expect(events.length).toBeGreaterThan(0);
       expect(events.some((e) => e.sourcePath === sourceFile)).toBe(true);
 
-      expect(archive.db.select().from(rawMessages).all().length).toBe(
-        rawBefore
-      );
-      expect(archive.db.select().from(messages).all().length).toBe(msgBefore);
-      expect(archive.db.select().from(chats).all().length).toBe(chatsBefore);
+      // The audit row writes nothing back into chats / messages (ADR-0002).
+      expect(archive.read.listChatRows().length).toBe(chatsBefore);
+      expect(totalMessageCount(archive)).toBe(messagesBefore);
     } finally {
       await watcher.close();
       archive.close();
@@ -217,7 +226,10 @@ describe("startWatcher", () => {
     await watcher.ready;
     await watcher.close();
 
-    const rawBefore = archive.db.select().from(rawMessages).all().length;
+    const messagesBefore = archive.read.listMessagesByChat(
+      "claude-code",
+      "session-1"
+    ).length;
 
     const sourceFile = path.join(
       env.homeDir,
@@ -240,7 +252,9 @@ describe("startWatcher", () => {
     fs.utimesSync(sourceFile, future, future);
 
     await new Promise((r) => setTimeout(r, 400));
-    expect(archive.db.select().from(rawMessages).all().length).toBe(rawBefore);
+    expect(
+      archive.read.listMessagesByChat("claude-code", "session-1").length
+    ).toBe(messagesBefore);
 
     archive.close();
   });


### PR DESCRIPTION
## Background (Why)

Closes the mechanical tail of #107's acceptance criterion 3. With #114 routing `ChatReader` through a dedicated read seam, the raw drizzle handle no longer has any production callers — only six test files still reach for it. While `readonly db` stays on the interface, the archive's outward surface is "the entire query builder," and every consumer can rewrite arbitrary state.

## Approach (How)

Vertical TDD slices: migrate one test file at a time onto the public read/write surface, then finally drop the field. To keep the public interface minimal, only one new read primitive is added (`listIngestionEvents` — needed for the watcher's unlink-audit assertion). Everything else routes through existing methods: write seam for seeding, `archive.read` for reads, `runIngestion` result fields for ingest-shape assertions. Schema-level constraint tests (`schema.test.ts`) open their own drizzle handle on the migrated archive file rather than borrowing the repository's, so the connection stays private without losing the UNIQUE / JSON round-trip coverage.

`countArchiveQueries` in `chat-reader.test.ts` (the #106 constant-query-count guard) is reframed to wrap `archive.read` methods instead of instrumenting `client.prepare`. Each read-seam method maps to one SQL statement, so the public-surface call count is a faithful proxy for the original raw-handle counter.

## Changes (What)

- [x] Remove `readonly db` from the `ArchiveRepository` interface; drop the `db:` field from the returned object.
- [x] Add `listIngestionEvents()` to the read seam.
- [x] Migrate six consumer tests off `archive.db`: `repository.test.ts`, `repository-write.test.ts`, `chat-reader.test.ts`, `app.test.ts`, `ingest.test.ts`, `watcher.test.ts`.
- [x] `schema.test.ts` opens its own drizzle handle on the migrated archive file.

### Test Verification

- [x] Full api suite: 139 passed (15 files).
- [x] Full web suite: 113 passed (7 files).
- [x] `tsc --noEmit` clean.
- [x] Behavioral assertions preserved: idempotent raw insert, last-write-wins for normalized upsert, never-delete on unlink (ADR-0002), constant-query-count for `listChats`.

## Additional Notes

- `ArchiveDb` type alias stays exported — it remains the parameter type of `createArchiveReadSeam`. The runtime handle is what becomes private.
- A few previously white-box assertions get behaviorally equivalent rewrites (e.g. "raw row survives unlink" → "repeat `insertRawMessage` dedupes to the same id"; "raw vs message row counts" → `result.normalizedUpserted < result.rawInserted`). Plugin-specific payload checks (`isMeta`, `file-history-snapshot`) move out of the ingest test, where they were leaking through anyway.

## Related Links

- Closes #115
- Parent: #107 (criterion 3)
- Predecessor: #117 (ChatReader read seam, #114)
- Predecessor: #116 (ingestion write seam, #107 criteria 1–2, 4–5)