### PR TITLE
feat(api): expose chat id (clog_) as the public API identifier

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -5,10 +5,11 @@ import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { createApp } from "./app.js";
 import { createArchiveRepository } from "./archive/repository.js";
 import { createMetadataRepository } from "./metadata/repository.js";
+import { formatChatId } from "./archive/chat-id.js";
 
 interface ChatResponse {
   id: string;
-  chatId: string;
+  sourceId: string;
   agent: string;
   title: string;
   project: string;
@@ -82,6 +83,17 @@ function seedMessage(
   });
 }
 
+// The public route handle is the wire-form chat id. Tests seed by source id,
+// so this renders the wire form to put in the URL.
+function wireIdFor(
+  archive: ReturnType<typeof createArchiveRepository>,
+  sourceId: string
+): string {
+  const row = archive.read.findChatBySourceId(sourceId);
+  if (!row) throw new Error(`no seeded chat for source id ${sourceId}`);
+  return formatChatId(row.chatId);
+}
+
 let dataDir: string;
 
 beforeEach(() => {
@@ -92,6 +104,70 @@ afterEach(() => {
   fs.rmSync(dataDir, { recursive: true, force: true });
 });
 
+describe("Chat id is the public API handle", () => {
+  it("GET /api/chats exposes id as the wire-form chat id plus sourceId", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const wireId = wireIdFor(archive, "session-1");
+
+    const app = createApp({ archive, metadata });
+    const list = await app.request("/api/chats");
+    const body = (await list.json()) as { chats: ChatResponse[] };
+    const chat = body.chats.find((s) => s.sourceId === "session-1");
+    expect(chat?.id).toBe(wireId);
+    expect(chat?.id.startsWith("clog_")).toBe(true);
+  });
+
+  it("GET /api/chats/:id 404s when given the source id instead of the chat id", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m1",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "hi",
+      blocks: [{ type: "text", text: "hi" }],
+    });
+
+    const app = createApp({ archive, metadata });
+    const res = await app.request("/api/chats/session-1");
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /api/chats/:id resolves messages by the wire-form chat id", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m1",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "hi",
+      blocks: [{ type: "text", text: "hi" }],
+    });
+    const wireId = wireIdFor(archive, "session-1");
+
+    const app = createApp({ archive, metadata });
+    const res = await app.request(`/api/chats/${wireId}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { messages: MessageResponse[] };
+    expect(body.messages).toHaveLength(1);
+  });
+});
+
 describe("Soft delete and restore (archive-backed)", () => {
   it("ignores the legacy includeDeleted query param", async () => {
     const archive = createArchiveRepository({ dataDir });
@@ -100,13 +176,14 @@ describe("Soft delete and restore (archive-backed)", () => {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
+    const wireId = wireIdFor(archive, "session-1");
 
     const app = createApp({ archive, metadata });
-    await app.request("/api/chats/session-1", { method: "DELETE" });
+    await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
 
     const res = await app.request("/api/chats?includeDeleted=true");
     const body = (await res.json()) as { chats: ChatResponse[] };
-    expect(body.chats.map((s) => s.id)).not.toContain("session-1");
+    expect(body.chats.map((s) => s.sourceId)).not.toContain("session-1");
   });
 
   it("hides a session from GET /api/chats after DELETE", async () => {
@@ -116,16 +193,17 @@ describe("Soft delete and restore (archive-backed)", () => {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
+    const wireId = wireIdFor(archive, "session-1");
 
     const app = createApp({ archive, metadata });
-    const del = await app.request("/api/chats/session-1", {
+    const del = await app.request(`/api/chats/${wireId}`, {
       method: "DELETE",
     });
     expect(del.status).toBe(204);
 
     const list = await app.request("/api/chats");
     const body = (await list.json()) as { chats: ChatResponse[] };
-    expect(body.chats.map((s) => s.id)).not.toContain("session-1");
+    expect(body.chats.map((s) => s.sourceId)).not.toContain("session-1");
   });
 
   it("restores a previously deleted session", async () => {
@@ -135,17 +213,18 @@ describe("Soft delete and restore (archive-backed)", () => {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
+    const wireId = wireIdFor(archive, "session-1");
 
     const app = createApp({ archive, metadata });
-    await app.request("/api/chats/session-1", { method: "DELETE" });
-    const restore = await app.request("/api/chats/session-1/restore", {
+    await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
+    const restore = await app.request(`/api/chats/${wireId}/restore`, {
       method: "POST",
     });
     expect(restore.status).toBe(204);
 
     const list = await app.request("/api/chats");
     const body = (await list.json()) as { chats: ChatResponse[] };
-    expect(body.chats.map((s) => s.id)).toContain("session-1");
+    expect(body.chats.map((s) => s.sourceId)).toContain("session-1");
   });
 
   it("never deletes archive.sessions rows on soft delete", async () => {
@@ -155,9 +234,10 @@ describe("Soft delete and restore (archive-backed)", () => {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
+    const wireId = wireIdFor(archive, "session-1");
 
     const app = createApp({ archive, metadata });
-    await app.request("/api/chats/session-1", { method: "DELETE" });
+    await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
 
     const row = archive.read.findChatBySourceId("session-1");
     expect(row?.sourceId).toBe("session-1");
@@ -180,11 +260,12 @@ describe("GET /api/chats/:id visibility", () => {
       text: "hi",
       blocks: [{ type: "text", text: "hi" }],
     });
+    const wireId = wireIdFor(archive, "session-1");
 
     const app = createApp({ archive, metadata });
-    await app.request("/api/chats/session-1", { method: "DELETE" });
+    await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
 
-    const res = await app.request("/api/chats/session-1");
+    const res = await app.request(`/api/chats/${wireId}`);
     expect(res.status).toBe(404);
   });
 
@@ -203,11 +284,12 @@ describe("GET /api/chats/:id visibility", () => {
       text: "hi",
       blocks: [{ type: "text", text: "hi" }],
     });
+    const wireId = wireIdFor(archive, "session-1");
 
     const app = createApp({ archive, metadata });
-    await app.request("/api/chats/session-1", { method: "DELETE" });
+    await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
 
-    const res = await app.request("/api/chats/session-1?includeTrashed=true");
+    const res = await app.request(`/api/chats/${wireId}?includeTrashed=true`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { messages: MessageResponse[] };
     expect(body.messages).toHaveLength(1);
@@ -220,10 +302,11 @@ describe("GET /api/chats/:id visibility", () => {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
+    const wireId = wireIdFor(archive, "session-1");
 
     const app = createApp({ archive, metadata });
-    await app.request("/api/chats/session-1", { method: "DELETE" });
-    const restore = await app.request("/api/chats/session-1/restore", {
+    await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
+    const restore = await app.request(`/api/chats/${wireId}/restore`, {
       method: "POST",
     });
     expect(restore.status).toBe(204);
@@ -231,7 +314,7 @@ describe("GET /api/chats/:id visibility", () => {
 });
 
 describe("DELETE / restore idempotency (archive-backed)", () => {
-  it("returns 404 when DELETE targets a session absent from archive", async () => {
+  it("returns 404 when DELETE targets a chat absent from archive", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     const app = createApp({ archive, metadata });
@@ -242,7 +325,7 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 404 when restore targets a session absent from archive", async () => {
+  it("returns 404 when restore targets a chat absent from archive", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     const app = createApp({ archive, metadata });
@@ -260,13 +343,14 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
+    const wireId = wireIdFor(archive, "session-1");
     const app = createApp({ archive, metadata });
 
-    const first = await app.request("/api/chats/session-1", {
+    const first = await app.request(`/api/chats/${wireId}`, {
       method: "DELETE",
     });
     expect(first.status).toBe(204);
-    const second = await app.request("/api/chats/session-1", {
+    const second = await app.request(`/api/chats/${wireId}`, {
       method: "DELETE",
     });
     expect(second.status).toBe(204);
@@ -279,9 +363,10 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
+    const wireId = wireIdFor(archive, "session-1");
     const app = createApp({ archive, metadata });
 
-    const res = await app.request("/api/chats/session-1/restore", {
+    const res = await app.request(`/api/chats/${wireId}/restore`, {
       method: "POST",
     });
     expect(res.status).toBe(204);
@@ -304,9 +389,10 @@ describe("PATCH /api/chats/:id/title", () => {
       text: "Build a login page",
       blocks: [{ type: "text", text: "Build a login page" }],
     });
+    const wireId = wireIdFor(archive, "session-1");
 
     const app = createApp({ archive, metadata });
-    const patch = await app.request("/api/chats/session-1/title", {
+    const patch = await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ title: "My favourite chat" }),
@@ -315,7 +401,7 @@ describe("PATCH /api/chats/:id/title", () => {
 
     const list = await app.request("/api/chats");
     const body = (await list.json()) as { chats: ChatResponse[] };
-    const session = body.chats.find((s) => s.id === "session-1");
+    const session = body.chats.find((s) => s.sourceId === "session-1");
     expect(session?.title).toBe("My favourite chat");
   });
 
@@ -335,9 +421,10 @@ describe("PATCH /api/chats/:id/title", () => {
       blocks: [{ type: "text", text: "Build a login page" }],
     });
     metadata.setCustomTitle(internalId, "Custom");
+    const wireId = wireIdFor(archive, "session-1");
 
     const app = createApp({ archive, metadata });
-    const patch = await app.request("/api/chats/session-1/title", {
+    const patch = await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ title: "" }),
@@ -346,7 +433,7 @@ describe("PATCH /api/chats/:id/title", () => {
 
     const list = await app.request("/api/chats");
     const body = (await list.json()) as { chats: ChatResponse[] };
-    const session = body.chats.find((s) => s.id === "session-1");
+    const session = body.chats.find((s) => s.sourceId === "session-1");
     expect(session?.title).toBe("Build a login page");
   });
 
@@ -358,9 +445,10 @@ describe("PATCH /api/chats/:id/title", () => {
       firstSeenAt: new Date(1700000000000),
     });
     metadata.setCustomTitle(internalId, "Custom");
+    const wireId = wireIdFor(archive, "session-1");
 
     const app = createApp({ archive, metadata });
-    const patch = await app.request("/api/chats/session-1/title", {
+    const patch = await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ title: "   " }),
@@ -369,7 +457,7 @@ describe("PATCH /api/chats/:id/title", () => {
 
     const list = await app.request("/api/chats");
     const body = (await list.json()) as { chats: ChatResponse[] };
-    const session = body.chats.find((s) => s.id === "session-1");
+    const session = body.chats.find((s) => s.sourceId === "session-1");
     expect(session?.title).toBe("Untitled");
   });
 
@@ -380,9 +468,10 @@ describe("PATCH /api/chats/:id/title", () => {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
+    const wireId = wireIdFor(archive, "session-1");
 
     const app = createApp({ archive, metadata });
-    await app.request("/api/chats/session-1/title", {
+    await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ title: "  Padded title  " }),
@@ -390,11 +479,11 @@ describe("PATCH /api/chats/:id/title", () => {
 
     const list = await app.request("/api/chats");
     const body = (await list.json()) as { chats: ChatResponse[] };
-    const session = body.chats.find((s) => s.id === "session-1");
+    const session = body.chats.find((s) => s.sourceId === "session-1");
     expect(session?.title).toBe("Padded title");
   });
 
-  it("returns 404 when archive has no session for the given id", async () => {
+  it("returns 404 when archive has no chat for the given id", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     const app = createApp({ archive, metadata });
@@ -414,9 +503,10 @@ describe("PATCH /api/chats/:id/title", () => {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
+    const wireId = wireIdFor(archive, "session-1");
     const app = createApp({ archive, metadata });
 
-    const wrongType = await app.request("/api/chats/session-1/title", {
+    const wrongType = await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ title: 123 }),
@@ -431,10 +521,11 @@ describe("PATCH /api/chats/:id/title", () => {
       sourceId: "session-1",
       firstSeenAt: new Date(1700000000000),
     });
+    const wireId = wireIdFor(archive, "session-1");
     const app = createApp({ archive, metadata });
 
     const tooLong = "x".repeat(201);
-    const res = await app.request("/api/chats/session-1/title", {
+    const res = await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ title: tooLong }),
@@ -444,7 +535,7 @@ describe("PATCH /api/chats/:id/title", () => {
 });
 
 describe("GET /api/chats/:id (route status mapping)", () => {
-  it("returns 404 when archive has no session for the given source id", async () => {
+  it("returns 404 when archive has no chat for the given id", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
 

--- a/api/src/archive/chat-id.test.ts
+++ b/api/src/archive/chat-id.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { CROCKFORD_ALPHABET, generateChatId } from "./chat-id.js";
+import {
+  CHAT_ID_PREFIX,
+  CROCKFORD_ALPHABET,
+  formatChatId,
+  generateChatId,
+  parseChatId,
+} from "./chat-id.js";
 
 const ALLOWED = new Set(CROCKFORD_ALPHABET);
 
@@ -51,5 +57,36 @@ describe("generateChatId", () => {
       expect(ALLOWED.has(banned)).toBe(false);
     }
     expect(CROCKFORD_ALPHABET).toHaveLength(32);
+  });
+});
+
+describe("formatChatId / parseChatId", () => {
+  it("formats a bare code into the clog_ wire form", () => {
+    expect(formatChatId("a3f7kx")).toBe("clog_a3f7kx");
+    expect(CHAT_ID_PREFIX).toBe("clog_");
+  });
+
+  it("parses a wire-form id back to the bare code", () => {
+    expect(parseChatId("clog_a3f7kx")).toBe("a3f7kx");
+  });
+
+  it("round-trips format then parse", () => {
+    const code = generateChatId({ isTaken: () => false });
+    expect(parseChatId(formatChatId(code))).toBe(code);
+  });
+
+  it("returns null when the clog_ prefix is missing", () => {
+    expect(parseChatId("a3f7kx")).toBeNull();
+  });
+
+  it("returns null when the code is the wrong length", () => {
+    expect(parseChatId("clog_a3f7k")).toBeNull();
+    expect(parseChatId("clog_a3f7kxy")).toBeNull();
+  });
+
+  it("returns null when the code has non-Crockford characters", () => {
+    // i, l, o, u are excluded from the alphabet
+    expect(parseChatId("clog_a3f7ki")).toBeNull();
+    expect(parseChatId("clog_A3F7KX")).toBeNull();
   });
 });

--- a/api/src/archive/chat-id.ts
+++ b/api/src/archive/chat-id.ts
@@ -5,6 +5,29 @@ export const CROCKFORD_ALPHABET = "0123456789abcdefghjkmnpqrstvwxyz";
 const CHAT_ID_LENGTH = 6;
 const MAX_RETRIES = 5;
 
+/** Wire-form prefix that makes a chat id paste-anywhere pattern-matchable. */
+export const CHAT_ID_PREFIX = "clog_";
+
+const WIRE_FORM_RE = new RegExp(
+  `^${CHAT_ID_PREFIX}[${CROCKFORD_ALPHABET}]{${CHAT_ID_LENGTH}}$`
+);
+
+/** Render a stored bare chat_id code into its public wire form. */
+export function formatChatId(code: string): string {
+  return `${CHAT_ID_PREFIX}${code}`;
+}
+
+/**
+ * Parse a public wire-form chat id back to its bare code, or null when the
+ * input is not a well-formed `clog_` + 6 Crockford characters. Strict: a bare
+ * code, wrong length, or out-of-alphabet character all parse to null so the
+ * caller can collapse them into the same 404 path.
+ */
+export function parseChatId(wire: string): string | null {
+  if (!WIRE_FORM_RE.test(wire)) return null;
+  return wire.slice(CHAT_ID_PREFIX.length);
+}
+
 export interface GenerateChatIdOptions {
   isTaken: (candidate: string) => boolean;
   randomIndex?: () => number;

--- a/api/src/archive/read-seam.ts
+++ b/api/src/archive/read-seam.ts
@@ -41,6 +41,8 @@ export interface ArchiveReadSeam {
   listChatRows(): ChatRow[];
   /** Resolve a chat by its source id; null when absent. */
   findChatBySourceId(sourceId: string): ChatRow | null;
+  /** Resolve a chat by its bare chat_id code (the public handle); null when absent. */
+  findChatByChatId(chatId: string): ChatRow | null;
   /** Messages for one `(agent, source_id)` chat, ordered by ascending ts. */
   listMessagesByChat(agent: string, sourceId: string): MessageRow[];
   /**
@@ -71,6 +73,11 @@ export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
       return (
         db.select().from(chats).where(eq(chats.sourceId, sourceId)).get() ??
         null
+      );
+    },
+    findChatByChatId(chatId) {
+      return (
+        db.select().from(chats).where(eq(chats.chatId, chatId)).get() ?? null
       );
     },
     listMessagesByChat(agent, sourceId) {

--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -5,10 +5,22 @@ import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { createChatReader } from "./chat-reader.js";
 import { createArchiveRepository } from "./archive/repository.js";
 import { createMetadataRepository } from "./metadata/repository.js";
-import { CROCKFORD_ALPHABET } from "./archive/chat-id.js";
+import { CROCKFORD_ALPHABET, formatChatId } from "./archive/chat-id.js";
 import type { ArchiveReadSeam } from "./archive/read-seam.js";
 
 const DEFAULT_AGENT = "claude-code";
+
+// The public handle is the wire-form chat id. Tests seed by source id, so this
+// looks up the chat's generated chat_id and renders the wire form callers pass
+// to findChat / getMessages.
+function wireIdFor(
+  archive: ReturnType<typeof createArchiveRepository>,
+  sourceId: string
+): string {
+  const row = archive.read.findChatBySourceId(sourceId);
+  if (!row) throw new Error(`no seeded chat for source id ${sourceId}`);
+  return formatChatId(row.chatId);
+}
 
 /**
  * Seed a chat through the write seam; returns the generated internal id so
@@ -115,7 +127,7 @@ describe("ChatReader.listChats", () => {
 
     const reader = createChatReader({ archive, metadata });
     const chats = reader.listChats({ includeTrashed: false });
-    expect(chats.map((c) => c.id)).toContain("session-1");
+    expect(chats.map((c) => c.sourceId)).toContain("session-1");
   });
 
   it("surfaces project from the archive chat row", () => {
@@ -131,7 +143,7 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.project).toBe("project-a");
   });
 
@@ -163,7 +175,7 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.title).toBe("Build a login page");
   });
 
@@ -188,7 +200,7 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.title).toBe("My favourite chat");
   });
 
@@ -204,7 +216,7 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.title).toBe("Untitled");
   });
 
@@ -236,7 +248,7 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.createdAt).toBe(1700000100000);
     expect(chat?.updatedAt).toBe(1700000500000);
   });
@@ -253,12 +265,35 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.createdAt).toBe(1700000000000);
     expect(chat?.updatedAt).toBe(1700000000000);
   });
 
-  it("returns a 6-char Crockford chatId from the archive chat row", () => {
+  it("exposes id as the wire-form chat id and sourceId as the source id", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const code = archive.read.findChatBySourceId("session-1")!.chatId;
+
+    const reader = createChatReader({ archive, metadata });
+    const chat = reader
+      .listChats({ includeTrashed: false })
+      .find((c) => c.sourceId === "session-1");
+    // id is the public wire-form chat id (clog_ + 6 Crockford chars).
+    expect(chat?.id).toBe(`clog_${code}`);
+    expect(code).toHaveLength(6);
+    const allowed = new Set(CROCKFORD_ALPHABET);
+    for (const ch of code) expect(allowed.has(ch)).toBe(true);
+    // sourceId carries the source id for display, never as a handle.
+    expect(chat?.sourceId).toBe("session-1");
+  });
+
+  it("does not expose a chatId field (collapsed into id)", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
 
@@ -270,10 +305,9 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
-    expect(chat?.chatId).toHaveLength(6);
-    const allowed = new Set(CROCKFORD_ALPHABET);
-    for (const ch of chat!.chatId) expect(allowed.has(ch)).toBe(true);
+      .find((c) => c.sourceId === "session-1");
+    expect(chat).toBeDefined();
+    expect("chatId" in chat!).toBe(false);
   });
 
   it("returns sourceFilePath from the most-recently-ingested raw row", () => {
@@ -300,7 +334,7 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.sourceFilePath).toBe("/new/path.jsonl");
   });
 
@@ -316,7 +350,7 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.sourceFilePath).toBeNull();
   });
 
@@ -332,7 +366,7 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.agent).toBe("claude-code");
   });
 
@@ -350,7 +384,7 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.projectPath).toBe("/Users/evaaaaawu/Documents/chat-logbook");
   });
 
@@ -366,7 +400,7 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.projectPath).toBeNull();
   });
 
@@ -383,7 +417,7 @@ describe("ChatReader.listChats", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.project).toBe("");
   });
 });
@@ -400,7 +434,7 @@ describe("ChatReader visibility", () => {
 
     const reader = createChatReader({ archive, metadata });
     const chats = reader.listChats({ includeTrashed: false });
-    expect(chats.map((c) => c.id)).not.toContain("session-1");
+    expect(chats.map((c) => c.sourceId)).not.toContain("session-1");
   });
 
   it("includes trashed chats with isDeleted flag when includeTrashed", () => {
@@ -415,7 +449,7 @@ describe("ChatReader visibility", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: true })
-      .find((c) => c.id === "session-1");
+      .find((c) => c.sourceId === "session-1");
     expect(chat?.isDeleted).toBe(true);
   });
 
@@ -435,8 +469,8 @@ describe("ChatReader visibility", () => {
 
     const reader = createChatReader({ archive, metadata });
     const chats = reader.listChats({ includeTrashed: true });
-    const active = chats.find((c) => c.id === "session-active");
-    const trashed = chats.find((c) => c.id === "session-trashed");
+    const active = chats.find((c) => c.sourceId === "session-active");
+    const trashed = chats.find((c) => c.sourceId === "session-trashed");
     expect(active?.deletedAt).toBeNull();
     expect(typeof trashed?.deletedAt).toBe("number");
     expect(trashed!.deletedAt!).toBeGreaterThanOrEqual(before);
@@ -470,7 +504,9 @@ describe("ChatReader.getMessages", () => {
     });
 
     const reader = createChatReader({ archive, metadata });
-    const messages = reader.getMessages("session-1", { includeTrashed: false });
+    const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
+      includeTrashed: false,
+    });
     expect(messages).toHaveLength(2);
     expect(messages![0].role).toBe("user");
     expect(messages![0].content).toEqual([
@@ -495,15 +531,14 @@ describe("ChatReader.getMessages", () => {
       text: "hi",
       blocks: [{ type: "text", text: "hi" }],
     });
+    const wireId = wireIdFor(archive, "session-1");
     metadata.softDelete(internalId);
 
     const reader = createChatReader({ archive, metadata });
-    expect(
-      reader.getMessages("session-1", { includeTrashed: false })
-    ).toBeNull();
+    expect(reader.getMessages(wireId, { includeTrashed: false })).toBeNull();
   });
 
-  it("returns null for an absent chat id", () => {
+  it("returns null for an absent (malformed) chat id", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
 
@@ -511,6 +546,51 @@ describe("ChatReader.getMessages", () => {
     expect(
       reader.getMessages("does-not-exist", { includeTrashed: false })
     ).toBeNull();
+  });
+
+  it("returns null when resolved by source id rather than the chat id", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m1",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "hi",
+      blocks: [{ type: "text", text: "hi" }],
+    });
+
+    const reader = createChatReader({ archive, metadata });
+    // Source id is no longer a public lookup key — only the wire-form chat id is.
+    expect(
+      reader.getMessages("session-1", { includeTrashed: false })
+    ).toBeNull();
+  });
+
+  it("returns null when resolved by the bare chat_id code without the prefix", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m1",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "hi",
+      blocks: [{ type: "text", text: "hi" }],
+    });
+    const bareCode = archive.read.findChatBySourceId("session-1")!.chatId;
+
+    const reader = createChatReader({ archive, metadata });
+    // Strict: only the clog_ wire form resolves; the bare code does not.
+    expect(reader.getMessages(bareCode, { includeTrashed: false })).toBeNull();
   });
 
   it("maps tool_result blocks back to snake_case for the API contract", () => {
@@ -531,7 +611,9 @@ describe("ChatReader.getMessages", () => {
     });
 
     const reader = createChatReader({ archive, metadata });
-    const messages = reader.getMessages("session-1", { includeTrashed: false });
+    const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
+      includeTrashed: false,
+    });
     expect(messages![0].content).toEqual([
       { type: "tool_result", tool_use_id: "tool-1", content: "result" },
     ]);
@@ -561,11 +643,11 @@ describe("ChatReader is agent-agnostic", () => {
     const reader = createChatReader({ archive, metadata });
     const chat = reader
       .listChats({ includeTrashed: false })
-      .find((c) => c.id === "session-codex");
+      .find((c) => c.sourceId === "session-codex");
     expect(chat?.agent).toBe("codex");
     expect(chat?.title).toBe("Hello from Codex");
 
-    const messages = reader.getMessages("session-codex", {
+    const messages = reader.getMessages(wireIdFor(archive, "session-codex"), {
       includeTrashed: false,
     });
     expect(messages).toHaveLength(1);
@@ -764,25 +846,25 @@ describe("ChatReader.listChats query batching", () => {
     const chats = reader.listChats({ includeTrashed: false });
 
     // Ordering mirrors the chat-row insertion order.
-    expect(chats.map((c) => c.id)).toEqual([
+    expect(chats.map((c) => c.sourceId)).toEqual([
       "session-a",
       "session-b",
       "session-c",
     ]);
 
-    const a = chats.find((c) => c.id === "session-a")!;
+    const a = chats.find((c) => c.sourceId === "session-a")!;
     expect(a.title).toBe("Title from A");
     expect(a.sourceFilePath).toBe("/a/new.jsonl");
     expect(a.createdAt).toBe(1700000100000);
     expect(a.updatedAt).toBe(1700000800000);
 
-    const b = chats.find((c) => c.id === "session-b")!;
+    const b = chats.find((c) => c.sourceId === "session-b")!;
     expect(b.title).toBe("Custom B title");
     expect(b.sourceFilePath).toBe("/b/only.jsonl");
     expect(b.createdAt).toBe(1700000200000);
     expect(b.updatedAt).toBe(1700000200000);
 
-    const c = chats.find((c) => c.id === "session-c")!;
+    const c = chats.find((c) => c.sourceId === "session-c")!;
     expect(c.title).toBe("Untitled");
     expect(c.sourceFilePath).toBeNull();
     expect(c.createdAt).toBe(1700000050000);

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -1,4 +1,5 @@
 import type { ArchiveRepository } from "./archive/repository.js";
+import { formatChatId, parseChatId } from "./archive/chat-id.js";
 import type { ChatRow } from "./archive/read-seam.js";
 import type { MetadataRepository } from "./metadata/repository.js";
 import { loadChatVisibility } from "./visibility.js";
@@ -14,8 +15,10 @@ import { loadChatVisibility } from "./visibility.js";
 export type ChatRecord = ChatRow;
 
 export interface ChatResponse {
+  /** Public wire-form chat id (`clog_…`) — the canonical, paste-anywhere handle. */
   id: string;
-  chatId: string;
+  /** The originating Agent's source id, surfaced for display only — never a handle. */
+  sourceId: string;
   agent: string;
   title: string;
   project: string;
@@ -58,15 +61,19 @@ function toApiBlock(block: StoredBlock): ApiContentBlock {
 export interface ChatReader {
   listChats(opts: { includeTrashed: boolean }): ChatResponse[];
   /**
-   * Messages for a Chat resolved by its source id. Returns null when the row
-   * is absent or not visible — the caller maps both to 404 (the two existing
-   * 404 paths collapse into one, behavior-preserving).
+   * Messages for a Chat resolved by its public wire-form chat id (`clog_…`).
+   * Returns null when the id is malformed, no chat matches, or it is not visible
+   * — the caller maps all of these to 404 (the 404 paths collapse into one).
    */
   getMessages(
     id: string,
     opts: { includeTrashed: boolean }
   ): MessageResponse[] | null;
-  /** Resolve a Chat by its source id for the mutation routes. */
+  /**
+   * Resolve a Chat by its public wire-form chat id (`clog_…`) for the mutation
+   * routes. Returns null when the id is malformed or no chat matches — both map
+   * to 404. Source ids and bare codes do not resolve.
+   */
   findChat(id: string): ChatRecord | null;
 }
 
@@ -80,7 +87,9 @@ export function createChatReader({
   metadata,
 }: ChatReaderDeps): ChatReader {
   function findChat(id: string): ChatRecord | null {
-    return archive.read.findChatBySourceId(id);
+    const code = parseChatId(id);
+    if (code === null) return null;
+    return archive.read.findChatByChatId(code);
   }
 
   function deriveTitle(
@@ -136,8 +145,8 @@ export function createChatReader({
       const tsRange = tsRangeByKey.get(rowKey);
       const firstSeenAtMs = row.firstSeenAt.getTime();
       const chat: ChatResponse = {
-        id: row.sourceId,
-        chatId: row.chatId,
+        id: formatChatId(row.chatId),
+        sourceId: row.sourceId,
         agent: row.agent,
         title: deriveTitle(
           customTitleById.get(row.id),

--- a/web/e2e/virtual-scrolling.spec.ts
+++ b/web/e2e/virtual-scrolling.spec.ts
@@ -23,8 +23,8 @@ test.describe("Virtual scrolling", () => {
         json: {
           chats: [
             {
-              id: "large-chat",
-              chatId: "LARGEC",
+              id: "clog_large1",
+              sourceId: "large-chat",
               agent: "claude-code",
               title: "Large conversation",
               project: "/test/project",
@@ -37,7 +37,7 @@ test.describe("Virtual scrolling", () => {
       })
     );
 
-    await page.route(/\/api\/chats\/large-chat(\?|$)/, (route) =>
+    await page.route(/\/api\/chats\/clog_large1(\?|$)/, (route) =>
       route.fulfill({
         json: { messages: generateMessages(MESSAGE_COUNT) },
       })

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -302,7 +302,7 @@ describe("Chat metadata popover", () => {
           chats: [
             {
               id: "chat-x",
-              chatId: "CHATXX",
+              sourceId: "CHATXX",
               agent: "claude-code",
               title: "Full path chat",
               project: "chat-logbook",
@@ -339,7 +339,7 @@ describe("Chat metadata popover", () => {
           chats: [
             {
               id: "chat-y",
-              chatId: "CHATYY",
+              sourceId: "CHATYY",
               agent: "claude-code",
               title: "Basename fallback chat",
               project: "legacy-basename",
@@ -371,7 +371,7 @@ describe("Chat metadata popover", () => {
           chats: [
             {
               id: "chat-x",
-              chatId: "CHATXX",
+              sourceId: "CHATXX",
               agent: "claude-code",
               title: "No project chat",
               project: "",
@@ -948,7 +948,7 @@ describe("Empty states", () => {
           chats: [
             {
               id: "chat-1",
-              chatId: "CHAT01",
+              sourceId: "CHAT01",
               agent: "claude-code",
               title: "Build a login page",
               project: "/Users/test/my-web-app",
@@ -978,7 +978,7 @@ describe("Empty states", () => {
           chats: [
             {
               id: "chat-deleted-only",
-              chatId: "CHATDX",
+              sourceId: "CHATDX",
               agent: "claude-code",
               title: "Only deleted",
               project: "/Users/test/p",
@@ -1358,7 +1358,7 @@ describe("Tool call rendering (continued)", () => {
 describe("Freeze sort order on background updates", () => {
   type WireChat = {
     id: string;
-    chatId: string;
+    sourceId: string;
     agent: string;
     title: string;
     project: string;
@@ -1376,7 +1376,7 @@ describe("Freeze sort order on background updates", () => {
     return [
       {
         id: "chat-2",
-        chatId: "CHAT02",
+        sourceId: "CHAT02",
         agent: "claude-code",
         title: "Fix database migration",
         project: "backend-api",
@@ -1387,7 +1387,7 @@ describe("Freeze sort order on background updates", () => {
       },
       {
         id: "chat-1",
-        chatId: "CHAT01",
+        sourceId: "CHAT01",
         agent: "claude-code",
         title: "Build a login page",
         project: "my-web-app",
@@ -1398,7 +1398,7 @@ describe("Freeze sort order on background updates", () => {
       },
       {
         id: "chat-3",
-        chatId: "CHAT03",
+        sourceId: "CHAT03",
         agent: "claude-code",
         title: "Refactor utils",
         project: "my-web-app",
@@ -1409,7 +1409,7 @@ describe("Freeze sort order on background updates", () => {
       },
       {
         id: "chat-missing",
-        chatId: "CHATMI",
+        sourceId: "CHATMI",
         agent: "claude-code",
         title: "Untitled",
         project: "some-project",
@@ -1427,7 +1427,7 @@ describe("Freeze sort order on background updates", () => {
     return [
       {
         id: "chat-deleted-1",
-        chatId: "CHATDE",
+        sourceId: "CHATDE",
         agent: "claude-code",
         title: "Old prototype",
         project: "my-web-app",
@@ -1440,7 +1440,7 @@ describe("Freeze sort order on background updates", () => {
       },
       {
         id: "chat-deleted-2",
-        chatId: "CHATD2",
+        sourceId: "CHATD2",
         agent: "claude-code",
         title: "Newer experiment",
         project: "my-web-app",
@@ -1574,7 +1574,7 @@ describe("Freeze sort order on background updates", () => {
       const withNew = activeChats();
       withNew.push({
         id: "chat-new",
-        chatId: "CHATNW",
+        sourceId: "CHATNW",
         agent: "claude-code",
         title: "Fresh ingest",
         project: "my-web-app",

--- a/web/src/chat/sort/freezeSortOrder.test.ts
+++ b/web/src/chat/sort/freezeSortOrder.test.ts
@@ -5,7 +5,7 @@ import { applyHeldOrder } from "./freezeSortOrder";
 function chat(id: string): Chat {
   return {
     id,
-    chatId: id.toUpperCase(),
+    sourceId: id.toUpperCase(),
     agent: "claude-code",
     title: id,
     project: "p",

--- a/web/src/chat/sort/sortChats.test.ts
+++ b/web/src/chat/sort/sortChats.test.ts
@@ -5,7 +5,7 @@ import { sortChats } from "./sortChats";
 function makeChat(overrides: Partial<Chat>): Chat {
   return {
     id: "id",
-    chatId: "CHAT",
+    sourceId: "session-1",
     agent: "claude-code",
     title: "",
     project: "p",

--- a/web/src/chat/sort/useChatOrder.test.tsx
+++ b/web/src/chat/sort/useChatOrder.test.tsx
@@ -6,7 +6,7 @@ import { useChatOrder } from "@/chat/sort/useChatOrder";
 function chat(id: string, fields: Partial<Chat> = {}): Chat {
   return {
     id,
-    chatId: id.toUpperCase(),
+    sourceId: id.toUpperCase(),
     agent: "claude-code",
     title: id,
     project: "p",

--- a/web/src/metadata/ChatMetadataPopover.tsx
+++ b/web/src/metadata/ChatMetadataPopover.tsx
@@ -195,14 +195,14 @@ export function ChatMetadataPopover({ chat }: ChatMetadataPopoverProps) {
           <SectionLabel>Identifiers & location</SectionLabel>
           <CopyableField
             label="Chat ID"
-            display={chat.chatId}
-            copyValue={chat.chatId}
+            display={chat.id}
+            copyValue={chat.id}
             copyAriaLabel="Copy chat id"
           />
           <CopyableField
             label="Source ID"
-            display={<TruncatedPath value={chat.id} />}
-            copyValue={chat.id}
+            display={<TruncatedPath value={chat.sourceId} />}
+            copyValue={chat.sourceId}
             copyAriaLabel="Copy source id"
           />
           {chat.sourceFilePath ? (

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from "msw";
 
 type FakeChat = {
   id: string;
-  chatId: string;
+  sourceId: string;
   agent: string;
   defaultTitle: string;
   customTitle: string | null;
@@ -18,7 +18,7 @@ type FakeChat = {
 const initialFakeChats: FakeChat[] = [
   {
     id: "chat-1",
-    chatId: "CHAT01",
+    sourceId: "CHAT01",
     agent: "claude-code",
     defaultTitle: "Build a login page",
     customTitle: null,
@@ -30,7 +30,7 @@ const initialFakeChats: FakeChat[] = [
   },
   {
     id: "chat-2",
-    chatId: "CHAT02",
+    sourceId: "CHAT02",
     agent: "claude-code",
     defaultTitle: "Fix database migration",
     customTitle: null,
@@ -42,7 +42,7 @@ const initialFakeChats: FakeChat[] = [
   },
   {
     id: "chat-3",
-    chatId: "CHAT03",
+    sourceId: "CHAT03",
     agent: "claude-code",
     defaultTitle: "Refactor utils",
     customTitle: null,
@@ -54,7 +54,7 @@ const initialFakeChats: FakeChat[] = [
   },
   {
     id: "chat-missing",
-    chatId: "CHATMI",
+    sourceId: "CHATMI",
     agent: "claude-code",
     defaultTitle: "Untitled",
     customTitle: null,
@@ -66,7 +66,7 @@ const initialFakeChats: FakeChat[] = [
   },
   {
     id: "chat-deleted-1",
-    chatId: "CHATDE",
+    sourceId: "CHATDE",
     agent: "claude-code",
     defaultTitle: "Old prototype",
     customTitle: null,
@@ -81,7 +81,7 @@ const initialFakeChats: FakeChat[] = [
   },
   {
     id: "chat-deleted-2",
-    chatId: "CHATD2",
+    sourceId: "CHATD2",
     agent: "claude-code",
     defaultTitle: "Newer experiment",
     customTitle: null,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,6 +1,8 @@
 export interface Chat {
+  /** Public wire-form chat id (`clog_…`) — the canonical handle used for routing. */
   id: string;
-  chatId: string;
+  /** The originating Agent's source id, surfaced for display only. */
+  sourceId: string;
   agent: string;
   title: string;
   project: string;


### PR DESCRIPTION
## Background (Why)

The HTTP API exposed the Agent's **source id** as a Chat's public handle: `GET /api/chats` returned `id: <source id>`, and every per-Chat route resolved `:id` by source id. That contradicts ADR-0009 and `CONTEXT.md`, which reserve the public, paste-anywhere handle for the **chat id** (wire form `clog_a3f7kx`). It is also a latent bug: source id is only unique as `(agent, source_id)`, so it collides across agents, whereas `chat_id` is a single-column unique key.

## Approach (How)

Switch the public identifier to the wire-form chat id end to end, keeping the seam-based read architecture intact:

- The wire form's shape lives in one place: `chat-id.ts` gains `CHAT_ID_PREFIX`, `formatChatId`, and `parseChatId`. `parseChatId` is strict — only `clog_` + 6 Crockford characters resolves; anything else (bare code, source id, malformed) returns `null` and collapses into the existing 404 path.
- `ChatReader.findChat` is the single resolution point (per #105): it parses the wire form and resolves via the new `archive.read.findChatByChatId`. `getMessages` follows through `findChat`. `findChatBySourceId` stays as an internal seam primitive for ingestion/repository.
- `listChats` outputs `id: formatChatId(chat_id)` and adds `sourceId` (display-only); the redundant `chatId` field is removed.
- The web client already keys routing on `chat.id`, so it picks up the wire form transparently; `types.ts` swaps `chatId` for `sourceId`, and the metadata popover reads `chat.id` for "Chat ID" and `chat.sourceId` for "Source ID".

No new ADR or `CONTEXT.md` change: this executes ADR-0009's stated design. Stored ids (`chats.id`, `source_id`, `chat_id`) are untouched.

## Changes (What)

- [x] `chat-id.ts`: add `CHAT_ID_PREFIX`, `formatChatId`, strict `parseChatId`
- [x] `read-seam.ts`: add `findChatByChatId` (keep `findChatBySourceId`)
- [x] `chat-reader.ts`: `findChat` resolves strictly by wire-form chat id; `listChats` emits `id` (wire form) + `sourceId`, drops `chatId`
- [x] `app.ts`: unchanged — routes pass `:id` straight to the wire-form resolver
- [x] web `types.ts` + `ChatMetadataPopover.tsx`: `chatId` → `sourceId`; popover fields re-sourced

### Test Verification

- [x] `parseChatId`/`formatChatId` round-trip `clog_a3f7kx` ↔ `a3f7kx`; malformed input (missing prefix, wrong length, non-Crockford, uppercase) → `null`
- [x] `findChat`/`getMessages` resolve by wire-form chat id; source id and bare code both return `null`
- [x] `listChats` exposes `id` as the wire form and `sourceId`, no `chatId` field
- [x] Routes (`GET /:id`, `DELETE`, restore, `PATCH title`) resolve by wire form; `GET /api/chats/:sourceId` 404s; 400 validation still reached for a resolving id
- [x] Visibility and 404 behavior unchanged (trashed default 404, `includeTrashed=true` visible)
- [x] Full suite green: api 154 + web 113 = 267 tests; both packages typecheck clean

## Additional Notes

`app.ts` required no change — the route layer transparently inherits the new contract through `ChatReader`. The web e2e fixture was updated to the new id shape but Playwright e2e was not run as part of this loop.

## Related Links

- Closes #108