### PR TITLE
feat: tag system (CRUD, assignment, and three-column UI)

### DIFF
--- a/api/drizzle/0004_add_tags.sql
+++ b/api/drizzle/0004_add_tags.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `tags` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`color` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `chat_tags` (
+	`chat_id` text NOT NULL,
+	`tag_id` text NOT NULL,
+	PRIMARY KEY(`chat_id`, `tag_id`),
+	FOREIGN KEY (`tag_id`) REFERENCES `tags`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `chat_tags_tag_id_idx` ON `chat_tags` (`tag_id`);

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1779500000000,
       "tag": "0003_add_deleted_at",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1780000000000,
+      "tag": "0004_add_tags",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { createApp } from "./app.js";
 import { createArchiveRepository } from "./archive/repository.js";
 import { createMetadataRepository } from "./metadata/repository.js";
+import { createTagRepository } from "./metadata/tags.js";
+import type { Tag } from "./metadata/tags.js";
 import { formatChatId } from "./archive/chat-id.js";
 
 interface ChatResponse {
@@ -114,7 +116,11 @@ describe("Chat id is the public API handle", () => {
     });
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const list = await app.request("/api/chats");
     const body = (await list.json()) as { chats: ChatResponse[] };
     const chat = body.chats.find((s) => s.sourceId === "session-1");
@@ -138,7 +144,11 @@ describe("Chat id is the public API handle", () => {
       blocks: [{ type: "text", text: "hi" }],
     });
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const res = await app.request("/api/chats/session-1");
     expect(res.status).toBe(404);
   });
@@ -160,7 +170,11 @@ describe("Chat id is the public API handle", () => {
     });
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const res = await app.request(`/api/chats/${wireId}`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { messages: MessageResponse[] };
@@ -178,7 +192,11 @@ describe("Soft delete and restore (archive-backed)", () => {
     });
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
 
     const res = await app.request("/api/chats?includeDeleted=true");
@@ -195,7 +213,11 @@ describe("Soft delete and restore (archive-backed)", () => {
     });
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const del = await app.request(`/api/chats/${wireId}`, {
       method: "DELETE",
     });
@@ -215,7 +237,11 @@ describe("Soft delete and restore (archive-backed)", () => {
     });
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
     const restore = await app.request(`/api/chats/${wireId}/restore`, {
       method: "POST",
@@ -236,7 +262,11 @@ describe("Soft delete and restore (archive-backed)", () => {
     });
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
 
     const row = archive.read.findChatBySourceId("session-1");
@@ -262,7 +292,11 @@ describe("GET /api/chats/:id visibility", () => {
     });
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
 
     const res = await app.request(`/api/chats/${wireId}`);
@@ -286,7 +320,11 @@ describe("GET /api/chats/:id visibility", () => {
     });
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
 
     const res = await app.request(`/api/chats/${wireId}?includeTrashed=true`);
@@ -304,7 +342,11 @@ describe("GET /api/chats/:id visibility", () => {
     });
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
     const restore = await app.request(`/api/chats/${wireId}/restore`, {
       method: "POST",
@@ -317,7 +359,11 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
   it("returns 404 when DELETE targets a chat absent from archive", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
 
     const res = await app.request("/api/chats/nonexistent", {
       method: "DELETE",
@@ -328,7 +374,11 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
   it("returns 404 when restore targets a chat absent from archive", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
 
     const res = await app.request("/api/chats/nonexistent/restore", {
       method: "POST",
@@ -344,7 +394,11 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
       firstSeenAt: new Date(1700000000000),
     });
     const wireId = wireIdFor(archive, "session-1");
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
 
     const first = await app.request(`/api/chats/${wireId}`, {
       method: "DELETE",
@@ -364,7 +418,11 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
       firstSeenAt: new Date(1700000000000),
     });
     const wireId = wireIdFor(archive, "session-1");
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
 
     const res = await app.request(`/api/chats/${wireId}/restore`, {
       method: "POST",
@@ -391,7 +449,11 @@ describe("PATCH /api/chats/:id/title", () => {
     });
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const patch = await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
@@ -423,7 +485,11 @@ describe("PATCH /api/chats/:id/title", () => {
     metadata.setCustomTitle(internalId, "Custom");
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const patch = await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
@@ -447,7 +513,11 @@ describe("PATCH /api/chats/:id/title", () => {
     metadata.setCustomTitle(internalId, "Custom");
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const patch = await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
@@ -470,7 +540,11 @@ describe("PATCH /api/chats/:id/title", () => {
     });
     const wireId = wireIdFor(archive, "session-1");
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
@@ -486,7 +560,11 @@ describe("PATCH /api/chats/:id/title", () => {
   it("returns 404 when archive has no chat for the given id", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
 
     const res = await app.request("/api/chats/nonexistent/title", {
       method: "PATCH",
@@ -504,7 +582,11 @@ describe("PATCH /api/chats/:id/title", () => {
       firstSeenAt: new Date(1700000000000),
     });
     const wireId = wireIdFor(archive, "session-1");
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
 
     const wrongType = await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
@@ -522,7 +604,11 @@ describe("PATCH /api/chats/:id/title", () => {
       firstSeenAt: new Date(1700000000000),
     });
     const wireId = wireIdFor(archive, "session-1");
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
 
     const tooLong = "x".repeat(201);
     const res = await app.request(`/api/chats/${wireId}/title`, {
@@ -549,7 +635,11 @@ describe("GET /api/chats?project= (server-side Project filter)", () => {
       project: "project-b",
     });
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const res = await app.request("/api/chats?project=project-a");
     const body = (await res.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((c) => c.sourceId)).toEqual(["session-a"]);
@@ -574,7 +664,11 @@ describe("GET /api/chats?project= (server-side Project filter)", () => {
       project: "project-c",
     });
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const res = await app.request(
       "/api/chats?project=project-a&project=project-c"
     );
@@ -599,7 +693,11 @@ describe("GET /api/chats?project= (server-side Project filter)", () => {
       project: "project-a",
     });
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const res = await app.request("/api/chats?project=");
     const body = (await res.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((c) => c.sourceId)).toEqual(["session-none"]);
@@ -619,7 +717,11 @@ describe("GET /api/chats?project= (server-side Project filter)", () => {
       project: "project-b",
     });
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const res = await app.request("/api/chats");
     const body = (await res.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((c) => c.sourceId).sort()).toEqual([
@@ -643,7 +745,11 @@ describe("GET /api/chats?project= (server-side Project filter)", () => {
     });
     metadata.softDelete(trashedId);
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const main = await app.request("/api/chats?project=project-a");
     const mainBody = (await main.json()) as { chats: ChatResponse[] };
     expect(mainBody.chats.map((c) => c.sourceId)).toEqual(["session-active"]);
@@ -664,8 +770,217 @@ describe("GET /api/chats/:id (route status mapping)", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
 
-    const app = createApp({ archive, metadata });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const res = await app.request("/api/chats/does-not-exist");
     expect(res.status).toBe(404);
+  });
+});
+
+describe("Tag API", () => {
+  function setup() {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+    const app = createApp({ archive, metadata, tags });
+    return { archive, metadata, tags, app };
+  }
+
+  it("POST /api/tags creates a tag and lists it via GET /api/tags", async () => {
+    const { app } = setup();
+
+    const created = await app.request("/api/tags", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "bug", color: "red" }),
+    });
+    expect(created.status).toBe(201);
+    const { tag } = (await created.json()) as { tag: Tag };
+    expect(tag).toMatchObject({ name: "bug", color: "red" });
+
+    const list = await app.request("/api/tags");
+    const { tags } = (await list.json()) as { tags: Tag[] };
+    expect(tags).toEqual([tag]);
+  });
+
+  it("POST /api/tags rejects a color outside the palette with 400", async () => {
+    const { app } = setup();
+
+    const res = await app.request("/api/tags", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "bug", color: "#ff0000" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH /api/tags/:id renames and recolors a tag", async () => {
+    const { app, tags } = setup();
+    const tag = tags.createTag("bug", "red");
+
+    const res = await app.request(`/api/tags/${tag.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "defect", color: "blue" }),
+    });
+    expect(res.status).toBe(204);
+    expect(tags.listTags()).toEqual([
+      { id: tag.id, name: "defect", color: "blue" },
+    ]);
+  });
+
+  it("PATCH /api/tags/:id 404s for an unknown tag", async () => {
+    const { app } = setup();
+
+    const res = await app.request("/api/tags/ghost", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "x" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("PATCH /api/tags/:id rejects a color outside the palette with 400", async () => {
+    const { app, tags } = setup();
+    const tag = tags.createTag("bug", "red");
+
+    const res = await app.request(`/api/tags/${tag.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ color: "#abc" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("DELETE /api/tags/:id removes it from chats and reports the count", async () => {
+    const { archive, app, tags } = setup();
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const wireId = wireIdFor(archive, "session-1");
+    const tag = tags.createTag("bug", "red");
+    await app.request(`/api/chats/${wireId}/tags`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tagId: tag.id }),
+    });
+
+    const res = await app.request(`/api/tags/${tag.id}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ removedFromChats: 1 });
+    expect(tags.listTags()).toEqual([]);
+  });
+
+  it("DELETE /api/tags/:id 404s for an unknown tag", async () => {
+    const { app } = setup();
+
+    const res = await app.request("/api/tags/ghost", { method: "DELETE" });
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /api/chats/:id/tags assigns a tag to the chat", async () => {
+    const { archive, app, tags } = setup();
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const wireId = wireIdFor(archive, "session-1");
+    const tag = tags.createTag("bug", "red");
+
+    const res = await app.request(`/api/chats/${wireId}/tags`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tagId: tag.id }),
+    });
+    expect(res.status).toBe(204);
+
+    const row = archive.read.findChatBySourceId("session-1")!;
+    expect(tags.listTagsForChat(row.id)).toEqual([tag]);
+  });
+
+  it("POST /api/chats/:id/tags 404s for an unknown chat", async () => {
+    const { app, tags } = setup();
+    const tag = tags.createTag("bug", "red");
+
+    const res = await app.request("/api/chats/clog_zzzzzz/tags", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tagId: tag.id }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /api/chats/:id/tags 404s for an unknown tag", async () => {
+    const { archive, app } = setup();
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const wireId = wireIdFor(archive, "session-1");
+
+    const res = await app.request(`/api/chats/${wireId}/tags`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tagId: "ghost" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /api/chats embeds each chat's assigned tags", async () => {
+    const { archive, app, tags } = setup();
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const row = archive.read.findChatBySourceId("session-1")!;
+    const bug = tags.createTag("bug", "red");
+    const idea = tags.createTag("idea", "violet");
+    tags.assignTag(row.id, bug.id);
+    tags.assignTag(row.id, idea.id);
+
+    const res = await app.request("/api/chats");
+    const body = (await res.json()) as {
+      chats: Array<{ sourceId: string; tags: Tag[] }>;
+    };
+    const chat = body.chats.find((c) => c.sourceId === "session-1");
+    expect(chat?.tags).toEqual([bug, idea]);
+  });
+
+  it("GET /api/chats returns an empty tags array for an untagged chat", async () => {
+    const { archive, app } = setup();
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+
+    const res = await app.request("/api/chats");
+    const body = (await res.json()) as {
+      chats: Array<{ sourceId: string; tags: Tag[] }>;
+    };
+    expect(body.chats.find((c) => c.sourceId === "session-1")?.tags).toEqual(
+      []
+    );
+  });
+
+  it("DELETE /api/chats/:id/tags/:tagId removes the assignment", async () => {
+    const { archive, app, tags } = setup();
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const wireId = wireIdFor(archive, "session-1");
+    const tag = tags.createTag("bug", "red");
+    const row = archive.read.findChatBySourceId("session-1")!;
+    tags.assignTag(row.id, tag.id);
+
+    const res = await app.request(`/api/chats/${wireId}/tags/${tag.id}`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+    expect(tags.listTagsForChat(row.id)).toEqual([]);
   });
 });

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -2,17 +2,20 @@ import { Hono } from "hono";
 import { serveStatic } from "@hono/node-server/serve-static";
 import type { ArchiveRepository } from "./archive/repository.js";
 import type { MetadataRepository } from "./metadata/repository.js";
+import type { TagRepository } from "./metadata/tags.js";
+import { isColorToken } from "./metadata/tag-colors.js";
 import { createChatReader } from "./chat-reader.js";
 
 interface AppOptions {
   archive: ArchiveRepository;
   metadata: MetadataRepository;
+  tags: TagRepository;
   webDistDir?: string;
 }
 
-export function createApp({ archive, metadata, webDistDir }: AppOptions) {
+export function createApp({ archive, metadata, tags, webDistDir }: AppOptions) {
   const app = new Hono();
-  const reader = createChatReader({ archive, metadata });
+  const reader = createChatReader({ archive, metadata, tags });
 
   app.get("/api/chats", (c) => {
     // Repeated `?project=` params union (OR); an empty value selects the
@@ -79,6 +82,106 @@ export function createApp({ archive, metadata, webDistDir }: AppOptions) {
       return c.json({ error: "Chat not found" }, 404);
     }
     return c.json({ messages });
+  });
+
+  app.get("/api/tags", (c) => {
+    return c.json({ tags: tags.listTags() });
+  });
+
+  app.post("/api/tags", async (c) => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const name =
+      body && typeof body === "object"
+        ? (body as { name?: unknown }).name
+        : undefined;
+    const color =
+      body && typeof body === "object"
+        ? (body as { color?: unknown }).color
+        : undefined;
+    if (typeof name !== "string" || name.trim().length === 0) {
+      return c.json({ error: "Invalid name" }, 400);
+    }
+    if (!isColorToken(color)) {
+      return c.json({ error: "Invalid color" }, 400);
+    }
+    const tag = tags.createTag(name.trim(), color);
+    return c.json({ tag }, 201);
+  });
+
+  app.patch("/api/tags/:id", async (c) => {
+    const id = c.req.param("id");
+    if (!tags.getTag(id)) {
+      return c.json({ error: "Tag not found" }, 404);
+    }
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const name =
+      body && typeof body === "object"
+        ? (body as { name?: unknown }).name
+        : undefined;
+    const color =
+      body && typeof body === "object"
+        ? (body as { color?: unknown }).color
+        : undefined;
+    if (name !== undefined) {
+      if (typeof name !== "string" || name.trim().length === 0) {
+        return c.json({ error: "Invalid name" }, 400);
+      }
+    }
+    if (color !== undefined && !isColorToken(color)) {
+      return c.json({ error: "Invalid color" }, 400);
+    }
+    if (typeof name === "string") tags.renameTag(id, name.trim());
+    if (isColorToken(color)) tags.recolorTag(id, color);
+    return c.body(null, 204);
+  });
+
+  app.delete("/api/tags/:id", (c) => {
+    if (!tags.getTag(c.req.param("id"))) {
+      return c.json({ error: "Tag not found" }, 404);
+    }
+    const result = tags.deleteTag(c.req.param("id"));
+    return c.json(result);
+  });
+
+  app.post("/api/chats/:id/tags", async (c) => {
+    const row = reader.findChat(c.req.param("id"));
+    if (!row) {
+      return c.json({ error: "Chat not found" }, 404);
+    }
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const tagId =
+      body && typeof body === "object"
+        ? (body as { tagId?: unknown }).tagId
+        : undefined;
+    if (typeof tagId !== "string" || !tags.getTag(tagId)) {
+      return c.json({ error: "Tag not found" }, 404);
+    }
+    tags.assignTag(row.id, tagId);
+    return c.body(null, 204);
+  });
+
+  app.delete("/api/chats/:id/tags/:tagId", (c) => {
+    const row = reader.findChat(c.req.param("id"));
+    if (!row) {
+      return c.json({ error: "Chat not found" }, 404);
+    }
+    tags.removeTag(row.id, c.req.param("tagId"));
+    return c.body(null, 204);
   });
 
   if (webDistDir) {

--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { createChatReader } from "./chat-reader.js";
 import { createArchiveRepository } from "./archive/repository.js";
 import { createMetadataRepository } from "./metadata/repository.js";
+import { createTagRepository } from "./metadata/tags.js";
 import { CROCKFORD_ALPHABET, formatChatId } from "./archive/chat-id.js";
 import type { ArchiveReadSeam } from "./archive/read-seam.js";
 
@@ -125,7 +126,11 @@ describe("ChatReader.listChats", () => {
       firstSeenAt: new Date(1700000000000),
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chats = reader.listChats({ includeTrashed: false });
     expect(chats.map((c) => c.sourceId)).toContain("session-1");
   });
@@ -140,7 +145,11 @@ describe("ChatReader.listChats", () => {
       project: "project-a",
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -172,7 +181,11 @@ describe("ChatReader.listChats", () => {
       blocks: [{ type: "text", text: "Build a login page" }],
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -197,7 +210,11 @@ describe("ChatReader.listChats", () => {
     });
     metadata.setCustomTitle(internalId, "My favourite chat");
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -213,7 +230,11 @@ describe("ChatReader.listChats", () => {
       firstSeenAt: new Date(1700000000000),
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -245,7 +266,11 @@ describe("ChatReader.listChats", () => {
       blocks: [{ type: "text", text: "ok" }],
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -262,7 +287,11 @@ describe("ChatReader.listChats", () => {
       firstSeenAt: new Date(1700000000000),
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -280,7 +309,11 @@ describe("ChatReader.listChats", () => {
     });
     const code = archive.read.findChatBySourceId("session-1")!.chatId;
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -302,7 +335,11 @@ describe("ChatReader.listChats", () => {
       firstSeenAt: new Date(1700000000000),
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -331,7 +368,11 @@ describe("ChatReader.listChats", () => {
       ingestedAt: new Date(1700000900000),
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -347,7 +388,11 @@ describe("ChatReader.listChats", () => {
       firstSeenAt: new Date(1700000000000),
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -363,7 +408,11 @@ describe("ChatReader.listChats", () => {
       firstSeenAt: new Date(1700000000000),
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -381,7 +430,11 @@ describe("ChatReader.listChats", () => {
       projectPath: "/Users/evaaaaawu/Documents/chat-logbook",
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -397,7 +450,11 @@ describe("ChatReader.listChats", () => {
       firstSeenAt: new Date(1700000000000),
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -414,7 +471,11 @@ describe("ChatReader.listChats", () => {
       project: null,
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-1");
@@ -438,7 +499,11 @@ describe("ChatReader.listChats project filter", () => {
       project: "project-b",
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chats = reader.listChats({
       includeTrashed: false,
       projects: ["project-a"],
@@ -466,7 +531,11 @@ describe("ChatReader.listChats project filter", () => {
       project: "project-c",
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chats = reader.listChats({
       includeTrashed: false,
       projects: ["project-a", "project-c"],
@@ -492,7 +561,11 @@ describe("ChatReader.listChats project filter", () => {
       project: "project-a",
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chats = reader.listChats({
       includeTrashed: false,
       projects: [""],
@@ -516,7 +589,11 @@ describe("ChatReader.listChats project filter", () => {
     });
     metadata.softDelete(trashedId);
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const active = reader.listChats({
       includeTrashed: false,
       projects: ["project-a"],
@@ -544,7 +621,11 @@ describe("ChatReader visibility", () => {
     });
     metadata.softDelete(internalId);
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chats = reader.listChats({ includeTrashed: false });
     expect(chats.map((c) => c.sourceId)).not.toContain("session-1");
   });
@@ -558,7 +639,11 @@ describe("ChatReader visibility", () => {
     });
     metadata.softDelete(internalId);
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: true })
       .find((c) => c.sourceId === "session-1");
@@ -579,7 +664,11 @@ describe("ChatReader visibility", () => {
     const before = Date.now();
     metadata.softDelete(trashedId);
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chats = reader.listChats({ includeTrashed: true });
     const active = chats.find((c) => c.sourceId === "session-active");
     const trashed = chats.find((c) => c.sourceId === "session-trashed");
@@ -615,7 +704,11 @@ describe("ChatReader.getMessages", () => {
       blocks: [{ type: "text", text: "Build a login page" }],
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
       includeTrashed: false,
     });
@@ -646,7 +739,11 @@ describe("ChatReader.getMessages", () => {
     const wireId = wireIdFor(archive, "session-1");
     metadata.softDelete(internalId);
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     expect(reader.getMessages(wireId, { includeTrashed: false })).toBeNull();
   });
 
@@ -654,7 +751,11 @@ describe("ChatReader.getMessages", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     expect(
       reader.getMessages("does-not-exist", { includeTrashed: false })
     ).toBeNull();
@@ -676,7 +777,11 @@ describe("ChatReader.getMessages", () => {
       blocks: [{ type: "text", text: "hi" }],
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     // Source id is no longer a public lookup key — only the wire-form chat id is.
     expect(
       reader.getMessages("session-1", { includeTrashed: false })
@@ -700,7 +805,11 @@ describe("ChatReader.getMessages", () => {
     });
     const bareCode = archive.read.findChatBySourceId("session-1")!.chatId;
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     // Strict: only the clog_ wire form resolves; the bare code does not.
     expect(reader.getMessages(bareCode, { includeTrashed: false })).toBeNull();
   });
@@ -722,7 +831,11 @@ describe("ChatReader.getMessages", () => {
       blocks: [{ type: "tool_result", toolUseId: "tool-1", content: "result" }],
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
       includeTrashed: false,
     });
@@ -752,7 +865,11 @@ describe("ChatReader is agent-agnostic", () => {
       agent: "codex",
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chat = reader
       .listChats({ includeTrashed: false })
       .find((c) => c.sourceId === "session-codex");
@@ -859,6 +976,7 @@ describe("ChatReader.listChats query batching", () => {
     const readerSmall = createChatReader({
       archive: archiveSmall,
       metadata: metadataSmall,
+      tags: createTagRepository({ dataDir }),
     });
     const smallCount = countArchiveQueries(archiveSmall, () => {
       readerSmall.listChats({ includeTrashed: false });
@@ -876,6 +994,7 @@ describe("ChatReader.listChats query batching", () => {
       const readerBig = createChatReader({
         archive: archiveBig,
         metadata: metadataBig,
+        tags: createTagRepository({ dataDir: bigDir }),
       });
       const bigCount = countArchiveQueries(archiveBig, () => {
         readerBig.listChats({ includeTrashed: false });
@@ -954,7 +1073,11 @@ describe("ChatReader.listChats query batching", () => {
       firstSeenAt: new Date(1700000050000),
     });
 
-    const reader = createChatReader({ archive, metadata });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+    });
     const chats = reader.listChats({ includeTrashed: false });
 
     // Ordering mirrors the chat-row insertion order.

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -2,6 +2,7 @@ import type { ArchiveRepository } from "./archive/repository.js";
 import { formatChatId, parseChatId } from "./archive/chat-id.js";
 import type { ChatRow } from "./archive/read-seam.js";
 import type { MetadataRepository } from "./metadata/repository.js";
+import type { Tag, TagRepository } from "./metadata/tags.js";
 import { loadChatVisibility } from "./visibility.js";
 
 /**
@@ -28,6 +29,8 @@ export interface ChatResponse {
   updatedAt: number;
   deletedAt: number | null;
   isDeleted?: boolean;
+  /** Tags assigned to this chat, batched in one grouped query (ADR-0016). */
+  tags: Tag[];
 }
 
 export type ApiContentBlock =
@@ -88,11 +91,13 @@ export interface ChatReader {
 interface ChatReaderDeps {
   archive: ArchiveRepository;
   metadata: MetadataRepository;
+  tags: TagRepository;
 }
 
 export function createChatReader({
   archive,
   metadata,
+  tags,
 }: ChatReaderDeps): ChatReader {
   function findChat(id: string): ChatRecord | null {
     const code = parseChatId(id);
@@ -145,6 +150,9 @@ export function createChatReader({
     );
 
     const customTitleById = metadata.listCustomTitles();
+    // One grouped query for every chat's tags, keyed by internal id — never one
+    // query per chat (ADR-0016).
+    const tagsByChatId = tags.listTagsByChat();
 
     const chats: ChatResponse[] = [];
     for (const row of rows) {
@@ -168,6 +176,7 @@ export function createChatReader({
         createdAt: tsRange?.minTs ?? firstSeenAtMs,
         updatedAt: tsRange?.maxTs ?? firstSeenAtMs,
         deletedAt: visibility.deletedAt(row.id),
+        tags: tagsByChatId.get(row.id) ?? [],
       };
       if (isDeleted) chat.isDeleted = true;
       chats.push(chat);

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -9,6 +9,7 @@ import { createApp } from "./app.js";
 import { createArchiveRepository } from "./archive/repository.js";
 import { createCheckpointRepository } from "./checkpoint/repository.js";
 import { createMetadataRepository } from "./metadata/repository.js";
+import { createTagRepository } from "./metadata/tags.js";
 import { startIngestionInBackground } from "./ingestion/background.js";
 import { startWatcher } from "./ingestion/watcher.js";
 import { plugins } from "./plugins/registry.js";
@@ -47,7 +48,8 @@ const port = action.port;
 const archive = createArchiveRepository({ dataDir });
 const checkpoint = createCheckpointRepository({ dataDir });
 const metadata = createMetadataRepository({ dataDir });
-const app = createApp({ archive, metadata, webDistDir });
+const tags = createTagRepository({ dataDir });
+const app = createApp({ archive, metadata, tags, webDistDir });
 
 const initialIngest = startIngestionInBackground({
   plugins,

--- a/api/src/metadata/schema.ts
+++ b/api/src/metadata/schema.ts
@@ -1,4 +1,10 @@
-import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import {
+  index,
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+} from "drizzle-orm/sqlite-core";
 
 export const chatsMeta = sqliteTable("chats_meta", {
   id: text("id").primaryKey(),
@@ -12,3 +18,31 @@ export const chatsMeta = sqliteTable("chats_meta", {
   // view's independent "Deleted time" sort axis.
   deletedAt: integer("deleted_at", { mode: "timestamp_ms" }),
 });
+
+// A user-defined Tag. `color` holds a semantic palette token (e.g. "violet"),
+// never a raw hex — rendering resolves token→hex through one shared map
+// (ADR-0015). Reusing a color across Tags is allowed.
+export const tags = sqliteTable("tags", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  color: text("color").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+});
+
+// Many-to-many join between Chats and Tags. PK `(chat_id, tag_id)` keys the
+// pair; the secondary index on `(tag_id)` serves the AND-intersection Tag
+// filter (#11 / ADR-0016).
+export const chatTags = sqliteTable(
+  "chat_tags",
+  {
+    chatId: text("chat_id").notNull(),
+    tagId: text("tag_id")
+      .notNull()
+      .references(() => tags.id, { onDelete: "cascade" }),
+  },
+  (table) => [
+    primaryKey({ columns: [table.chatId, table.tagId] }),
+    index("chat_tags_tag_id_idx").on(table.tagId),
+  ]
+);

--- a/api/src/metadata/tag-colors.ts
+++ b/api/src/metadata/tag-colors.ts
@@ -1,0 +1,23 @@
+// The closed Tag color vocabulary (ADR-0015): eight semantic tokens drawn from
+// the Solarized accent set. A Tag stores one of these tokens, never a raw hex —
+// rendering resolves token→hex through one shared palette map. Adding a ninth
+// color is a deliberate palette change, not user free-form input.
+export const TAG_COLORS = [
+  "yellow",
+  "orange",
+  "red",
+  "magenta",
+  "violet",
+  "blue",
+  "cyan",
+  "green",
+] as const;
+
+export type ColorToken = (typeof TAG_COLORS)[number];
+
+export function isColorToken(value: unknown): value is ColorToken {
+  return (
+    typeof value === "string" &&
+    (TAG_COLORS as readonly string[]).includes(value)
+  );
+}

--- a/api/src/metadata/tags.test.ts
+++ b/api/src/metadata/tags.test.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTagRepository } from "./tags.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-tags-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("TagRepository", () => {
+  it("creates a tag and lists it", () => {
+    const repo = createTagRepository({ dataDir });
+
+    const tag = repo.createTag("bug", "red");
+
+    expect(tag.name).toBe("bug");
+    expect(tag.color).toBe("red");
+    expect(tag.id).toEqual(expect.any(String));
+    expect(repo.listTags()).toEqual([tag]);
+  });
+
+  it("rejects creating a tag with a color outside the palette", () => {
+    const repo = createTagRepository({ dataDir });
+
+    expect(() => repo.createTag("bug", "#ff0000" as never)).toThrow();
+    expect(repo.listTags()).toEqual([]);
+  });
+
+  it("allows reusing one color across several tags", () => {
+    const repo = createTagRepository({ dataDir });
+
+    repo.createTag("bug", "violet");
+    repo.createTag("idea", "violet");
+
+    expect(repo.listTags().map((t) => t.color)).toEqual(["violet", "violet"]);
+  });
+
+  it("renames a tag", () => {
+    const repo = createTagRepository({ dataDir });
+    const tag = repo.createTag("bug", "red");
+
+    repo.renameTag(tag.id, "defect");
+
+    expect(repo.listTags()).toEqual([{ ...tag, name: "defect" }]);
+  });
+
+  it("recolors a tag", () => {
+    const repo = createTagRepository({ dataDir });
+    const tag = repo.createTag("bug", "red");
+
+    repo.recolorTag(tag.id, "blue");
+
+    expect(repo.listTags()).toEqual([{ ...tag, color: "blue" }]);
+  });
+
+  it("rejects recoloring a tag to a color outside the palette", () => {
+    const repo = createTagRepository({ dataDir });
+    const tag = repo.createTag("bug", "red");
+
+    expect(() => repo.recolorTag(tag.id, "#000" as never)).toThrow();
+    expect(repo.listTags()).toEqual([tag]);
+  });
+
+  it("assigns a tag to a chat and lists it for that chat", () => {
+    const repo = createTagRepository({ dataDir });
+    const tag = repo.createTag("bug", "red");
+
+    repo.assignTag("chat-1", tag.id);
+
+    expect(repo.listTagsForChat("chat-1")).toEqual([tag]);
+    expect(repo.listTagsForChat("chat-2")).toEqual([]);
+  });
+
+  it("treats re-assigning the same tag to a chat as an idempotent no-op", () => {
+    const repo = createTagRepository({ dataDir });
+    const tag = repo.createTag("bug", "red");
+
+    repo.assignTag("chat-1", tag.id);
+    repo.assignTag("chat-1", tag.id);
+
+    expect(repo.listTagsForChat("chat-1")).toEqual([tag]);
+  });
+
+  it("removes a tag from a chat", () => {
+    const repo = createTagRepository({ dataDir });
+    const tag = repo.createTag("bug", "red");
+    repo.assignTag("chat-1", tag.id);
+
+    repo.removeTag("chat-1", tag.id);
+
+    expect(repo.listTagsForChat("chat-1")).toEqual([]);
+  });
+
+  it("deletes a tag, drops it from every chat, and reports the affected count", () => {
+    const repo = createTagRepository({ dataDir });
+    const tag = repo.createTag("bug", "red");
+    repo.assignTag("chat-1", tag.id);
+    repo.assignTag("chat-2", tag.id);
+
+    const result = repo.deleteTag(tag.id);
+
+    expect(result).toEqual({ removedFromChats: 2 });
+    expect(repo.listTags()).toEqual([]);
+    expect(repo.listTagsForChat("chat-1")).toEqual([]);
+    expect(repo.listTagsForChat("chat-2")).toEqual([]);
+  });
+
+  it("groups tags by chat in a single batched query", () => {
+    const repo = createTagRepository({ dataDir });
+    const bug = repo.createTag("bug", "red");
+    const idea = repo.createTag("idea", "violet");
+    repo.assignTag("chat-1", bug.id);
+    repo.assignTag("chat-1", idea.id);
+    repo.assignTag("chat-2", bug.id);
+
+    const byChat = repo.listTagsByChat();
+
+    expect(byChat.get("chat-1")).toEqual([bug, idea]);
+    expect(byChat.get("chat-2")).toEqual([bug]);
+    expect(byChat.has("chat-3")).toBe(false);
+  });
+
+  it("persists tags and assignments across repository instances", () => {
+    const first = createTagRepository({ dataDir });
+    const tag = first.createTag("bug", "red");
+    first.assignTag("chat-1", tag.id);
+
+    const second = createTagRepository({ dataDir });
+
+    expect(second.listTags()).toEqual([tag]);
+    expect(second.listTagsForChat("chat-1")).toEqual([tag]);
+  });
+});

--- a/api/src/metadata/tags.ts
+++ b/api/src/metadata/tags.ts
@@ -1,0 +1,170 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, inArray } from "drizzle-orm";
+import { openStore } from "../storage/openStore.js";
+import * as schema from "./schema.js";
+import { chatTags, tags } from "./schema.js";
+import { type ColorToken, isColorToken } from "./tag-colors.js";
+
+const DB_FILE = "metadata.db";
+
+export interface Tag {
+  id: string;
+  name: string;
+  color: ColorToken;
+}
+
+export interface TagRepository {
+  createTag(name: string, color: ColorToken): Tag;
+  listTags(): Tag[];
+  getTag(id: string): Tag | null;
+  renameTag(id: string, name: string): void;
+  recolorTag(id: string, color: ColorToken): void;
+  /** Delete a Tag and every Chat association it had. Returns how many Chats it
+   * was removed from, for the confirmation copy ("removed from N Chats"). */
+  deleteTag(id: string): { removedFromChats: number };
+  /** Assign a Tag to a Chat. Re-assigning the same pair is an idempotent no-op
+   * (the `(chat_id, tag_id)` primary key absorbs the conflict). */
+  assignTag(chatId: string, tagId: string): void;
+  removeTag(chatId: string, tagId: string): void;
+  listTagsForChat(chatId: string): Tag[];
+  /** Tags grouped by Chat id in one query — never one query per Chat
+   * (ADR-0016). Pass `chatIds` to scope to a subset; omit for every Chat. */
+  listTagsByChat(chatIds?: string[]): Map<string, Tag[]>;
+}
+
+interface TagRepositoryOptions {
+  dataDir: string;
+}
+
+export function createTagRepository({
+  dataDir,
+}: TagRepositoryOptions): TagRepository {
+  const { db } = openStore({
+    dataDir,
+    dbFile: DB_FILE,
+    callerUrl: import.meta.url,
+    migrationsSubdir: "drizzle",
+    schema,
+  });
+
+  function toTag(row: { id: string; name: string; color: string }): Tag {
+    return { id: row.id, name: row.name, color: row.color as ColorToken };
+  }
+
+  function assertColor(color: ColorToken): void {
+    if (!isColorToken(color)) {
+      throw new Error(`Invalid tag color token: ${String(color)}`);
+    }
+  }
+
+  return {
+    createTag(name, color) {
+      assertColor(color);
+      const now = new Date();
+      const row = {
+        id: randomUUID(),
+        name,
+        color,
+        createdAt: now,
+        updatedAt: now,
+      };
+      db.insert(tags).values(row).run();
+      return toTag(row);
+    },
+
+    listTags() {
+      return db
+        .select({ id: tags.id, name: tags.name, color: tags.color })
+        .from(tags)
+        .all()
+        .map(toTag);
+    },
+
+    getTag(id) {
+      const row = db
+        .select({ id: tags.id, name: tags.name, color: tags.color })
+        .from(tags)
+        .where(eq(tags.id, id))
+        .get();
+      return row ? toTag(row) : null;
+    },
+
+    renameTag(id, name) {
+      db.update(tags)
+        .set({ name, updatedAt: new Date() })
+        .where(eq(tags.id, id))
+        .run();
+    },
+
+    recolorTag(id, color) {
+      assertColor(color);
+      db.update(tags)
+        .set({ color, updatedAt: new Date() })
+        .where(eq(tags.id, id))
+        .run();
+    },
+
+    deleteTag(id) {
+      // SQLite FK enforcement (and the schema's ON DELETE cascade) is off
+      // unless `PRAGMA foreign_keys=ON`, which the shared store doesn't set —
+      // so clear the associations explicitly rather than trusting the cascade,
+      // and do both in one transaction so no orphan chat_tags rows can leak.
+      return db.transaction((tx) => {
+        const removedFromChats = tx
+          .select({ chatId: chatTags.chatId })
+          .from(chatTags)
+          .where(eq(chatTags.tagId, id))
+          .all().length;
+        tx.delete(chatTags).where(eq(chatTags.tagId, id)).run();
+        tx.delete(tags).where(eq(tags.id, id)).run();
+        return { removedFromChats };
+      });
+    },
+
+    assignTag(chatId, tagId) {
+      db.insert(chatTags).values({ chatId, tagId }).onConflictDoNothing().run();
+    },
+
+    removeTag(chatId, tagId) {
+      db.delete(chatTags)
+        .where(and(eq(chatTags.chatId, chatId), eq(chatTags.tagId, tagId)))
+        .run();
+    },
+
+    listTagsForChat(chatId) {
+      return db
+        .select({ id: tags.id, name: tags.name, color: tags.color })
+        .from(chatTags)
+        .innerJoin(tags, eq(chatTags.tagId, tags.id))
+        .where(eq(chatTags.chatId, chatId))
+        .all()
+        .map(toTag);
+    },
+
+    listTagsByChat(chatIds) {
+      const base = db
+        .select({
+          chatId: chatTags.chatId,
+          id: tags.id,
+          name: tags.name,
+          color: tags.color,
+        })
+        .from(chatTags)
+        .innerJoin(tags, eq(chatTags.tagId, tags.id));
+      const rows =
+        chatIds === undefined
+          ? base.all()
+          : chatIds.length === 0
+            ? []
+            : base.where(inArray(chatTags.chatId, chatIds)).all();
+
+      const byChat = new Map<string, Tag[]>();
+      for (const row of rows) {
+        const list = byChat.get(row.chatId) ?? [];
+        list.push(toTag(row));
+        byChat.set(row.chatId, list);
+      }
+      return byChat;
+    },
+  };
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useChats } from "@/chat/useChats";
+import { useTags } from "@/tags/useTags";
 import { useMessages } from "@/conversation/useMessages";
 import { useToast } from "@/shared/useToast";
 import { useChatOrder } from "@/chat/sort/useChatOrder";
@@ -17,7 +18,20 @@ import {
 } from "@/shared/ui/resizable";
 
 function App() {
-  const { chats, sortEpoch, softDelete, restore, setTitle } = useChats();
+  const { chats, sortEpoch, softDelete, restore, setTitle, reload } =
+    useChats();
+  const onAssignmentChange = useCallback(() => {
+    void reload();
+  }, [reload]);
+  const {
+    tags: tagCatalog,
+    createTag,
+    renameTag,
+    recolorTag,
+    deleteTag,
+    assignTag,
+    removeTag,
+  } = useTags({ onAssignmentChange });
   const handleRenameTitle = (id: string, title: string) => {
     void setTitle(id, title);
   };
@@ -74,6 +88,26 @@ function App() {
   );
   const selectedChat = chats.find((c) => c.id === selectedId) ?? null;
 
+  const countForTag = useCallback(
+    (tagId: string) =>
+      chats.filter((c) => !c.isDeleted && c.tags?.some((t) => t.id === tagId))
+        .length,
+    [chats]
+  );
+  // Create a Tag and immediately assign it to the chat the popover is on.
+  const createTagForChat = useCallback(
+    async (
+      chatId: string,
+      name: string,
+      color: Parameters<typeof createTag>[1]
+    ) => {
+      const created = await createTag(name, color);
+      if (created) await assignTag(chatId, created.id);
+      return created;
+    },
+    [createTag, assignTag]
+  );
+
   const handleRestore = (id: string) => {
     if (id === selectedId) {
       const idx = deletedChats.findIndex((c) => c.id === id);
@@ -115,6 +149,15 @@ function App() {
         target?.tagName === "TEXTAREA" ||
         target?.isContentEditable === true;
       if (isEditable) return;
+      // Keystrokes inside an open popover (find-or-create, recolor, metadata…)
+      // belong to that popover, not the global chat shortcuts. Without this,
+      // Enter/Backspace while focus sits on a non-input element in a popover
+      // (e.g. a color swatch) would start a title rename or trash the chat.
+      if (
+        target instanceof Element &&
+        target.closest('[data-slot="popover-content"]')
+      )
+        return;
 
       if (e.key === "Escape" && mode === "trash") {
         e.preventDefault();
@@ -163,6 +206,11 @@ function App() {
             selectedProjects={selectedProjects}
             onToggleProject={toggleProject}
             onClearFilters={clearProjects}
+            tags={tagCatalog}
+            countForTag={countForTag}
+            onRenameTag={(id, name) => void renameTag(id, name)}
+            onRecolorTag={(id, color) => void recolorTag(id, color)}
+            onDeleteTag={(id) => void deleteTag(id)}
           />
         </ResizablePanel>
         <ResizableHandle />
@@ -192,6 +240,10 @@ function App() {
             error={error}
             onRestore={handleRestore}
             onRenameTitle={handleRenameTitle}
+            allTags={tagCatalog}
+            onAssignTag={(chatId, tagId) => void assignTag(chatId, tagId)}
+            onRemoveTag={(chatId, tagId) => void removeTag(chatId, tagId)}
+            onCreateTag={createTagForChat}
           />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/web/src/chat/ChatList.tsx
+++ b/web/src/chat/ChatList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { ArrowLeft, Pencil, RotateCcw, Trash2 } from "lucide-react";
 import type { Chat } from "@/types";
 import { EditableTitle } from "@/metadata/EditableTitle";
+import { TagChipList } from "@/tags/TagChipList";
 
 interface ChatListProps {
   mode?: "main" | "trash";
@@ -256,6 +257,9 @@ export function ChatList({
             const rowContent = (
               <>
                 <div className="min-w-0">{titleNode}</div>
+                {chat.tags && chat.tags.length > 0 && (
+                  <TagChipList tags={chat.tags} />
+                )}
                 <span className="flex items-center justify-between text-xs text-muted-foreground">
                   <span className="truncate">
                     {getProjectName(chat.project)}

--- a/web/src/chat/FilterPanel.tsx
+++ b/web/src/chat/FilterPanel.tsx
@@ -2,6 +2,9 @@ import { Trash2 } from "lucide-react";
 import { ProjectsSection } from "@/chat/projects/ProjectsSection";
 import { FilterSummary } from "@/chat/FilterSummary";
 import type { ProjectFacet } from "@/chat/projects/deriveProjects";
+import { TagsSection } from "@/tags/TagsSection";
+import type { Tag } from "@/types";
+import type { ColorToken } from "@/tags/palette";
 
 interface FilterPanelProps {
   deletedCount: number;
@@ -10,6 +13,11 @@ interface FilterPanelProps {
   selectedProjects: ReadonlySet<string>;
   onToggleProject: (project: string) => void;
   onClearFilters: () => void;
+  tags: Tag[];
+  countForTag: (tagId: string) => number;
+  onRenameTag: (id: string, name: string) => void;
+  onRecolorTag: (id: string, color: ColorToken) => void;
+  onDeleteTag: (id: string) => void;
 }
 
 export function FilterPanel({
@@ -19,6 +27,11 @@ export function FilterPanel({
   selectedProjects,
   onToggleProject,
   onClearFilters,
+  tags,
+  countForTag,
+  onRenameTag,
+  onRecolorTag,
+  onDeleteTag,
 }: FilterPanelProps) {
   return (
     <div data-testid="filter-panel" className="flex h-full flex-col">
@@ -35,6 +48,13 @@ export function FilterPanel({
           facets={projectFacets}
           selected={selectedProjects}
           onToggle={onToggleProject}
+        />
+        <TagsSection
+          tags={tags}
+          countForTag={countForTag}
+          onRename={onRenameTag}
+          onRecolor={onRecolorTag}
+          onDelete={onDeleteTag}
         />
       </div>
       <div className="flex h-12 shrink-0 items-center border-t border-border px-2">

--- a/web/src/chat/useChats.ts
+++ b/web/src/chat/useChats.ts
@@ -17,6 +17,10 @@ interface UseChatsResult {
   softDelete: (id: string) => Promise<void>;
   restore: (id: string) => Promise<void>;
   setTitle: (id: string, title: string) => Promise<void>;
+  // Re-pull the list and re-sort. Used after a tag assignment changes the
+  // chips/dots a chat shows, so the change lands without waiting for the
+  // background refresh interval.
+  reload: () => Promise<void>;
 }
 
 export function useChats(): UseChatsResult {
@@ -121,5 +125,5 @@ export function useChats(): UseChatsResult {
     [bumpEpoch, reload]
   );
 
-  return { chats, loading, sortEpoch, softDelete, restore, setTitle };
+  return { chats, loading, sortEpoch, softDelete, restore, setTitle, reload };
 }

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -4,13 +4,26 @@ import { RotateCcw } from "lucide-react";
 import Markdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
-import type { Message, ContentBlock, Chat } from "@/types";
+import type { Message, ContentBlock, Chat, Tag } from "@/types";
 import { CollapsibleThinking } from "@/conversation/CollapsibleThinking";
 import { CollapsibleToolCall } from "@/conversation/CollapsibleToolCall";
 import { ChatMetadataPopover } from "@/metadata/ChatMetadataPopover";
 import { EditableTitle } from "@/metadata/EditableTitle";
+import { TagStrip } from "@/tags/TagStrip";
+import type { ColorToken } from "@/tags/palette";
 
-interface ConversationViewProps {
+interface TagControls {
+  allTags: Tag[];
+  onAssignTag: (chatId: string, tagId: string) => void;
+  onRemoveTag: (chatId: string, tagId: string) => void;
+  onCreateTag: (
+    chatId: string,
+    name: string,
+    color: ColorToken
+  ) => Promise<Tag | null>;
+}
+
+interface ConversationViewProps extends Partial<TagControls> {
   chat: Chat | null;
   messages: Message[];
   error?: string | null;
@@ -172,7 +185,15 @@ export function ConversationView({
   onRenameTitle,
   editingTitle,
   onEditingTitleChange,
+  allTags,
+  onAssignTag,
+  onRemoveTag,
+  onCreateTag,
 }: ConversationViewProps) {
+  const tagControls: TagControls | undefined =
+    allTags && onAssignTag && onRemoveTag && onCreateTag
+      ? { allTags, onAssignTag, onRemoveTag, onCreateTag }
+      : undefined;
   const [internalEditing, setInternalEditing] = useState(false);
   const headerEditing =
     editingTitle !== undefined ? editingTitle : internalEditing;
@@ -204,6 +225,16 @@ export function ConversationView({
         onEditingChange={setHeaderEditing}
         onRenameTitle={onRenameTitle}
       />
+      {chat && tagControls && (
+        <TagStrip
+          chatId={chat.id}
+          assigned={chat.tags ?? []}
+          allTags={tagControls.allTags}
+          onAssign={tagControls.onAssignTag}
+          onRemove={tagControls.onRemoveTag}
+          onCreate={tagControls.onCreateTag}
+        />
+      )}
       {chat?.isDeleted && onRestore && (
         <DeletedBanner chatId={chat.id} onRestore={onRestore} />
       )}

--- a/web/src/tags/AddTagPopover.tsx
+++ b/web/src/tags/AddTagPopover.tsx
@@ -1,0 +1,200 @@
+import { useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { Check, Plus, Search } from "lucide-react";
+import type { Tag } from "@/types";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
+import {
+  TAG_COLOR_HEX,
+  defaultColorFor,
+  type ColorToken,
+} from "@/tags/palette";
+import { ColorSwatches } from "@/tags/ColorSwatches";
+import { sortTagsByName } from "@/tags/sortTags";
+
+interface AddTagPopoverProps {
+  // Tags currently assigned to this chat.
+  assigned: Tag[];
+  // The full Tag catalog to filter over.
+  allTags: Tag[];
+  onAssign: (tagId: string) => void;
+  onRemove: (tagId: string) => void;
+  // Create a Tag, then assign it to this chat. Returns the created Tag (or null
+  // on failure).
+  onCreate: (name: string, color: ColorToken) => Promise<Tag | null>;
+  // Trigger overrides — lets the same popover hang off both the "+ Tag" button
+  // and the "+N" overflow pill.
+  triggerTestId?: string;
+  triggerAriaLabel?: string;
+  triggerClassName?: string;
+  triggerContent?: ReactNode;
+}
+
+const DEFAULT_TRIGGER_CLASS =
+  "flex h-7 shrink-0 items-center gap-1 rounded-full border border-dashed border-border px-2 text-xs text-muted-foreground transition-colors hover:border-foreground/40 hover:text-foreground focus-visible:outline-2 focus-visible:outline-ring";
+
+export function AddTagPopover({
+  assigned,
+  allTags,
+  onAssign,
+  onRemove,
+  onCreate,
+  triggerTestId = "add-tag-button",
+  triggerAriaLabel = "Add tag",
+  triggerClassName = DEFAULT_TRIGGER_CLASS,
+  triggerContent,
+}: AddTagPopoverProps) {
+  const [query, setQuery] = useState("");
+  // null means "follow the name-derived default"; a value means the user picked.
+  const [override, setOverride] = useState<ColorToken | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const assignedIds = useMemo(
+    () => new Set(assigned.map((t) => t.id)),
+    [assigned]
+  );
+
+  const trimmed = query.trim();
+  const filtered = useMemo(() => {
+    const q = trimmed.toLowerCase();
+    const matched =
+      q.length === 0
+        ? allTags
+        : allTags.filter((t) => t.name.toLowerCase().includes(q));
+    return sortTagsByName(matched);
+  }, [allTags, trimmed]);
+
+  const exactMatch = allTags.some(
+    (t) => t.name.toLowerCase() === trimmed.toLowerCase()
+  );
+  const canCreate = trimmed.length > 0 && !exactMatch;
+  const createColor = override ?? defaultColorFor(trimmed);
+
+  const reset = () => {
+    setQuery("");
+    setOverride(null);
+  };
+
+  const handleCreate = async () => {
+    if (!canCreate) return;
+    await onCreate(trimmed, createColor);
+    reset();
+  };
+
+  return (
+    <Popover onOpenChange={(open) => !open && reset()}>
+      <PopoverTrigger
+        data-testid={triggerTestId}
+        aria-label={triggerAriaLabel}
+        className={triggerClassName}
+      >
+        {triggerContent ?? (
+          <>
+            <Plus size={12} aria-hidden="true" />
+            Tag
+          </>
+        )}
+      </PopoverTrigger>
+      <PopoverContent
+        data-testid="add-tag-popover"
+        align="end"
+        sideOffset={6}
+        className="w-64 gap-2 p-2"
+      >
+        <div className="relative">
+          <Search
+            size={14}
+            aria-hidden="true"
+            className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
+          <input
+            ref={inputRef}
+            autoFocus
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setOverride(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && canCreate) {
+                e.preventDefault();
+                void handleCreate();
+              }
+            }}
+            placeholder="Find or create a tag…"
+            aria-label="Find or create a tag"
+            className="w-full rounded-md border border-border bg-transparent py-1.5 pr-2 pl-7 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-primary"
+          />
+        </div>
+
+        <ul className="flex max-h-56 flex-col gap-0.5 overflow-y-auto">
+          {filtered.map((tag) => {
+            const isAssigned = assignedIds.has(tag.id);
+            return (
+              <li key={tag.id}>
+                <button
+                  type="button"
+                  data-testid="add-tag-option"
+                  data-tag-id={tag.id}
+                  aria-pressed={isAssigned}
+                  onClick={() =>
+                    isAssigned ? onRemove(tag.id) : onAssign(tag.id)
+                  }
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-white/6"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: TAG_COLOR_HEX[tag.color] }}
+                  />
+                  <span className="min-w-0 flex-1 truncate">{tag.name}</span>
+                  {isAssigned && (
+                    <Check
+                      size={14}
+                      aria-hidden="true"
+                      className="shrink-0 text-primary"
+                    />
+                  )}
+                </button>
+              </li>
+            );
+          })}
+          {filtered.length === 0 && !canCreate && (
+            <li className="px-2 py-1.5 text-xs text-muted-foreground">
+              No tags yet.
+            </li>
+          )}
+        </ul>
+
+        {canCreate && (
+          <div className="flex flex-col gap-2 border-t border-border pt-2">
+            <button
+              type="button"
+              data-testid="create-tag-button"
+              onClick={() => void handleCreate()}
+              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-white/6"
+            >
+              <span
+                aria-hidden="true"
+                className="h-2.5 w-2.5 shrink-0 rounded-full"
+                style={{ backgroundColor: TAG_COLOR_HEX[createColor] }}
+              />
+              <span className="min-w-0 flex-1 truncate">
+                Create <span className="font-medium">“{trimmed}”</span>
+              </span>
+            </button>
+            <ColorSwatches
+              value={createColor}
+              onChange={(color) => {
+                setOverride(color);
+                // Picking a swatch moves focus to its button. Return focus to
+                // the input so Enter still creates the tag (instead of the
+                // keystroke escaping to the global shortcut handler).
+                inputRef.current?.focus();
+              }}
+            />
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/tags/ColorSwatches.tsx
+++ b/web/src/tags/ColorSwatches.tsx
@@ -1,0 +1,42 @@
+import { Check } from "lucide-react";
+import {
+  TAG_COLOR_HEX,
+  TAG_COLOR_TOKENS,
+  type ColorToken,
+} from "@/tags/palette";
+
+interface ColorSwatchesProps {
+  value: ColorToken;
+  onChange: (color: ColorToken) => void;
+}
+
+// The eight-swatch palette picker (ADR-0015), shared by inline create-override
+// and the management recolor popover.
+export function ColorSwatches({ value, onChange }: ColorSwatchesProps) {
+  return (
+    <div data-testid="color-swatches" className="flex items-center gap-1.5">
+      {TAG_COLOR_TOKENS.map((token) => {
+        const selected = token === value;
+        return (
+          <button
+            key={token}
+            type="button"
+            aria-label={`Color ${token}`}
+            aria-pressed={selected}
+            onClick={() => onChange(token)}
+            className={`flex h-5 w-5 items-center justify-center rounded-full transition-transform hover:scale-110 ${
+              selected
+                ? "ring-2 ring-foreground/70 ring-offset-1 ring-offset-popover"
+                : ""
+            }`}
+            style={{ backgroundColor: TAG_COLOR_HEX[token] }}
+          >
+            {selected && (
+              <Check size={12} aria-hidden="true" className="text-black/70" />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/tags/TagChip.tsx
+++ b/web/src/tags/TagChip.tsx
@@ -1,0 +1,38 @@
+import { X } from "lucide-react";
+import type { Tag } from "@/types";
+import { TAG_COLOR_HEX, TAG_TEXT_HEX } from "@/tags/palette";
+
+interface TagChipProps {
+  tag: Tag;
+  // When given, the chip reveals a remove affordance on hover that calls this.
+  onRemove?: (tag: Tag) => void;
+}
+
+// A full Tag chip for the conversation header: a solid pill filled with the
+// tag's color, text color chosen for contrast (ADR-0015 palette). The remove
+// "×" overlays the right edge on hover, so the chip reserves no blank gutter.
+export function TagChip({ tag, onRemove }: TagChipProps) {
+  const bg = TAG_COLOR_HEX[tag.color];
+  const fg = TAG_TEXT_HEX[tag.color];
+  return (
+    <span
+      data-testid="tag-chip"
+      data-tag-id={tag.id}
+      className="group/chip relative inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium"
+      style={{ backgroundColor: bg, color: fg }}
+    >
+      <span className="max-w-[14ch] truncate">{tag.name}</span>
+      {onRemove && (
+        <button
+          type="button"
+          aria-label={`Remove tag ${tag.name}`}
+          onClick={() => onRemove(tag)}
+          style={{ color: fg }}
+          className="absolute right-0.5 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded-full bg-black/25 opacity-0 transition-opacity hover:bg-black/40 focus-visible:opacity-100 group-hover/chip:opacity-100"
+        >
+          <X size={11} aria-hidden="true" />
+        </button>
+      )}
+    </span>
+  );
+}

--- a/web/src/tags/TagChipList.tsx
+++ b/web/src/tags/TagChipList.tsx
@@ -1,0 +1,37 @@
+import type { Tag } from "@/types";
+import { TagChip } from "@/tags/TagChip";
+import { sortTagsByName } from "@/tags/sortTags";
+
+interface TagChipListProps {
+  tags: Tag[];
+  // How many name chips to show before collapsing the rest into "+N". The chat
+  // list column is narrow, so this caps row height predictably.
+  max?: number;
+}
+
+// Read-only Tag chips for the chat list's third line — same solid pills as the
+// conversation header, names shown directly (no remove affordance here).
+export function TagChipList({ tags, max = 3 }: TagChipListProps) {
+  if (tags.length === 0) return null;
+  const sorted = sortTagsByName(tags);
+  const shown = sorted.slice(0, max);
+  const overflow = sorted.slice(max);
+  return (
+    <span
+      data-testid="tag-chip-list"
+      className="flex items-center gap-1 overflow-hidden"
+    >
+      {shown.map((tag) => (
+        <TagChip key={tag.id} tag={tag} />
+      ))}
+      {overflow.length > 0 && (
+        <span
+          title={overflow.map((t) => t.name).join(", ")}
+          className="shrink-0 rounded-full bg-card px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-muted-foreground"
+        >
+          +{overflow.length}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/web/src/tags/TagFlow.test.tsx
+++ b/web/src/tags/TagFlow.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import App from "@/App";
+
+// End-to-end wiring of the find-or-create popover against the MSW tag handlers:
+// create a tag inline, see it become a chip in the tag strip and a dot in the
+// list.
+describe("Tag assignment flow", () => {
+  it("creates a tag from the popover and shows it as a chip and a list dot", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Open a chat so the conversation header and tag strip render.
+    await user.click(await screen.findByText("Build a login page"));
+
+    await user.click(await screen.findByTestId("add-tag-button"));
+    await user.type(
+      await screen.findByLabelText("Find or create a tag"),
+      "bug"
+    );
+    await user.click(await screen.findByTestId("create-tag-button"));
+
+    // Chip appears in the tag strip below the header.
+    const strip = screen.getByTestId("tag-strip");
+    await waitFor(() => {
+      expect(within(strip).getByTestId("tag-chip")).toHaveTextContent("bug");
+    });
+
+    // The new tag is in the management section of the navigation panel.
+    expect(
+      within(screen.getByTestId("tags-section")).getByText("bug")
+    ).toBeInTheDocument();
+
+    // And the chat list row shows the tag as a name chip on its third line.
+    await waitFor(() => {
+      expect(
+        within(screen.getByTestId("chat-list")).getAllByTestId("tag-chip-list")
+          .length
+      ).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("creates a tag with an overridden color via Enter after clicking a swatch", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+    await user.click(await screen.findByTestId("add-tag-button"));
+    await user.type(
+      await screen.findByLabelText("Find or create a tag"),
+      "design"
+    );
+
+    // Override the auto-picked color, which moves focus onto the swatch button.
+    await user.click(screen.getByLabelText("Color blue"));
+    // Enter must still create the tag — not start a chat-title rename.
+    await user.keyboard("{Enter}");
+
+    const strip = screen.getByTestId("tag-strip");
+    await waitFor(() => {
+      expect(within(strip).getByTestId("tag-chip")).toHaveTextContent("design");
+    });
+    // The chat title must not have entered rename mode.
+    expect(
+      within(screen.getByTestId("conversation-header")).queryByLabelText(
+        "Chat title"
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it("removes an assigned tag from the strip chip", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Build a login page"));
+    await user.click(await screen.findByTestId("add-tag-button"));
+    await user.type(
+      await screen.findByLabelText("Find or create a tag"),
+      "bug"
+    );
+    await user.click(await screen.findByTestId("create-tag-button"));
+
+    const strip = screen.getByTestId("tag-strip");
+    await waitFor(() =>
+      expect(within(strip).getByTestId("tag-chip")).toBeInTheDocument()
+    );
+
+    await user.click(within(strip).getByLabelText("Remove tag bug"));
+
+    await waitFor(() =>
+      expect(within(strip).queryByTestId("tag-chip")).not.toBeInTheDocument()
+    );
+  });
+});

--- a/web/src/tags/TagStrip.tsx
+++ b/web/src/tags/TagStrip.tsx
@@ -1,0 +1,128 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import type { Tag } from "@/types";
+import type { ColorToken } from "@/tags/palette";
+import { TagChip } from "@/tags/TagChip";
+import { AddTagPopover } from "@/tags/AddTagPopover";
+import { sortTagsByName } from "@/tags/sortTags";
+
+interface TagStripProps {
+  chatId: string;
+  assigned: Tag[];
+  allTags: Tag[];
+  onAssign: (chatId: string, tagId: string) => void;
+  onRemove: (chatId: string, tagId: string) => void;
+  onCreate: (
+    chatId: string,
+    name: string,
+    color: ColorToken
+  ) => Promise<Tag | null>;
+}
+
+const CHIP_GAP = 8;
+// Horizontal room kept clear for the "+N" pill and the "+ Tag" button so the
+// last fitting chip never collides with them.
+const CONTROLS_RESERVE = 120;
+
+// The tag strip below the conversation header (ADR-0015 / issue #10). It lives
+// in the content area, not the header band, so the three columns' 48px headers
+// stay aligned. Chips render on a single line; any that don't fit collapse into
+// a "+N" pill that opens the same find-or-create popover as "+ Tag".
+export function TagStrip({
+  chatId,
+  assigned,
+  allTags,
+  onAssign,
+  onRemove,
+  onCreate,
+}: TagStripProps) {
+  const rowRef = useRef<HTMLDivElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState(assigned.length);
+
+  useLayoutEffect(() => {
+    const row = rowRef.current;
+    const measure = measureRef.current;
+    if (!row || !measure) return;
+    const recompute = () => {
+      // Before layout (and under jsdom) clientWidth is 0 — show every chip
+      // rather than collapsing them all into "+N".
+      if (row.clientWidth === 0) {
+        setVisibleCount(assigned.length);
+        return;
+      }
+      const chipEls = Array.from(measure.children) as HTMLElement[];
+      const available = row.clientWidth - CONTROLS_RESERVE;
+      let used = 0;
+      let count = 0;
+      for (const el of chipEls) {
+        used += el.offsetWidth + CHIP_GAP;
+        if (used <= available) count += 1;
+        else break;
+      }
+      setVisibleCount(Math.max(0, Math.min(assigned.length, count)));
+    };
+    const observer = new ResizeObserver(recompute);
+    observer.observe(row);
+    recompute();
+    return () => observer.disconnect();
+  }, [assigned]);
+
+  const sorted = sortTagsByName(assigned);
+  const visible = sorted.slice(0, visibleCount);
+  const hiddenCount = sorted.length - visible.length;
+
+  return (
+    <div
+      data-testid="tag-strip"
+      className="relative flex h-10 shrink-0 items-center bg-[#06303b] px-5"
+    >
+      {/* Off-screen plain copies that mirror each chip's width (the × overlays
+          absolutely so it adds none), measured to decide how many fit. Plain
+          spans avoid duplicating the chip's test id and remove button. */}
+      <div
+        ref={measureRef}
+        aria-hidden="true"
+        className="pointer-events-none absolute -top-96 left-0 flex gap-2 opacity-0"
+      >
+        {sorted.map((tag) => (
+          <span
+            key={tag.id}
+            className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium"
+          >
+            <span className="max-w-[14ch] truncate">{tag.name}</span>
+          </span>
+        ))}
+      </div>
+
+      <div ref={rowRef} className="flex min-w-0 flex-1 items-center gap-2">
+        {visible.map((tag) => (
+          <TagChip
+            key={tag.id}
+            tag={tag}
+            onRemove={(t) => onRemove(chatId, t.id)}
+          />
+        ))}
+        {hiddenCount > 0 && (
+          <AddTagPopover
+            assigned={assigned}
+            allTags={allTags}
+            onAssign={(tagId) => onAssign(chatId, tagId)}
+            onRemove={(tagId) => onRemove(chatId, tagId)}
+            onCreate={(name, color) => onCreate(chatId, name, color)}
+            triggerTestId="tag-overflow"
+            triggerAriaLabel={`Show ${hiddenCount} more tags`}
+            triggerClassName="flex h-7 shrink-0 items-center rounded-full bg-card px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-2 focus-visible:outline-ring"
+            triggerContent={`+${hiddenCount}`}
+          />
+        )}
+        <AddTagPopover
+          assigned={assigned}
+          allTags={allTags}
+          onAssign={(tagId) => onAssign(chatId, tagId)}
+          onRemove={(tagId) => onRemove(chatId, tagId)}
+          onCreate={(name, color) => onCreate(chatId, name, color)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/tags/TagsSection.tsx
+++ b/web/src/tags/TagsSection.tsx
@@ -1,0 +1,295 @@
+import { useMemo, useState } from "react";
+import {
+  ArrowLeft,
+  ChevronDown,
+  MoreHorizontal,
+  Pencil,
+  Palette,
+  Trash2,
+} from "lucide-react";
+import type { Tag } from "@/types";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
+import { TAG_COLOR_HEX, type ColorToken } from "@/tags/palette";
+import { ColorSwatches } from "@/tags/ColorSwatches";
+import { sortTagsByName } from "@/tags/sortTags";
+
+interface TagsSectionProps {
+  tags: Tag[];
+  // How many chats carry a given tag — drives the row count and delete-confirm.
+  countForTag: (tagId: string) => number;
+  onRename: (id: string, name: string) => void;
+  onRecolor: (id: string, color: ColorToken) => void;
+  onDelete: (id: string) => void;
+}
+
+function RenameRow({
+  tag,
+  onCommit,
+  onCancel,
+}: {
+  tag: Tag;
+  onCommit: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(tag.name);
+  const commit = () => {
+    const next = value.trim();
+    if (next.length > 0 && next !== tag.name) onCommit(next);
+    else onCancel();
+  };
+  return (
+    <input
+      autoFocus
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") commit();
+        else if (e.key === "Escape") onCancel();
+      }}
+      aria-label={`Rename tag ${tag.name}`}
+      className="min-w-0 flex-1 rounded border border-primary bg-transparent px-1.5 py-0.5 text-sm text-foreground outline-none"
+    />
+  );
+}
+
+// The ⋯ control: one portaled popover with three views (menu / recolor /
+// delete-confirm). Living in the portal means the wide swatch row and the
+// confirm card render above everything instead of being clipped by the
+// narrow navigation column's overflow.
+function ManageMenu({
+  tag,
+  count,
+  onRenameStart,
+  onRecolor,
+  onDelete,
+}: {
+  tag: Tag;
+  count: number;
+  onRenameStart: () => void;
+  onRecolor: (color: ColorToken) => void;
+  onDelete: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<"menu" | "recolor" | "delete">("menu");
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setView("menu");
+      }}
+    >
+      <PopoverTrigger
+        aria-label={`Manage tag ${tag.name}`}
+        className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-white/10 hover:text-foreground focus-visible:opacity-100 group-hover/tag:opacity-100 data-[popup-open]:opacity-100"
+      >
+        <MoreHorizontal size={14} aria-hidden="true" />
+      </PopoverTrigger>
+      <PopoverContent
+        data-testid="tag-manage-menu"
+        align="end"
+        sideOffset={4}
+        className="w-60 gap-1 p-1"
+      >
+        {view === "menu" && (
+          <>
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                onRenameStart();
+              }}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-white/6"
+            >
+              <Pencil size={14} aria-hidden="true" />
+              Rename
+            </button>
+            <button
+              type="button"
+              data-testid="tag-recolor-button"
+              onClick={() => setView("recolor")}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-white/6"
+            >
+              <Palette size={14} aria-hidden="true" />
+              Recolor
+            </button>
+            <button
+              type="button"
+              onClick={() => setView("delete")}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-destructive transition-colors hover:bg-[#3a1d23]"
+            >
+              <Trash2 size={14} aria-hidden="true" />
+              Delete
+            </button>
+          </>
+        )}
+
+        {view === "recolor" && (
+          <div className="flex flex-col gap-2 p-1">
+            <button
+              type="button"
+              onClick={() => setView("menu")}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <ArrowLeft size={12} aria-hidden="true" />
+              Color
+            </button>
+            <ColorSwatches value={tag.color} onChange={onRecolor} />
+          </div>
+        )}
+
+        {view === "delete" && (
+          <div data-testid="tag-delete-confirm" className="p-1.5">
+            <p className="flex items-center gap-1.5 font-medium text-foreground">
+              <Trash2
+                size={14}
+                aria-hidden="true"
+                className="text-destructive"
+              />
+              Delete tag “{tag.name}”?
+            </p>
+            <p className="mt-1.5 text-xs text-muted-foreground">
+              It will be removed from{" "}
+              <span className="font-medium text-foreground">
+                {count} {count === 1 ? "chat" : "chats"}
+              </span>
+              . This can’t be undone.
+            </p>
+            <div className="mt-2.5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setView("menu")}
+                className="rounded-md border border-border px-2.5 py-1 text-xs text-foreground transition-colors hover:bg-white/6"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                data-testid="tag-delete-confirm-button"
+                onClick={() => {
+                  onDelete();
+                  setOpen(false);
+                }}
+                className="rounded-md bg-destructive px-2.5 py-1 text-xs font-semibold text-white transition-colors hover:bg-destructive/90"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function TagRow({
+  tag,
+  count,
+  onRename,
+  onRecolor,
+  onDelete,
+}: {
+  tag: Tag;
+  count: number;
+  onRename: (name: string) => void;
+  onRecolor: (color: ColorToken) => void;
+  onDelete: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+
+  return (
+    <li
+      data-testid="tag-manage-row"
+      data-tag-id={tag.id}
+      className="group/tag relative flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground/90 hover:bg-card"
+    >
+      <span
+        aria-hidden="true"
+        className="h-2.5 w-2.5 shrink-0 rounded-full"
+        style={{ backgroundColor: TAG_COLOR_HEX[tag.color] }}
+      />
+      {editing ? (
+        <RenameRow
+          tag={tag}
+          onCommit={(name) => {
+            onRename(name);
+            setEditing(false);
+          }}
+          onCancel={() => setEditing(false)}
+        />
+      ) : (
+        <>
+          <span className="min-w-0 flex-1 truncate">{tag.name}</span>
+          <ManageMenu
+            tag={tag}
+            count={count}
+            onRenameStart={() => setEditing(true)}
+            onRecolor={onRecolor}
+            onDelete={onDelete}
+          />
+          <span className="shrink-0 text-xs tabular-nums text-muted-foreground group-hover/tag:hidden">
+            {count}
+          </span>
+        </>
+      )}
+    </li>
+  );
+}
+
+export function TagsSection({
+  tags,
+  countForTag,
+  onRename,
+  onRecolor,
+  onDelete,
+}: TagsSectionProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const sorted = useMemo(() => sortTagsByName(tags), [tags]);
+
+  return (
+    <div data-testid="tags-section" className="flex flex-col">
+      <button
+        type="button"
+        data-testid="tags-header"
+        onClick={() => setCollapsed((c) => !c)}
+        aria-expanded={!collapsed}
+        className="flex items-center justify-between px-2 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <span>Tags</span>
+        <span
+          data-testid="tags-order-caption"
+          title="Sorted A–Z"
+          className="flex items-center gap-0.5 text-muted-foreground/80"
+        >
+          A–Z
+          <ChevronDown
+            size={12}
+            aria-hidden="true"
+            className={`transition-transform ${collapsed ? "-rotate-90" : ""}`}
+          />
+        </span>
+      </button>
+      {!collapsed &&
+        (sorted.length === 0 ? (
+          <p className="px-2 py-1.5 text-xs text-muted-foreground">
+            No tags yet. Add one from a chat’s header.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-0.5">
+            {sorted.map((tag) => (
+              <TagRow
+                key={tag.id}
+                tag={tag}
+                count={countForTag(tag.id)}
+                onRename={(name) => onRename(tag.id, name)}
+                onRecolor={(color) => onRecolor(tag.id, color)}
+                onDelete={() => onDelete(tag.id)}
+              />
+            ))}
+          </ul>
+        ))}
+    </div>
+  );
+}

--- a/web/src/tags/palette.ts
+++ b/web/src/tags/palette.ts
@@ -1,0 +1,82 @@
+// The closed Tag color vocabulary (ADR-0015): eight semantic tokens from the
+// Solarized accent set. The token is what we store; this map is the single
+// place that resolves token → hex for every Tag surface (chips, dots, swatches,
+// the future Spotlight picker). Re-theming is a remap here, not a data change.
+export const TAG_COLOR_TOKENS = [
+  "yellow",
+  "orange",
+  "red",
+  "magenta",
+  "violet",
+  "blue",
+  "cyan",
+  "green",
+] as const;
+
+export type ColorToken = (typeof TAG_COLOR_TOKENS)[number];
+
+export const TAG_COLOR_HEX: Record<ColorToken, string> = {
+  yellow: "#b58900",
+  orange: "#cb4b16",
+  red: "#dc322f",
+  magenta: "#d33682",
+  violet: "#6c71c4",
+  blue: "#268bd2",
+  cyan: "#2aa198",
+  green: "#859900",
+};
+
+export function isColorToken(value: string): value is ColorToken {
+  return (TAG_COLOR_TOKENS as readonly string[]).includes(value);
+}
+
+// Solarized base03 — the dark text color used on light-filled chips.
+const DARK_TEXT = "#002b36";
+const LIGHT_TEXT = "#ffffff";
+
+function srgbToLinear(channel: number): number {
+  const s = channel / 255;
+  return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return (
+    0.2126 * srgbToLinear(r) +
+    0.7152 * srgbToLinear(g) +
+    0.0722 * srgbToLinear(b)
+  );
+}
+
+function contrast(a: number, b: number): number {
+  const hi = Math.max(a, b);
+  const lo = Math.min(a, b);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// Pick the readable text color for a filled chip: whichever of white / base03
+// has the higher contrast against the tag's background. Light tokens (yellow,
+// cyan, green) land on dark text; the rest on white — all eight stay legible.
+const DARK_TEXT_LUMINANCE = relativeLuminance(DARK_TEXT);
+export const TAG_TEXT_HEX: Record<ColorToken, string> = Object.fromEntries(
+  TAG_COLOR_TOKENS.map((token) => {
+    const bg = relativeLuminance(TAG_COLOR_HEX[token]);
+    const onWhite = contrast(bg, 1);
+    const onDark = contrast(bg, DARK_TEXT_LUMINANCE);
+    return [token, onWhite >= onDark ? LIGHT_TEXT : DARK_TEXT];
+  })
+) as Record<ColorToken, string>;
+
+// The default color picked when a Tag is created inline, before the user
+// overrides it. Derived from the Tag name so repeated creates of the same name
+// land on a stable swatch, but any of the eight is a one-click override.
+export function defaultColorFor(name: string): ColorToken {
+  let hash = 0;
+  for (let i = 0; i < name.length; i += 1) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  const index = Math.abs(hash) % TAG_COLOR_TOKENS.length;
+  return TAG_COLOR_TOKENS[index];
+}

--- a/web/src/tags/sortTags.ts
+++ b/web/src/tags/sortTags.ts
@@ -1,0 +1,7 @@
+import type { Tag } from "@/types";
+
+// One shared A–Z ordering for every Tag surface (navigation panel, chat-list
+// chips, conversation strip, find-or-create options) so they all read the same.
+export function sortTagsByName(tags: Tag[]): Tag[] {
+  return [...tags].sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/web/src/tags/useTags.ts
+++ b/web/src/tags/useTags.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useState } from "react";
+import type { Tag } from "@/types";
+import type { ColorToken } from "@/tags/palette";
+
+interface UseTagsOptions {
+  // Called after an assignment changes which tags a chat carries, so the chat
+  // list can re-pull and re-render its chips/dots.
+  onAssignmentChange: () => void;
+}
+
+export interface UseTagsResult {
+  /** The full Tag catalog — drives the management section and the find-or-create
+   * popover's option list. */
+  tags: Tag[];
+  createTag: (name: string, color: ColorToken) => Promise<Tag | null>;
+  renameTag: (id: string, name: string) => Promise<void>;
+  recolorTag: (id: string, color: ColorToken) => Promise<void>;
+  deleteTag: (id: string) => Promise<void>;
+  assignTag: (chatId: string, tagId: string) => Promise<void>;
+  removeTag: (chatId: string, tagId: string) => Promise<void>;
+}
+
+async function fetchTags(): Promise<Tag[]> {
+  const res = await fetch("/api/tags");
+  const data = (await res.json()) as { tags: Tag[] };
+  return data.tags;
+}
+
+export function useTags({ onAssignmentChange }: UseTagsOptions): UseTagsResult {
+  const [tags, setTags] = useState<Tag[]>([]);
+
+  const refresh = useCallback(async () => {
+    try {
+      setTags(await fetchTags());
+    } catch {
+      // Ignore transient failures; the catalog stays at its last-known value.
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchTags()
+      .then((next) => {
+        if (!cancelled) setTags(next);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const createTag = useCallback(
+    async (name: string, color: ColorToken) => {
+      const res = await fetch("/api/tags", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name, color }),
+      });
+      if (!res.ok) return null;
+      const { tag } = (await res.json()) as { tag: Tag };
+      await refresh();
+      return tag;
+    },
+    [refresh]
+  );
+
+  const renameTag = useCallback(
+    async (id: string, name: string) => {
+      await fetch(`/api/tags/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      await refresh();
+      onAssignmentChange();
+    },
+    [refresh, onAssignmentChange]
+  );
+
+  const recolorTag = useCallback(
+    async (id: string, color: ColorToken) => {
+      await fetch(`/api/tags/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ color }),
+      });
+      await refresh();
+      onAssignmentChange();
+    },
+    [refresh, onAssignmentChange]
+  );
+
+  const deleteTag = useCallback(
+    async (id: string) => {
+      await fetch(`/api/tags/${encodeURIComponent(id)}`, { method: "DELETE" });
+      await refresh();
+      onAssignmentChange();
+    },
+    [refresh, onAssignmentChange]
+  );
+
+  const assignTag = useCallback(
+    async (chatId: string, tagId: string) => {
+      await fetch(`/api/chats/${encodeURIComponent(chatId)}/tags`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tagId }),
+      });
+      onAssignmentChange();
+    },
+    [onAssignmentChange]
+  );
+
+  const removeTag = useCallback(
+    async (chatId: string, tagId: string) => {
+      await fetch(
+        `/api/chats/${encodeURIComponent(chatId)}/tags/${encodeURIComponent(tagId)}`,
+        { method: "DELETE" }
+      );
+      onAssignmentChange();
+    },
+    [onAssignmentChange]
+  );
+
+  return {
+    tags,
+    createTag,
+    renameTag,
+    recolorTag,
+    deleteTag,
+    assignTag,
+    removeTag,
+  };
+}

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -100,8 +100,34 @@ const initialFakeChats: FakeChat[] = [
 
 export let fakeChats: FakeChat[] = structuredClone(initialFakeChats);
 
+type FakeTag = { id: string; name: string; color: string };
+
+export let fakeTags: FakeTag[] = [];
+// chatId -> ordered list of tag ids assigned to it.
+export let fakeChatTags: Record<string, string[]> = {};
+
+const PALETTE = [
+  "yellow",
+  "orange",
+  "red",
+  "magenta",
+  "violet",
+  "blue",
+  "cyan",
+  "green",
+];
+
 export function resetFakeChats(): void {
   fakeChats = structuredClone(initialFakeChats);
+  fakeTags = [];
+  fakeChatTags = {};
+}
+
+function tagsForChat(chatId: string): FakeTag[] {
+  const ids = fakeChatTags[chatId] ?? [];
+  return ids
+    .map((id) => fakeTags.find((t) => t.id === id))
+    .filter((t): t is FakeTag => t !== undefined);
 }
 
 export const fakeMessages = {
@@ -179,7 +205,11 @@ export const fakeMessages = {
 
 function projectChat(c: FakeChat) {
   const { defaultTitle, customTitle, ...rest } = c;
-  return { ...rest, title: customTitle ?? defaultTitle };
+  return {
+    ...rest,
+    title: customTitle ?? defaultTitle,
+    tags: tagsForChat(c.id),
+  };
 }
 
 export const handlers = [
@@ -234,6 +264,90 @@ export const handlers = [
     }
     chat.isDeleted = false;
     chat.deletedAt = null;
+    return new HttpResponse(null, { status: 204 });
+  }),
+  http.get("/api/tags", () => {
+    return HttpResponse.json({ tags: fakeTags });
+  }),
+  http.post("/api/tags", async ({ request }) => {
+    const body = (await request.json()) as { name?: unknown; color?: unknown };
+    if (typeof body?.name !== "string" || body.name.trim().length === 0) {
+      return HttpResponse.json({ error: "Invalid name" }, { status: 400 });
+    }
+    if (typeof body?.color !== "string" || !PALETTE.includes(body.color)) {
+      return HttpResponse.json({ error: "Invalid color" }, { status: 400 });
+    }
+    const tag: FakeTag = {
+      id: `tag-${fakeTags.length + 1}-${body.name.trim()}`,
+      name: body.name.trim(),
+      color: body.color,
+    };
+    fakeTags = [...fakeTags, tag];
+    return HttpResponse.json({ tag }, { status: 201 });
+  }),
+  http.patch("/api/tags/:id", async ({ params, request }) => {
+    const id = params.id as string;
+    const tag = fakeTags.find((t) => t.id === id);
+    if (!tag) {
+      return HttpResponse.json({ error: "Tag not found" }, { status: 404 });
+    }
+    const body = (await request.json()) as { name?: unknown; color?: unknown };
+    if (typeof body?.name === "string" && body.name.trim().length > 0) {
+      tag.name = body.name.trim();
+    }
+    if (typeof body?.color === "string") {
+      if (!PALETTE.includes(body.color)) {
+        return HttpResponse.json({ error: "Invalid color" }, { status: 400 });
+      }
+      tag.color = body.color;
+    }
+    return new HttpResponse(null, { status: 204 });
+  }),
+  http.delete("/api/tags/:id", ({ params }) => {
+    const id = params.id as string;
+    const exists = fakeTags.some((t) => t.id === id);
+    if (!exists) {
+      return HttpResponse.json({ error: "Tag not found" }, { status: 404 });
+    }
+    let removedFromChats = 0;
+    for (const [chatId, ids] of Object.entries(fakeChatTags)) {
+      if (ids.includes(id)) {
+        removedFromChats += 1;
+        fakeChatTags[chatId] = ids.filter((t) => t !== id);
+      }
+    }
+    fakeTags = fakeTags.filter((t) => t.id !== id);
+    return HttpResponse.json({ removedFromChats });
+  }),
+  http.post("/api/chats/:id/tags", async ({ params, request }) => {
+    const chatId = params.id as string;
+    const chat = fakeChats.find((c) => c.id === chatId);
+    if (!chat) {
+      return HttpResponse.json({ error: "Chat not found" }, { status: 404 });
+    }
+    const body = (await request.json()) as { tagId?: unknown };
+    if (
+      typeof body?.tagId !== "string" ||
+      !fakeTags.some((t) => t.id === body.tagId)
+    ) {
+      return HttpResponse.json({ error: "Tag not found" }, { status: 404 });
+    }
+    const current = fakeChatTags[chatId] ?? [];
+    if (!current.includes(body.tagId)) {
+      fakeChatTags[chatId] = [...current, body.tagId];
+    }
+    return new HttpResponse(null, { status: 204 });
+  }),
+  http.delete("/api/chats/:id/tags/:tagId", ({ params }) => {
+    const chatId = params.id as string;
+    const tagId = params.tagId as string;
+    const chat = fakeChats.find((c) => c.id === chatId);
+    if (!chat) {
+      return HttpResponse.json({ error: "Chat not found" }, { status: 404 });
+    }
+    fakeChatTags[chatId] = (fakeChatTags[chatId] ?? []).filter(
+      (t) => t !== tagId
+    );
     return new HttpResponse(null, { status: 204 });
   }),
 ];

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,3 +1,11 @@
+import type { ColorToken } from "@/tags/palette";
+
+export interface Tag {
+  id: string;
+  name: string;
+  color: ColorToken;
+}
+
 export interface Chat {
   /** Public wire-form chat id (`clog_…`) — the canonical handle used for routing. */
   id: string;
@@ -13,6 +21,8 @@ export interface Chat {
   /** Soft-delete time in ms; null while the chat is active. */
   deletedAt?: number | null;
   isDeleted?: boolean;
+  /** Tags assigned to this chat (batched server-side; see ADR-0016). */
+  tags?: Tag[];
 }
 
 export type ContentBlock =


### PR DESCRIPTION
## Background (Why)

Implements the Tag system (closes #10): create Tags with a name and a color, assign one or more to each Chat, and manage them. This is the data + management layer; filtering by Tag is tracked separately in #11.

## Approach (How)

- **Storage (`metadata.db`):** new `tags` and `chat_tags` tables. `chat_tags` uses PK `(chat_id, tag_id)` plus a secondary index on `(tag_id)` for the future AND-intersection filter (ADR-0016). Migration `0004_add_tags.sql` is hand-written to match the repo's existing migration practice (drizzle-kit generate needs a TTY).
- **Color as a semantic token (ADR-0015):** `tags.color` stores one of a fixed 8-color Solarized accent palette, never raw hex; both API and UI validate against that closed set. Chip text color is chosen per-tag by WCAG contrast so all eight stay legible.
- **No N+1 (ADR-0016):** `GET /api/chats` embeds each chat's tags via the ChatReader using one grouped `listTagsByChat` query, which is the single source the chat list and conversation header render from.
- **Three-column UI:** tags live in a sub-strip below the 48px conversation-header band (so all three column headers stay aligned), with a responsive `+N` overflow; the chat list shows name chips on a third line; the navigation panel hosts an A–Z management section.

## Changes (What)

- [x] `tags` + `chat_tags` schema and migration `0004` (PK + `(tag_id)` index)
- [x] `TagRepository`: create / list / get / rename / recolor / delete, assign / remove, and batched `listTagsByChat`; `deleteTag` clears associations in a transaction and returns the affected-chat count
- [x] API: `POST/GET/PATCH/DELETE /api/tags`, `POST/DELETE /api/chats/:id/tags`, and tags embedded in `GET /api/chats`
- [x] Conversation header: find-or-create popover (filter, inline create with auto-picked overridable color) + borderless tinted tag strip with `+N` overflow
- [x] Navigation Tags section: A–Z list with per-tag counts; rename, recolor, delete (confirm with affected count)
- [x] Chat list: three-line rows with tag name chips; tags sorted A–Z across every surface

### Test Verification

- [x] Repository unit tests — create/list/get, invalid color rejected, rename/recolor, assign idempotency, remove, delete-with-count, batched grouping, persistence (12 tests)
- [x] API integration tests — CRUD, assignment, 400/404 paths, and tags embedded in `GET /api/chats`
- [x] Web — find-or-create flow, create-with-overridden-color via Enter (regression for the global-shortcut bug), chip removal
- [x] Full suite green: 188 api + 137 web; typecheck, lint, build all pass

## Additional Notes

- The find-or-create popover currently filters with a plain substring match. Issue #26 (Spotlight) is updated to replace it with the shared in-memory MiniSearch index once that exists.
- Filtering by Tag (selecting tags in the navigation panel) is intentionally out of scope here — tracked in #11.

## Related Links

- Closes #10
- Follow-up wiring noted in #26 (Spotlight Tags picker) and #11 (Tag filtering)