### PR TITLE
refactor(api): migrate Metadata onto openStore

### DIFF
--- a/api/src/metadata/repository.ts
+++ b/api/src/metadata/repository.ts
@@ -1,27 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 import { eq, isNotNull } from "drizzle-orm";
-import {
-  drizzle,
-  type BetterSQLite3Database,
-} from "drizzle-orm/better-sqlite3";
-import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { type BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { openStore } from "../storage/openStore.js";
+import * as schema from "./schema.js";
 import { chatsMeta } from "./schema.js";
 
-function resolveMigrationsFolder(): string {
-  const here = path.dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    path.join(here, "../../drizzle"),
-    path.join(here, "./drizzle"),
-  ];
-  const found = candidates.find((p) => fs.existsSync(p));
-  if (!found) {
-    throw new Error("Could not locate drizzle migrations folder");
-  }
-  return found;
-}
+export type MetadataDb = BetterSQLite3Database<typeof schema>;
 
 const DB_FILE = "metadata.db";
 const LEGACY_DB_FILE = "data.db";
@@ -74,11 +60,17 @@ export function createMetadataRepository({
   lookupInternalId,
   ensureChat,
 }: RepositoryOptions): MetadataRepository {
-  fs.mkdirSync(dataDir, { recursive: true });
+  // Rename a pre-v0.9 data.db before opening (ADR-0012). openStore has no
+  // beforeOpen hook; the rename is a no-op when dataDir doesn't exist yet, so
+  // plain ordering here is enough.
   migrateLegacyDbFile(dataDir);
-  const sqlite = new Database(path.join(dataDir, DB_FILE));
-  const db: BetterSQLite3Database = drizzle(sqlite);
-  migrate(db, { migrationsFolder: resolveMigrationsFolder() });
+  const { db, sqlite } = openStore({
+    dataDir,
+    dbFile: DB_FILE,
+    callerUrl: import.meta.url,
+    migrationsSubdir: "drizzle",
+    schema,
+  });
 
   if (lookupInternalId) {
     rekeyLegacyRows(sqlite, db, lookupInternalId, ensureChat);
@@ -181,7 +173,7 @@ const REKEY_USER_VERSION = 4;
 
 function rekeyLegacyRows(
   sqlite: Database.Database,
-  db: BetterSQLite3Database,
+  db: MetadataDb,
   lookupInternalId: LookupInternalId,
   ensureChat: EnsureChat | undefined
 ): void {


### PR DESCRIPTION
## Background (Why)

The Metadata store repeated the shared bootstrap (resolve-folder fallback + mkdir + open + drizzle + migrate) that `openStore` (#119) already encapsulates. It also had a latent inconsistency: metadata opened with `drizzle(sqlite)` **without** a schema, while archive and checkpoint pass `{ schema }`, leaving metadata's `db` untyped.

## Approach (How)

Route metadata's bootstrap through `openStore`, keeping the store's own legacy-file rename and rekey logic in the repository per ADR-0001 / ADR-0012:

- The repository calls `migrateLegacyDbFile(dataDir)` **first**, then `openStore`. No `beforeOpen` hook is added — the rename is a no-op when `dataDir` doesn't exist yet, so plain ordering in the repo is enough.
- `rekeyLegacyRows` (which reads/writes `user_version` via `sqlite.pragma(...)`) runs **after** open, using the raw handle from `openStore`'s return.
- Metadata's `db` is now typed via `openStore`'s generic `schema` parameter, replacing the untyped `drizzle(sqlite)`. Existing `.select().from()` calls are unaffected.

Metadata keeps its own `metadata.db` file, schema, and migration lineage; `openStore` shares only the opening mechanism and does not merge stores.

## Changes (What)

- [x] `createMetadataRepository` calls `migrateLegacyDbFile(dataDir)` then `openStore`, dropping its own resolve-folder / mkdir / open / drizzle / migrate copy
- [x] No `beforeOpen` hook on `openStore`; the rename is ordered by the repository
- [x] `rekeyLegacyRows` stays in the repository, run after open via the returned `{ db, sqlite }`
- [x] Metadata's `db` is typed via `openStore`'s generic `schema` (new `MetadataDb` alias); `data.db` → `metadata.db` rename stays in `migrateLegacyDbFile`

### Test Verification

- [x] Existing metadata tests pass unchanged (13/13)
- [x] Full api suite green (142/142), full web suite green (113/113)
- [x] Typecheck passes
- [x] Fresh install creates `metadata.db` and never `data.db`; legacy `data.db` renamed preserving rows; stale `data.db` does not clobber existing `metadata.db`
- [x] Rekey legacy rows runs once across startups, after open

## Additional Notes

Pure refactor — no new runtime behavior. The existing test suite serves as the regression net. The only new surface is the typed `db`, enforced at compile time by `tsc`.

## Related Links

- Closes #121
- Blocked by / builds on #119 (openStore)