### PR TITLE
feat: filter chats by Project in the navigation panel

### DIFF
--- a/api/drizzle/archive/0008_add_chats_project_idx.sql
+++ b/api/drizzle/archive/0008_add_chats_project_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `chats_project_idx` ON `chats` (`project`);

--- a/api/drizzle/archive/meta/_journal.json
+++ b/api/drizzle/archive/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1779200000000,
       "tag": "0007_drop_session_scan_state",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1779300000000,
+      "tag": "0008_add_chats_project_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -534,6 +534,131 @@ describe("PATCH /api/chats/:id/title", () => {
   });
 });
 
+describe("GET /api/chats?project= (server-side Project filter)", () => {
+  it("filters to a single project", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedChat(archive, {
+      sourceId: "session-a",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+    seedChat(archive, {
+      sourceId: "session-b",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-b",
+    });
+
+    const app = createApp({ archive, metadata });
+    const res = await app.request("/api/chats?project=project-a");
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    expect(body.chats.map((c) => c.sourceId)).toEqual(["session-a"]);
+  });
+
+  it("unions chats across repeated project params (OR)", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedChat(archive, {
+      sourceId: "session-a",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+    seedChat(archive, {
+      sourceId: "session-b",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-b",
+    });
+    seedChat(archive, {
+      sourceId: "session-c",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-c",
+    });
+
+    const app = createApp({ archive, metadata });
+    const res = await app.request(
+      "/api/chats?project=project-a&project=project-c"
+    );
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    expect(body.chats.map((c) => c.sourceId).sort()).toEqual([
+      "session-a",
+      "session-c",
+    ]);
+  });
+
+  it("selects the (No project) group when project= is empty", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedChat(archive, {
+      sourceId: "session-none",
+      firstSeenAt: new Date(1700000000000),
+      project: null,
+    });
+    seedChat(archive, {
+      sourceId: "session-a",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+
+    const app = createApp({ archive, metadata });
+    const res = await app.request("/api/chats?project=");
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    expect(body.chats.map((c) => c.sourceId)).toEqual(["session-none"]);
+  });
+
+  it("returns every chat when no project param is given", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedChat(archive, {
+      sourceId: "session-a",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+    seedChat(archive, {
+      sourceId: "session-b",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-b",
+    });
+
+    const app = createApp({ archive, metadata });
+    const res = await app.request("/api/chats");
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    expect(body.chats.map((c) => c.sourceId).sort()).toEqual([
+      "session-a",
+      "session-b",
+    ]);
+  });
+
+  it("composes with includeTrashed within the active view", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    seedChat(archive, {
+      sourceId: "session-active",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+    const trashedId = seedChat(archive, {
+      sourceId: "session-trashed",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+    metadata.softDelete(trashedId);
+
+    const app = createApp({ archive, metadata });
+    const main = await app.request("/api/chats?project=project-a");
+    const mainBody = (await main.json()) as { chats: ChatResponse[] };
+    expect(mainBody.chats.map((c) => c.sourceId)).toEqual(["session-active"]);
+
+    const trash = await app.request(
+      "/api/chats?project=project-a&includeTrashed=true"
+    );
+    const trashBody = (await trash.json()) as { chats: ChatResponse[] };
+    expect(trashBody.chats.map((c) => c.sourceId).sort()).toEqual([
+      "session-active",
+      "session-trashed",
+    ]);
+  });
+});
+
 describe("GET /api/chats/:id (route status mapping)", () => {
   it("returns 404 when archive has no chat for the given id", async () => {
     const archive = createArchiveRepository({ dataDir });

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -15,8 +15,12 @@ export function createApp({ archive, metadata, webDistDir }: AppOptions) {
   const reader = createChatReader({ archive, metadata });
 
   app.get("/api/chats", (c) => {
+    // Repeated `?project=` params union (OR); an empty value selects the
+    // `(No project)` group. Absent param => undefined => unfiltered.
+    const projects = c.req.queries("project");
     const chats = reader.listChats({
       includeTrashed: c.req.query("includeTrashed") === "true",
+      projects,
     });
     return c.json({ chats });
   });

--- a/api/src/archive/read-seam.ts
+++ b/api/src/archive/read-seam.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import type { ArchiveDb } from "./repository.js";
 import { chats, ingestionEvents, messages, rawMessages } from "./schema.js";
 
@@ -37,8 +37,13 @@ export interface FirstUserText {
 }
 
 export interface ArchiveReadSeam {
-  /** Every chat row, in insertion order. */
-  listChatRows(): ChatRow[];
+  /**
+   * Chat rows in insertion order. With `projects`, filters server-side to rows
+   * whose project is in the set (OR / union) — an empty-string entry selects
+   * the `(No project)` group (project NULL or ''). An empty array filters to
+   * nothing; omitting `projects` returns every row.
+   */
+  listChatRows(opts?: { projects?: string[] }): ChatRow[];
   /** Resolve a chat by its source id; null when absent. */
   findChatBySourceId(sourceId: string): ChatRow | null;
   /** Resolve a chat by its bare chat_id code (the public handle); null when absent. */
@@ -66,7 +71,17 @@ export interface ArchiveReadSeam {
 
 export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
   return {
-    listChatRows() {
+    listChatRows(opts) {
+      const projects = opts?.projects;
+      if (projects) {
+        // Empty-string entries select the `(No project)` group, so compare
+        // against COALESCE(project,'') to fold NULL and '' into one bucket.
+        return db
+          .select()
+          .from(chats)
+          .where(inArray(sql`coalesce(${chats.project}, '')`, projects))
+          .all();
+      }
       return db.select().from(chats).all();
     },
     findChatBySourceId(sourceId) {

--- a/api/src/archive/schema.ts
+++ b/api/src/archive/schema.ts
@@ -1,4 +1,5 @@
 import {
+  index,
   integer,
   sqliteTable,
   text,
@@ -27,7 +28,11 @@ export const chats = sqliteTable(
     project: text("project"),
     projectPath: text("project_path"),
   },
-  (t) => [uniqueIndex("chats_agent_source_idx").on(t.agent, t.sourceId)]
+  (t) => [
+    uniqueIndex("chats_agent_source_idx").on(t.agent, t.sourceId),
+    // Backs the server-side Project filter (`WHERE coalesce(project,'') IN …`).
+    index("chats_project_idx").on(t.project),
+  ]
 );
 
 export const rawMessages = sqliteTable(

--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -422,6 +422,118 @@ describe("ChatReader.listChats", () => {
   });
 });
 
+describe("ChatReader.listChats project filter", () => {
+  it("returns only chats in the given project", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-a",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+    seedChat(archive, {
+      sourceId: "session-b",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-b",
+    });
+
+    const reader = createChatReader({ archive, metadata });
+    const chats = reader.listChats({
+      includeTrashed: false,
+      projects: ["project-a"],
+    });
+    expect(chats.map((c) => c.sourceId)).toEqual(["session-a"]);
+  });
+
+  it("returns the union of chats across several projects (OR)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-a",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+    seedChat(archive, {
+      sourceId: "session-b",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-b",
+    });
+    seedChat(archive, {
+      sourceId: "session-c",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-c",
+    });
+
+    const reader = createChatReader({ archive, metadata });
+    const chats = reader.listChats({
+      includeTrashed: false,
+      projects: ["project-a", "project-c"],
+    });
+    expect(chats.map((c) => c.sourceId).sort()).toEqual([
+      "session-a",
+      "session-c",
+    ]);
+  });
+
+  it("selects the (No project) group when the filter value is the empty string", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-none",
+      firstSeenAt: new Date(1700000000000),
+      project: null,
+    });
+    seedChat(archive, {
+      sourceId: "session-a",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+
+    const reader = createChatReader({ archive, metadata });
+    const chats = reader.listChats({
+      includeTrashed: false,
+      projects: [""],
+    });
+    expect(chats.map((c) => c.sourceId)).toEqual(["session-none"]);
+  });
+
+  it("composes the project filter with trash visibility (active view only)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-active",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+    const trashedId = seedChat(archive, {
+      sourceId: "session-trashed",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+    metadata.softDelete(trashedId);
+
+    const reader = createChatReader({ archive, metadata });
+    const active = reader.listChats({
+      includeTrashed: false,
+      projects: ["project-a"],
+    });
+    expect(active.map((c) => c.sourceId)).toEqual(["session-active"]);
+
+    const trash = reader.listChats({
+      includeTrashed: true,
+      projects: ["project-a"],
+    });
+    expect(trash.map((c) => c.sourceId).sort()).toEqual([
+      "session-active",
+      "session-trashed",
+    ]);
+  });
+});
+
 describe("ChatReader visibility", () => {
   it("excludes trashed chats by default", () => {
     const archive = createArchiveRepository({ dataDir });

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -59,7 +59,15 @@ function toApiBlock(block: StoredBlock): ApiContentBlock {
 }
 
 export interface ChatReader {
-  listChats(opts: { includeTrashed: boolean }): ChatResponse[];
+  /**
+   * List visible chats. `projects`, when given, filters server-side to chats in
+   * any of those Projects (OR / union); an empty-string entry selects the
+   * `(No project)` group. Omitting it returns every visible chat.
+   */
+  listChats(opts: {
+    includeTrashed: boolean;
+    projects?: string[];
+  }): ChatResponse[];
   /**
    * Messages for a Chat resolved by its public wire-form chat id (`clog_…`).
    * Returns null when the id is malformed, no chat matches, or it is not visible
@@ -109,11 +117,13 @@ export function createChatReader({
 
   function listChats({
     includeTrashed,
+    projects,
   }: {
     includeTrashed: boolean;
+    projects?: string[];
   }): ChatResponse[] {
     const visibility = loadChatVisibility(metadata, { includeTrashed });
-    const rows = archive.read.listChatRows();
+    const rows = archive.read.listChatRows(projects ? { projects } : undefined);
 
     // One grouped/windowed query per derived field, assembled in memory keyed
     // by (agent, source_id) — so listing N chats stays a constant query count

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -25,9 +25,13 @@ describe("Chat list", () => {
 
     await screen.findByText("Build a login page");
 
-    // Project name: last segment of path
-    expect(screen.getAllByText("my-web-app").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("backend-api")).toBeInTheDocument();
+    // Project name: last segment of path. Scope to the chat list — the
+    // navigation panel's Projects section also renders these names.
+    const list = screen.getByTestId("chat-list");
+    expect(
+      within(list).getAllByText("my-web-app").length
+    ).toBeGreaterThanOrEqual(1);
+    expect(within(list).getByText("backend-api")).toBeInTheDocument();
   });
 
   it("sorts sessions by updatedAt descending (most recent first)", async () => {
@@ -1627,5 +1631,101 @@ describe("Freeze sort order on background updates", () => {
     });
     rows = within(list).getAllByTestId("chat-row");
     expect(rows[rows.length - 1].textContent).toContain("Zzz renamed last");
+  });
+});
+
+describe("Project filter", () => {
+  it("filters the chat list to the clicked Project", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("project-row-backend-api"));
+
+    const list = screen.getByTestId("chat-list");
+    await waitFor(() => {
+      expect(
+        within(list).queryByText("Build a login page")
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      within(list).getByText("Fix database migration")
+    ).toBeInTheDocument();
+  });
+
+  it("unions chats across several selected Projects (OR)", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    await user.click(screen.getByTestId("project-row-my-web-app"));
+    await user.click(screen.getByTestId("project-row-backend-api"));
+
+    const list = screen.getByTestId("chat-list");
+    expect(within(list).getByText("Build a login page")).toBeInTheDocument();
+    expect(
+      within(list).getByText("Fix database migration")
+    ).toBeInTheDocument();
+    // some-project's chat ("Untitled") is in neither selected project.
+    await waitFor(() => {
+      expect(within(list).queryByText("Untitled")).not.toBeInTheDocument();
+    });
+  });
+
+  it("marks the selected Project row as pressed", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    const row = screen.getByTestId("project-row-backend-api");
+    expect(row).toHaveAttribute("aria-pressed", "false");
+    await user.click(row);
+    expect(row).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows a 'filters active' summary and Clear restores the full list", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    // No filter active: the summary bar is hidden.
+    expect(screen.queryByTestId("filters-summary")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("project-row-backend-api"));
+
+    const summary = screen.getByTestId("filters-summary");
+    expect(summary).toHaveTextContent("1 filter active");
+
+    const list = screen.getByTestId("chat-list");
+    await waitFor(() => {
+      expect(
+        within(list).queryByText("Build a login page")
+      ).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("filters-clear"));
+    expect(
+      await within(list).findByText("Build a login page")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("filters-summary")).not.toBeInTheDocument();
+  });
+
+  it("derives Project counts from the active view (main vs Trash)", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    // Main view: backend-api has one active chat.
+    expect(screen.getByTestId("project-row-backend-api")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("trash-link"));
+
+    const section = await screen.findByTestId("projects-section");
+    // Trash has no backend-api chats, so its row is gone; my-web-app has two.
+    expect(
+      within(section).queryByTestId("project-row-backend-api")
+    ).not.toBeInTheDocument();
+    const webRow = within(section).getByTestId("project-row-my-web-app");
+    expect(within(webRow).getByText("2")).toBeInTheDocument();
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useChats } from "@/chat/useChats";
 import { useMessages } from "@/conversation/useMessages";
 import { useToast } from "@/shared/useToast";
 import { useChatOrder } from "@/chat/sort/useChatOrder";
+import { deriveProjects } from "@/chat/projects/deriveProjects";
+import { filterChatsByProjects } from "@/chat/projects/filterChatsByProjects";
 import { FilterPanel } from "@/chat/FilterPanel";
 import { ChatList } from "@/chat/ChatList";
 import { SortControl } from "@/chat/sort/SortControl";
@@ -43,7 +45,33 @@ function App() {
   const order = mode === "trash" ? trashOrder : mainOrder;
   const mainChats = mainOrder.orderedChats;
   const deletedChats = trashOrder.orderedChats;
-  const visibleChats = order.orderedChats;
+
+  // Project filter: an empty selection means "all Projects". Facets are derived
+  // from the active view's chats (so counts are per-view), and the selected
+  // Projects are ensured into the list so a selected Project stays visible even
+  // after its last chat leaves the view (count 0).
+  const [selectedProjects, setSelectedProjects] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
+  const toggleProject = useCallback((project: string) => {
+    setSelectedProjects((prev) => {
+      const next = new Set(prev);
+      if (next.has(project)) next.delete(project);
+      else next.add(project);
+      return next;
+    });
+  }, []);
+  const clearProjects = useCallback(() => setSelectedProjects(new Set()), []);
+
+  const projectFacets = useMemo(
+    () => deriveProjects(order.orderedChats, { ensure: [...selectedProjects] }),
+    [order.orderedChats, selectedProjects]
+  );
+
+  const visibleChats = filterChatsByProjects(
+    order.orderedChats,
+    selectedProjects
+  );
   const selectedChat = chats.find((c) => c.id === selectedId) ?? null;
 
   const handleRestore = (id: string) => {
@@ -131,6 +159,10 @@ function App() {
           <FilterPanel
             deletedCount={deletedChats.length}
             onOpenTrash={() => switchMode("trash")}
+            projectFacets={projectFacets}
+            selectedProjects={selectedProjects}
+            onToggleProject={toggleProject}
+            onClearFilters={clearProjects}
           />
         </ResizablePanel>
         <ResizableHandle />

--- a/web/src/chat/FilterPanel.tsx
+++ b/web/src/chat/FilterPanel.tsx
@@ -1,20 +1,41 @@
 import { Trash2 } from "lucide-react";
+import { ProjectsSection } from "@/chat/projects/ProjectsSection";
+import { FilterSummary } from "@/chat/FilterSummary";
+import type { ProjectFacet } from "@/chat/projects/deriveProjects";
 
 interface FilterPanelProps {
   deletedCount: number;
   onOpenTrash: () => void;
+  projectFacets: ProjectFacet[];
+  selectedProjects: ReadonlySet<string>;
+  onToggleProject: (project: string) => void;
+  onClearFilters: () => void;
 }
 
-export function FilterPanel({ deletedCount, onOpenTrash }: FilterPanelProps) {
+export function FilterPanel({
+  deletedCount,
+  onOpenTrash,
+  projectFacets,
+  selectedProjects,
+  onToggleProject,
+  onClearFilters,
+}: FilterPanelProps) {
   return (
     <div data-testid="filter-panel" className="flex h-full flex-col">
       <div className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4 text-sm font-semibold text-foreground">
         <div className="h-4 w-4 rounded bg-primary" />
         Chat Logbook
       </div>
-      <div className="flex-1 px-4 pt-8 text-center text-sm text-muted-foreground">
-        Filters coming soon
-        <div className="mt-1 text-xs">Projects, tags, search</div>
+      <div className="flex-1 overflow-y-auto px-2 py-2">
+        <FilterSummary
+          activeCount={selectedProjects.size}
+          onClear={onClearFilters}
+        />
+        <ProjectsSection
+          facets={projectFacets}
+          selected={selectedProjects}
+          onToggle={onToggleProject}
+        />
       </div>
       <div className="flex h-12 shrink-0 items-center border-t border-border px-2">
         <button

--- a/web/src/chat/FilterSummary.tsx
+++ b/web/src/chat/FilterSummary.tsx
@@ -1,0 +1,31 @@
+interface FilterSummaryProps {
+  /** How many filters are currently active (selected Projects, and later Tags). */
+  activeCount: number;
+  onClear: () => void;
+}
+
+/**
+ * The "N filters active — Clear" bar above the filter sections. Hidden when no
+ * filter is active. Clear resets every filter at once.
+ */
+export function FilterSummary({ activeCount, onClear }: FilterSummaryProps) {
+  if (activeCount === 0) return null;
+  return (
+    <div
+      data-testid="filters-summary"
+      className="flex items-center justify-between px-2 py-1.5 text-xs text-muted-foreground"
+    >
+      <span>
+        {activeCount} {activeCount === 1 ? "filter" : "filters"} active
+      </span>
+      <button
+        type="button"
+        data-testid="filters-clear"
+        onClick={onClear}
+        className="text-primary transition-colors hover:text-primary/80"
+      >
+        Clear
+      </button>
+    </div>
+  );
+}

--- a/web/src/chat/projects/ProjectsSection.test.tsx
+++ b/web/src/chat/projects/ProjectsSection.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { ProjectsSection } from "./ProjectsSection";
+import type { ProjectFacet } from "./deriveProjects";
+
+const facets: ProjectFacet[] = [
+  { project: "web", label: "web", count: 3, lastActiveAt: 30 },
+  { project: "api", label: "api", count: 1, lastActiveAt: 20 },
+  { project: "", label: "(No project)", count: 2, lastActiveAt: 10 },
+];
+
+function renderSection(overrides?: {
+  selected?: Set<string>;
+  onToggle?: (p: string) => void;
+}) {
+  return render(
+    <ProjectsSection
+      facets={facets}
+      selected={overrides?.selected ?? new Set()}
+      onToggle={overrides?.onToggle ?? (() => {})}
+    />
+  );
+}
+
+describe("ProjectsSection", () => {
+  it("renders a row per project showing its label and count", () => {
+    renderSection();
+    const section = screen.getByTestId("projects-section");
+    expect(within(section).getByText("web")).toBeInTheDocument();
+    expect(within(section).getByText("api")).toBeInTheDocument();
+    expect(within(section).getByText("(No project)")).toBeInTheDocument();
+    // The web row carries its count.
+    const webRow = screen.getByTestId("project-row-web");
+    expect(within(webRow).getByText("3")).toBeInTheDocument();
+  });
+
+  it("calls onToggle with the project when a row is clicked", async () => {
+    const onToggle = vi.fn();
+    renderSection({ onToggle });
+    await userEvent.click(screen.getByTestId("project-row-api"));
+    expect(onToggle).toHaveBeenCalledWith("api");
+  });
+
+  it("marks a selected row as pressed", () => {
+    renderSection({ selected: new Set(["web"]) });
+    expect(screen.getByTestId("project-row-web")).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    expect(screen.getByTestId("project-row-api")).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+  });
+
+  it("shows a check on the selected row only", () => {
+    const { container } = renderSection({ selected: new Set(["web"]) });
+    const webRow = screen.getByTestId("project-row-web");
+    const apiRow = screen.getByTestId("project-row-api");
+    // The check icon (lucide) renders as an svg with the `lucide-check` class.
+    expect(webRow.querySelector(".lucide-check")).not.toBeNull();
+    expect(apiRow.querySelector(".lucide-check")).toBeNull();
+    expect(container).toBeTruthy();
+  });
+
+  it("shows a 'Recent' order caption with a tooltip", () => {
+    renderSection();
+    const caption = screen.getByTestId("projects-order-caption");
+    expect(caption).toHaveTextContent("Recent");
+    expect(caption).toHaveAttribute("title", "Sorted by recent activity");
+  });
+
+  it("collapses and expands the project list from the header", async () => {
+    renderSection();
+    expect(screen.getByTestId("project-row-web")).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId("projects-header"));
+    expect(screen.queryByTestId("project-row-web")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByTestId("projects-header"));
+    expect(screen.getByTestId("project-row-web")).toBeInTheDocument();
+  });
+});

--- a/web/src/chat/projects/ProjectsSection.tsx
+++ b/web/src/chat/projects/ProjectsSection.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { Check, ChevronDown, Folder } from "lucide-react";
+import type { ProjectFacet } from "./deriveProjects";
+
+// Projects are ordered by recency; the caption captions that order, with the
+// detail in a tooltip.
+const ORDER_CAPTION = "Recent";
+const ORDER_TOOLTIP = "Sorted by recent activity";
+
+interface ProjectsSectionProps {
+  facets: ProjectFacet[];
+  selected: ReadonlySet<string>;
+  onToggle: (project: string) => void;
+}
+
+// A stable, selector-friendly id for the (No project) group, whose project
+// value is the empty string.
+function rowId(project: string): string {
+  return `project-row-${project === "" ? "none" : project}`;
+}
+
+export function ProjectsSection({
+  facets,
+  selected,
+  onToggle,
+}: ProjectsSectionProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div data-testid="projects-section" className="flex flex-col">
+      <button
+        type="button"
+        data-testid="projects-header"
+        onClick={() => setCollapsed((c) => !c)}
+        aria-expanded={!collapsed}
+        className="flex items-center justify-between px-2 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <span>Projects</span>
+        <span
+          data-testid="projects-order-caption"
+          title={ORDER_TOOLTIP}
+          className="flex items-center gap-0.5 text-muted-foreground/80"
+        >
+          {ORDER_CAPTION}
+          <ChevronDown
+            size={12}
+            aria-hidden="true"
+            className={`transition-transform ${collapsed ? "-rotate-90" : ""}`}
+          />
+        </span>
+      </button>
+      {!collapsed && (
+        <ul className="flex flex-col gap-0.5">
+          {facets.map((facet) => {
+            const isSelected = selected.has(facet.project);
+            const isNoProject = facet.project === "";
+            return (
+              <li key={facet.project || "__none__"}>
+                <button
+                  type="button"
+                  data-testid={rowId(facet.project)}
+                  aria-pressed={isSelected}
+                  onClick={() => onToggle(facet.project)}
+                  className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors ${
+                    isSelected
+                      ? "bg-primary/15 text-foreground"
+                      : "text-foreground/80 hover:bg-card"
+                  }`}
+                >
+                  <Folder
+                    size={15}
+                    aria-hidden="true"
+                    className={`shrink-0 ${
+                      isSelected
+                        ? "text-primary"
+                        : isNoProject
+                          ? "text-muted-foreground/60"
+                          : "text-muted-foreground"
+                    }`}
+                  />
+                  <span
+                    className={`min-w-0 flex-1 truncate ${
+                      isNoProject ? "italic text-muted-foreground" : ""
+                    }`}
+                  >
+                    {facet.label}
+                  </span>
+                  {isSelected && (
+                    <Check
+                      size={14}
+                      aria-hidden="true"
+                      className="shrink-0 text-primary"
+                    />
+                  )}
+                  <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                    {facet.count}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/chat/projects/deriveProjects.test.ts
+++ b/web/src/chat/projects/deriveProjects.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import type { Chat } from "@/types";
+import { deriveProjects } from "./deriveProjects";
+
+function chat(partial: Partial<Chat> & { id: string }): Chat {
+  return {
+    sourceId: partial.id,
+    agent: "claude-code",
+    title: partial.title ?? "Untitled",
+    project: partial.project ?? "",
+    projectPath: partial.projectPath ?? null,
+    sourceFilePath: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...partial,
+  };
+}
+
+describe("deriveProjects", () => {
+  it("groups chats by project with per-project counts", () => {
+    const facets = deriveProjects([
+      chat({ id: "a", project: "web", updatedAt: 3 }),
+      chat({ id: "b", project: "web", updatedAt: 2 }),
+      chat({ id: "c", project: "api", updatedAt: 1 }),
+    ]);
+    const byProject = new Map(facets.map((f) => [f.project, f.count]));
+    expect(byProject.get("web")).toBe(2);
+    expect(byProject.get("api")).toBe(1);
+  });
+
+  it("orders projects by recency, most-recently-active first", () => {
+    const facets = deriveProjects([
+      chat({ id: "a", project: "old", updatedAt: 10 }),
+      chat({ id: "b", project: "new", updatedAt: 100 }),
+      chat({ id: "c", project: "mid", updatedAt: 50 }),
+    ]);
+    expect(facets.map((f) => f.project)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("pins the (No project) group last regardless of recency", () => {
+    const facets = deriveProjects([
+      chat({ id: "a", project: "", updatedAt: 1000 }),
+      chat({ id: "b", project: "web", updatedAt: 5 }),
+    ]);
+    expect(facets[facets.length - 1].project).toBe("");
+  });
+
+  it("labels the empty-project group as (No project) and others by name", () => {
+    const facets = deriveProjects([
+      chat({ id: "a", project: "web", updatedAt: 2 }),
+      chat({ id: "b", project: "", updatedAt: 1 }),
+    ]);
+    const web = facets.find((f) => f.project === "web");
+    const none = facets.find((f) => f.project === "");
+    expect(web?.label).toBe("web");
+    expect(none?.label).toBe("(No project)");
+  });
+
+  it("keeps an ensured project visible at count 0 when no chats remain in it", () => {
+    const facets = deriveProjects(
+      [chat({ id: "a", project: "web", updatedAt: 2 })],
+      { ensure: ["api"] }
+    );
+    const api = facets.find((f) => f.project === "api");
+    expect(api).toBeDefined();
+    expect(api?.count).toBe(0);
+  });
+
+  it("does not duplicate an ensured project that still has chats", () => {
+    const facets = deriveProjects(
+      [chat({ id: "a", project: "web", updatedAt: 2 })],
+      { ensure: ["web"] }
+    );
+    expect(facets.filter((f) => f.project === "web")).toHaveLength(1);
+    expect(facets.find((f) => f.project === "web")?.count).toBe(1);
+  });
+});

--- a/web/src/chat/projects/deriveProjects.ts
+++ b/web/src/chat/projects/deriveProjects.ts
@@ -1,0 +1,69 @@
+import type { Chat } from "@/types";
+
+/** The pinned label for chats whose Project (working directory) is empty. */
+export const NO_PROJECT_LABEL = "(No project)";
+
+/** Display label for a Project value: the name, or `(No project)` when empty. */
+function labelFor(project: string): string {
+  return project === "" ? NO_PROJECT_LABEL : project;
+}
+
+export interface ProjectFacet {
+  /** The `chat.project` value; "" identifies the `(No project)` group. */
+  project: string;
+  /** Display label: the project name, or `(No project)` for the empty group. */
+  label: string;
+  /** How many of the given chats fall in this project. */
+  count: number;
+  /** Most-recent `updatedAt` across the group — the recency sort key. */
+  lastActiveAt: number;
+}
+
+/**
+ * Fold a chat list into the Projects facet list for the navigation panel:
+ * grouped by `project`, counted, and ordered by recency (most-recently-active
+ * Project first). The `(No project)` group is always pinned last, whatever its
+ * recency. Pure: returns a fresh array and never mutates the input.
+ *
+ * `ensure` keeps named Projects in the list even when no chat falls in them
+ * (count 0) — so a selected Project stays visible after its last chat leaves
+ * the active view.
+ */
+export function deriveProjects(
+  chats: Chat[],
+  opts?: { ensure?: string[] }
+): ProjectFacet[] {
+  const byProject = new Map<string, ProjectFacet>();
+  for (const p of opts?.ensure ?? []) {
+    byProject.set(p, {
+      project: p,
+      label: labelFor(p),
+      count: 0,
+      lastActiveAt: 0,
+    });
+  }
+  for (const c of chats) {
+    const existing = byProject.get(c.project);
+    if (existing) {
+      byProject.set(c.project, {
+        ...existing,
+        count: existing.count + 1,
+        lastActiveAt: Math.max(existing.lastActiveAt, c.updatedAt),
+      });
+    } else {
+      byProject.set(c.project, {
+        project: c.project,
+        label: labelFor(c.project),
+        count: 1,
+        lastActiveAt: c.updatedAt,
+      });
+    }
+  }
+
+  return [...byProject.values()].sort((a, b) => {
+    // The (No project) group sinks to the bottom regardless of recency.
+    if (a.project === "" && b.project !== "") return 1;
+    if (b.project === "" && a.project !== "") return -1;
+    return b.lastActiveAt - a.lastActiveAt;
+  });
+}

--- a/web/src/chat/projects/filterChatsByProjects.test.ts
+++ b/web/src/chat/projects/filterChatsByProjects.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import type { Chat } from "@/types";
+import { filterChatsByProjects } from "./filterChatsByProjects";
+
+function chat(id: string, project: string): Chat {
+  return {
+    id,
+    sourceId: id,
+    agent: "claude-code",
+    title: "Untitled",
+    project,
+    projectPath: null,
+    sourceFilePath: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe("filterChatsByProjects", () => {
+  const chats = [chat("a", "web"), chat("b", "api"), chat("c", "")];
+
+  it("returns every chat when the selection is empty", () => {
+    expect(filterChatsByProjects(chats, new Set()).map((c) => c.id)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("keeps only chats in the selected project", () => {
+    expect(
+      filterChatsByProjects(chats, new Set(["web"])).map((c) => c.id)
+    ).toEqual(["a"]);
+  });
+
+  it("unions chats across several selected projects (OR)", () => {
+    expect(
+      filterChatsByProjects(chats, new Set(["web", "api"])).map((c) => c.id)
+    ).toEqual(["a", "b"]);
+  });
+
+  it("selects the (No project) group via the empty-string entry", () => {
+    expect(
+      filterChatsByProjects(chats, new Set([""])).map((c) => c.id)
+    ).toEqual(["c"]);
+  });
+});

--- a/web/src/chat/projects/filterChatsByProjects.ts
+++ b/web/src/chat/projects/filterChatsByProjects.ts
@@ -1,0 +1,14 @@
+import type { Chat } from "@/types";
+
+/**
+ * Keep chats in any of the selected Projects (OR / union). An empty selection
+ * means "all Projects" and returns every chat unchanged. The empty-string entry
+ * selects the `(No project)` group. Pure: preserves input order, never mutates.
+ */
+export function filterChatsByProjects(
+  chats: Chat[],
+  selected: ReadonlySet<string>
+): Chat[] {
+  if (selected.size === 0) return chats;
+  return chats.filter((c) => selected.has(c.project));
+}


### PR DESCRIPTION
## Background (Why)

Each Chat belongs to a Project (its working directory), but there was no way to narrow the list to one. This adds Project-based filtering to the navigation panel so you can focus on a single area of work, while still showing everything by default.

## Approach (How)

Two layers, split along the issue's scale posture:

- **Server-side (scale-ready):** the filter lives in SQL. The Archive read seam gains an optional project filter — `WHERE coalesce(project,'') IN (…)` — so repeated `?project=` params union (OR) and an empty value selects the `(No project)` group. A new `chats.project` index backs it (per ADR-0016). `ChatReader` threads `projects` through; the Hono route reads the multi-value query.
- **Client-side (current UI):** the frontend still loads the full list, so the Projects section and counts are derived in app code from the active view's chats, and the filter is applied after ordering (smallest seam — sort/freeze logic untouched). Project facets are ordered by recency with `(No project)` pinned last; a selected Project is "ensured" into the list so it stays visible at count 0.

## Changes (What)

- [x] `GET /api/chats?project=a&project=b` filters server-side, OR across Projects, empty value = `(No project)`; composes with `includeTrashed`
- [x] Index on `chats.project` + migration `0008` (hand-written, matching the repo's 0005+ convention)
- [x] Projects section in the first column: folder icon, name, count, teal highlight + check when selected
- [x] Multi-select OR; no selection = all; per-view static counts; selected Project stays at count 0
- [x] "N filters active / Clear" bar resets the filter
- [x] Collapsible section header with a muted `Recent` order caption + tooltip
- [x] Works in both the main list and Trash (per-view facets and filtering)

### Test Verification

- [x] API: single Project, multi-Project OR, `(No project)` via empty value, no-param = all, composes with `includeTrashed` (`api/src/app.test.ts`)
- [x] Reader: single/union/`(No project)`/trash-compose (`api/src/chat-reader.test.ts`)
- [x] `deriveProjects`: grouping, counts, recency order, `(No project)` last, `ensure` keeps count-0 rows
- [x] `filterChatsByProjects`: all / single / OR / `(No project)`
- [x] `ProjectsSection`: rows + counts, toggle, selection check, `Recent` caption + tooltip, collapse
- [x] App integration: click-to-filter, OR, Clear restores, per-view counts (main vs Trash)
- [x] Full suite green: api 163, web 134; typecheck clean

## Additional Notes

- **Scope line:** the mockup also shows a Search box (Spotlight #26) and a Tags section (#10/#11). Those are separate issues and are intentionally not built here — only the Projects portion + the shared filters/Clear bar.
- "Combined with Tag (#11)" has no target yet (Tags backend doesn't exist); "combined with search" is exercised via the trash/`includeTrashed` compose path. The client-side intersection + server-side OR are compatible with both when they land.
- The `Recent` caption is a label, not a sort control; the header's chevron drives collapse. A sort toggle remains a future enhancement.

## Related Links

- Closes #8
- Mockup: #10