### PR TITLE
refactor(api): migrate Archive bootstrap onto openStore

### DIFF
--- a/api/src/archive/repository.ts
+++ b/api/src/archive/repository.ts
@@ -1,14 +1,7 @@
 import crypto from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import Database from "better-sqlite3";
-import {
-  drizzle,
-  type BetterSQLite3Database,
-} from "drizzle-orm/better-sqlite3";
-import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { type BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { and, eq } from "drizzle-orm";
+import { openStore } from "../storage/openStore.js";
 import * as schema from "./schema.js";
 import {
   archiveMeta,
@@ -66,19 +59,6 @@ export interface IngestionEventInput {
   detail: unknown;
   /** Defaults to now when omitted. */
   observedAt?: Date;
-}
-
-function resolveMigrationsFolder(): string {
-  const here = path.dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    path.join(here, "../../drizzle/archive"),
-    path.join(here, "./drizzle/archive"),
-  ];
-  const found = candidates.find((p) => fs.existsSync(p));
-  if (!found) {
-    throw new Error("Could not locate archive drizzle migrations folder");
-  }
-  return found;
 }
 
 export interface AppliedMigration {
@@ -148,10 +128,13 @@ function parseTs(ts: string): Date {
 export function createArchiveRepository({
   dataDir,
 }: RepositoryOptions): ArchiveRepository {
-  fs.mkdirSync(dataDir, { recursive: true });
-  const sqlite = new Database(path.join(dataDir, "archive.db"));
-  const db: ArchiveDb = drizzle(sqlite, { schema });
-  migrate(db, { migrationsFolder: resolveMigrationsFolder() });
+  const { db, sqlite } = openStore({
+    dataDir,
+    dbFile: "archive.db",
+    callerUrl: import.meta.url,
+    migrationsSubdir: "drizzle/archive",
+    schema,
+  });
 
   const drizzleMigrations = sqlite
     .prepare("SELECT id, created_at FROM __drizzle_migrations ORDER BY id ASC")


### PR DESCRIPTION
## Background (Why)

The Archive store repeated the shared store bootstrap — resolve-migrations-folder fallback + mkdir + open + drizzle + migrate — that #119 extracted into `openStore`. With Checkpoint already migrated (#122), Archive was the remaining caller still hand-rolling its own copy. Migrating it removes the duplication while keeping everything that is genuinely archive-specific.

## Approach (How)

Replace the hand-rolled bootstrap with a single `openStore` call, passing `dbFile: "archive.db"` and `migrationsSubdir: "drizzle/archive"`. `openStore` returns `{ db, sqlite }`, so the archive-specific post-open init keeps the handles it needs:

- the `__drizzle_migrations` → `schemaVersion` backfill runs on the raw `sqlite` handle;
- the `archiveMeta` UUID init runs on the drizzle `db`.

The drizzle `db` stays private to the repository — the `ArchiveRepository` interface exposes no `db` (consistent with the privatization that landed in #118), and `openStore` does not re-expose it. Archive keeps its own `archive.db` file, schema, and migration lineage (ADR-0001); `openStore` shares only the opening mechanism.

## Changes (What)

- [x] Archive repository calls `openStore` once and drops its own resolve-folder / mkdir / open / drizzle / migrate
- [x] Removed the now-unused `resolveMigrationsFolder` helper and the `fs` / `path` / `fileURLToPath` / `Database` / `drizzle` / `migrate` imports
- [x] Kept the `__drizzle_migrations` → `schemaVersion` backfill and `archiveMeta` UUID init, run after open via the returned `{ db, sqlite }`
- [x] `db` handle stays private (no public re-exposure)

### Test Verification

- [x] Existing archive tests pass unchanged (`repository.test.ts` 10, `repository-write.test.ts` 6)
- [x] Full suite green via pre-commit hook: 142 api + 113 web tests pass
- [x] `tsc --noEmit` clean for api and web

## Additional Notes

Pure refactor — no behavior change. Net `-17` lines (9 insertions, 26 deletions).

## Related Links

- Closes #120
- Blocked by #119 (`openStore`), follows #122 (Checkpoint migration)