### PR TITLE
refactor(api): introduce openStore; migrate Checkpoint onto it

### DIFF
--- a/api/src/checkpoint/repository.ts
+++ b/api/src/checkpoint/repository.ts
@@ -1,13 +1,6 @@
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import Database from "better-sqlite3";
 import { and, eq } from "drizzle-orm";
-import {
-  drizzle,
-  type BetterSQLite3Database,
-} from "drizzle-orm/better-sqlite3";
-import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { type BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { openStore } from "../storage/openStore.js";
 import * as schema from "./schema.js";
 import { chatScanState } from "./schema.js";
 
@@ -41,26 +34,16 @@ interface RepositoryOptions {
   dataDir: string;
 }
 
-function resolveMigrationsFolder(): string {
-  const here = path.dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    path.join(here, "../../drizzle/checkpoint"),
-    path.join(here, "./drizzle/checkpoint"),
-  ];
-  const found = candidates.find((p) => fs.existsSync(p));
-  if (!found) {
-    throw new Error("Could not locate checkpoint drizzle migrations folder");
-  }
-  return found;
-}
-
 export function createCheckpointRepository({
   dataDir,
 }: RepositoryOptions): CheckpointRepository {
-  fs.mkdirSync(dataDir, { recursive: true });
-  const sqlite = new Database(path.join(dataDir, "checkpoint.db"));
-  const db: CheckpointDb = drizzle(sqlite, { schema });
-  migrate(db, { migrationsFolder: resolveMigrationsFolder() });
+  const { db, sqlite } = openStore({
+    dataDir,
+    dbFile: "checkpoint.db",
+    callerUrl: import.meta.url,
+    migrationsSubdir: "drizzle/checkpoint",
+    schema,
+  });
 
   return {
     db,

--- a/api/src/storage/openStore.test.ts
+++ b/api/src/storage/openStore.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as checkpointSchema from "../checkpoint/schema.js";
+import { openStore } from "./openStore.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-openstore-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("openStore", () => {
+  it("creates the data dir, opens the db file, and runs migrations", () => {
+    const { sqlite } = openStore({
+      dataDir,
+      dbFile: "checkpoint.db",
+      callerUrl: import.meta.url,
+      migrationsSubdir: "drizzle/checkpoint",
+      schema: checkpointSchema,
+    });
+
+    try {
+      expect(fs.existsSync(path.join(dataDir, "checkpoint.db"))).toBe(true);
+
+      const tables = sqlite
+        .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+        .all() as { name: string }[];
+      expect(tables.map((t) => t.name)).toContain("chat_scan_state");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns a db handle typed over the passed schema that round-trips writes", () => {
+    const { db, sqlite } = openStore({
+      dataDir,
+      dbFile: "checkpoint.db",
+      callerUrl: import.meta.url,
+      migrationsSubdir: "drizzle/checkpoint",
+      schema: checkpointSchema,
+    });
+
+    try {
+      db.insert(checkpointSchema.chatScanState)
+        .values({
+          agent: "claude-code",
+          sourceId: "src-1",
+          sourcePath: "/src/one.jsonl",
+          lastMtimeMs: 1000,
+          lastSizeBytes: 4096,
+          lastScannedAt: new Date(1_700_000_000_000),
+        })
+        .run();
+
+      const rows = db.select().from(checkpointSchema.chatScanState).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        agent: "claude-code",
+        sourceId: "src-1",
+        lastMtimeMs: 1000,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("throws when the migrations folder cannot be located relative to callerUrl", () => {
+    // A callerUrl deep in a temp dir: neither ../../<subdir> nor ./<subdir>
+    // resolves, so resolution relative to the caller must fail loudly.
+    const strayCaller = pathToFileURL(
+      path.join(dataDir, "nested", "stray.js")
+    ).href;
+
+    expect(() =>
+      openStore({
+        dataDir,
+        dbFile: "checkpoint.db",
+        callerUrl: strayCaller,
+        migrationsSubdir: "drizzle/checkpoint",
+        schema: checkpointSchema,
+      })
+    ).toThrow(/migrations folder/i);
+  });
+});

--- a/api/src/storage/openStore.ts
+++ b/api/src/storage/openStore.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import {
+  drizzle,
+  type BetterSQLite3Database,
+} from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+
+export interface OpenStoreOptions<TSchema extends Record<string, unknown>> {
+  dataDir: string;
+  dbFile: string;
+  callerUrl: string;
+  migrationsSubdir: string;
+  schema: TSchema;
+}
+
+export interface OpenStoreResult<TSchema extends Record<string, unknown>> {
+  db: BetterSQLite3Database<TSchema>;
+  sqlite: Database.Database;
+}
+
+// Resolve the migrations folder relative to the *caller*, trying the built
+// layout (`../../<subdir>`) before the source layout (`./<subdir>`). The offset
+// is caller-relative, so callers pass their own import.meta.url.
+function resolveMigrationsFolder(
+  callerUrl: string,
+  migrationsSubdir: string
+): string {
+  const here = path.dirname(fileURLToPath(callerUrl));
+  const candidates = [
+    path.join(here, "../..", migrationsSubdir),
+    path.join(here, ".", migrationsSubdir),
+  ];
+  const found = candidates.find((p) => fs.existsSync(p));
+  if (!found) {
+    throw new Error(`Could not locate migrations folder "${migrationsSubdir}"`);
+  }
+  return found;
+}
+
+export function openStore<TSchema extends Record<string, unknown>>({
+  dataDir,
+  dbFile,
+  callerUrl,
+  migrationsSubdir,
+  schema,
+}: OpenStoreOptions<TSchema>): OpenStoreResult<TSchema> {
+  // Resolve migrations first so a misconfigured caller fails before we create
+  // the data dir or the db file.
+  const migrationsFolder = resolveMigrationsFolder(callerUrl, migrationsSubdir);
+  fs.mkdirSync(dataDir, { recursive: true });
+  const sqlite = new Database(path.join(dataDir, dbFile));
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder });
+  return { db, sqlite };
+}


### PR DESCRIPTION
## Background (Why)

`archive`, `metadata`, and `checkpoint` each repeated the same store-bootstrap verbatim: a two-candidate migrations-folder fallback (`../../drizzle/<sub>` for the built layout vs `./drizzle/<sub>` for source), `mkdirSync(dataDir)`, `new Database(...)`, `drizzle(sqlite, { schema })`, and `migrate(...)`. Changing the bootstrap meant editing three files. This concentrates that machinery in one deep module.

## Approach (How)

Introduce `openStore` under `api/src/storage/`. It owns the opening mechanism once; each store keeps its own schema, db file, migration lineage, domain methods, and post-open init.

- The two-candidate fallback is resolved relative to the **caller's** `import.meta.url` (passed as `callerUrl`), because the `../../` vs `./` offset is caller-relative — resolving against `openStore`'s own location would be wrong.
- Returns **both** `{ db, sqlite }`: the drizzle handle and the raw better-sqlite3 handle, because later slices need the raw handle (archive does `sqlite.prepare(...)`, metadata does `sqlite.pragma(...)`).
- `db` is generic over the passed schema.

Built via TDD, with Checkpoint as the first tracer bullet (it needs only `db`, no post-open init).

### Scope guard (ADR-0001)

Shares only the *opening mechanism* — it does **not** merge stores: separate files, schemas, and migration lineages all stay. No Index-specific `skipMigrate` knob was added; `migrate` stays a fixed step (revisit if/when the Index store lands).

## Changes (What)

- [x] New `openStore` module at `api/src/storage/openStore.ts` with the agreed shape, returning `{ db, sqlite }`.
- [x] The two-candidate migrations fallback lives once inside `openStore`, resolved relative to `callerUrl`.
- [x] Checkpoint repository calls `openStore` once and drops its own resolve-folder / mkdir / open / drizzle / migrate.
- [x] Checkpoint keeps its schema, `checkpoint.db` file, migration lineage, and domain methods (`getScanState`, `recordScanState`).

### Test Verification

- [x] `openStore` creates the data dir, opens the db file, and runs migrations.
- [x] `openStore` returns a `db` handle typed over the passed schema that round-trips writes.
- [x] `openStore` throws a clear error when the migrations folder can't be located relative to `callerUrl`.
- [x] Existing checkpoint tests pass unchanged after the migration.
- [x] Full suite green: api 142/142, web 113/113; typecheck clean.

## Additional Notes

Archive and metadata are intentionally left untouched here — they are follow-up slices, and the `{ db, sqlite }` return already supports the raw handle they need.

## Related Links

- Closes #119