### PR TITLE
feat: Tag filtering in the navigation panel

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -765,6 +765,103 @@ describe("GET /api/chats?project= (server-side Project filter)", () => {
   });
 });
 
+describe("GET /api/chats?tags= (server-side Tag filter)", () => {
+  it("returns only chats holding ALL listed tags (AND intersection)", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+    const both = seedChat(archive, {
+      sourceId: "session-both",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const bugOnly = seedChat(archive, {
+      sourceId: "session-bug",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const bug = tags.createTag("bug", "red");
+    const idea = tags.createTag("idea", "violet");
+    tags.assignTag(both, bug.id);
+    tags.assignTag(both, idea.id);
+    tags.assignTag(bugOnly, bug.id);
+
+    const app = createApp({ archive, metadata, tags });
+    const res = await app.request(`/api/chats?tags=${bug.id},${idea.id}`);
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    expect(body.chats.map((c) => c.sourceId)).toEqual(["session-both"]);
+  });
+
+  it("combines the tag filter with the project filter (AND across types)", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+    const inA = seedChat(archive, {
+      sourceId: "session-a-tagged",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+    const inB = seedChat(archive, {
+      sourceId: "session-b-tagged",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-b",
+    });
+    const bug = tags.createTag("bug", "red");
+    tags.assignTag(inA, bug.id);
+    tags.assignTag(inB, bug.id);
+
+    const app = createApp({ archive, metadata, tags });
+    const res = await app.request(
+      `/api/chats?tags=${bug.id}&project=project-a`
+    );
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    expect(body.chats.map((c) => c.sourceId)).toEqual(["session-a-tagged"]);
+  });
+
+  it("selects the Untagged group when tags= is empty", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+    seedChat(archive, {
+      sourceId: "session-bare",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const tagged = seedChat(archive, {
+      sourceId: "session-tagged",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const bug = tags.createTag("bug", "red");
+    tags.assignTag(tagged, bug.id);
+
+    const app = createApp({ archive, metadata, tags });
+    const res = await app.request("/api/chats?tags=");
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    expect(body.chats.map((c) => c.sourceId)).toEqual(["session-bare"]);
+  });
+
+  it("returns every chat when no tags param is given", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+    const a = seedChat(archive, {
+      sourceId: "session-a",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedChat(archive, {
+      sourceId: "session-b",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const bug = tags.createTag("bug", "red");
+    tags.assignTag(a, bug.id);
+
+    const app = createApp({ archive, metadata, tags });
+    const res = await app.request("/api/chats");
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    expect(body.chats.map((c) => c.sourceId).sort()).toEqual([
+      "session-a",
+      "session-b",
+    ]);
+  });
+});
+
 describe("GET /api/chats/:id (route status mapping)", () => {
   it("returns 404 when archive has no chat for the given id", async () => {
     const archive = createArchiveRepository({ dataDir });

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -21,9 +21,15 @@ export function createApp({ archive, metadata, tags, webDistDir }: AppOptions) {
     // Repeated `?project=` params union (OR); an empty value selects the
     // `(No project)` group. Absent param => undefined => unfiltered.
     const projects = c.req.queries("project");
+    // A single comma-separated `?tags=` param, AND within. `tags=` (empty)
+    // splits to `[""]` — the `Untagged` group — mirroring `project=`'s empty
+    // `(No project)` convention. Absent param => undefined => unfiltered.
+    const tagsParam = c.req.query("tags");
+    const tags = tagsParam === undefined ? undefined : tagsParam.split(",");
     const chats = reader.listChats({
       includeTrashed: c.req.query("includeTrashed") === "true",
       projects,
+      tags,
     });
     return c.json({ chats });
   });

--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -611,6 +611,140 @@ describe("ChatReader.listChats project filter", () => {
   });
 });
 
+describe("ChatReader.listChats tag filter", () => {
+  it("returns only chats holding ALL selected tags (AND)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const both = seedChat(archive, {
+      sourceId: "session-both",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const bugOnly = seedChat(archive, {
+      sourceId: "session-bug",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const bug = tags.createTag("bug", "red");
+    const idea = tags.createTag("idea", "violet");
+    tags.assignTag(both, bug.id);
+    tags.assignTag(both, idea.id);
+    tags.assignTag(bugOnly, bug.id);
+
+    const reader = createChatReader({ archive, metadata, tags });
+    const chats = reader.listChats({
+      includeTrashed: false,
+      tags: [bug.id, idea.id],
+    });
+    expect(chats.map((c) => c.sourceId)).toEqual(["session-both"]);
+  });
+
+  it("selects chats with zero tags for the Untagged group (empty-string entry)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-bare",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const tagged = seedChat(archive, {
+      sourceId: "session-tagged",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const bug = tags.createTag("bug", "red");
+    tags.assignTag(tagged, bug.id);
+
+    const reader = createChatReader({ archive, metadata, tags });
+    const chats = reader.listChats({ includeTrashed: false, tags: [""] });
+    expect(chats.map((c) => c.sourceId)).toEqual(["session-bare"]);
+  });
+
+  it("yields nothing when Untagged is combined with a real tag", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-bare",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const tagged = seedChat(archive, {
+      sourceId: "session-tagged",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const bug = tags.createTag("bug", "red");
+    tags.assignTag(tagged, bug.id);
+
+    const reader = createChatReader({ archive, metadata, tags });
+    const chats = reader.listChats({
+      includeTrashed: false,
+      tags: ["", bug.id],
+    });
+    expect(chats).toEqual([]);
+  });
+
+  it("intersects the tag filter with the project filter (AND across types)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const inA = seedChat(archive, {
+      sourceId: "session-a-tagged",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-a",
+    });
+    const inB = seedChat(archive, {
+      sourceId: "session-b-tagged",
+      firstSeenAt: new Date(1700000000000),
+      project: "project-b",
+    });
+    const bug = tags.createTag("bug", "red");
+    tags.assignTag(inA, bug.id);
+    tags.assignTag(inB, bug.id);
+
+    const reader = createChatReader({ archive, metadata, tags });
+    const chats = reader.listChats({
+      includeTrashed: false,
+      projects: ["project-a"],
+      tags: [bug.id],
+    });
+    expect(chats.map((c) => c.sourceId)).toEqual(["session-a-tagged"]);
+  });
+
+  it("composes the tag filter with trash visibility (active view only)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const active = seedChat(archive, {
+      sourceId: "session-active",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const trashed = seedChat(archive, {
+      sourceId: "session-trashed",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const bug = tags.createTag("bug", "red");
+    tags.assignTag(active, bug.id);
+    tags.assignTag(trashed, bug.id);
+    metadata.softDelete(trashed);
+
+    const reader = createChatReader({ archive, metadata, tags });
+    expect(
+      reader
+        .listChats({ includeTrashed: false, tags: [bug.id] })
+        .map((c) => c.sourceId)
+    ).toEqual(["session-active"]);
+    expect(
+      reader
+        .listChats({ includeTrashed: true, tags: [bug.id] })
+        .map((c) => c.sourceId)
+        .sort()
+    ).toEqual(["session-active", "session-trashed"]);
+  });
+});
+
 describe("ChatReader visibility", () => {
   it("excludes trashed chats by default", () => {
     const archive = createArchiveRepository({ dataDir });

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -70,6 +70,13 @@ export interface ChatReader {
   listChats(opts: {
     includeTrashed: boolean;
     projects?: string[];
+    /**
+     * Tag filter, AND within: a Chat must hold every selected Tag to pass. An
+     * empty-string entry selects the `Untagged` group (zero Tags) — mixing it
+     * with a real Tag id naturally yields nothing. Combined with `projects` (OR
+     * within) the two AND across types. Omitting it leaves Tags unfiltered.
+     */
+    tags?: string[];
   }): ChatResponse[];
   /**
    * Messages for a Chat resolved by its public wire-form chat id (`clog_…`).
@@ -123,12 +130,38 @@ export function createChatReader({
   function listChats({
     includeTrashed,
     projects,
+    tags: tagSelection,
   }: {
     includeTrashed: boolean;
     projects?: string[];
+    tags?: string[];
   }): ChatResponse[] {
     const visibility = loadChatVisibility(metadata, { includeTrashed });
     const rows = archive.read.listChatRows(projects ? { projects } : undefined);
+
+    // Tag filter (AND within) is resolved as a per-Chat predicate intersected
+    // in app code with the Project-filtered Archive rows — the cross-store
+    // intersection ADR-0016 mandates instead of a single cross-database JOIN.
+    // A real-id set comes from the AND-intersection query; the `Untagged`
+    // group is "holds no Tag at all", so it excludes any Chat that appears in
+    // the grouped tags map. Selecting both at once leaves nothing, as intended.
+    let passesTagFilter: ((chatInternalId: string) => boolean) | null = null;
+    if (tagSelection) {
+      const realTagIds = tagSelection.filter((t) => t !== "");
+      const wantUntagged = tagSelection.includes("");
+      const allowedByTags =
+        realTagIds.length > 0
+          ? new Set(tags.listChatIdsWithAllTags(realTagIds))
+          : null;
+      const taggedChatIds = wantUntagged
+        ? new Set(tags.listTagsByChat().keys())
+        : null;
+      passesTagFilter = (chatInternalId) => {
+        if (allowedByTags && !allowedByTags.has(chatInternalId)) return false;
+        if (taggedChatIds && taggedChatIds.has(chatInternalId)) return false;
+        return true;
+      };
+    }
 
     // One grouped/windowed query per derived field, assembled in memory keyed
     // by (agent, source_id) — so listing N chats stays a constant query count
@@ -157,6 +190,7 @@ export function createChatReader({
     const chats: ChatResponse[] = [];
     for (const row of rows) {
       if (!visibility.isVisible(row.id)) continue;
+      if (passesTagFilter && !passesTagFilter(row.id)) continue;
       const isDeleted = visibility.isTrashed(row.id);
 
       const rowKey = key(row.agent, row.sourceId);

--- a/api/src/metadata/tags.test.ts
+++ b/api/src/metadata/tags.test.ts
@@ -137,4 +137,39 @@ describe("TagRepository", () => {
     expect(second.listTags()).toEqual([tag]);
     expect(second.listTagsForChat("chat-1")).toEqual([tag]);
   });
+
+  it("lists chats holding ALL of the given tags (AND intersection)", () => {
+    const repo = createTagRepository({ dataDir });
+    const bug = repo.createTag("bug", "red");
+    const idea = repo.createTag("idea", "violet");
+    repo.assignTag("chat-both", bug.id);
+    repo.assignTag("chat-both", idea.id);
+    repo.assignTag("chat-bug-only", bug.id);
+    repo.assignTag("chat-idea-only", idea.id);
+
+    const chatIds = repo.listChatIdsWithAllTags([bug.id, idea.id]);
+
+    expect(chatIds).toEqual(["chat-both"]);
+  });
+
+  it("lists every chat carrying a single given tag", () => {
+    const repo = createTagRepository({ dataDir });
+    const bug = repo.createTag("bug", "red");
+    repo.assignTag("chat-1", bug.id);
+    repo.assignTag("chat-2", bug.id);
+
+    const chatIds = repo.listChatIdsWithAllTags([bug.id]);
+
+    expect(chatIds.sort()).toEqual(["chat-1", "chat-2"]);
+  });
+
+  it("de-duplicates repeated tag ids so they don't inflate the AND count", () => {
+    const repo = createTagRepository({ dataDir });
+    const bug = repo.createTag("bug", "red");
+    repo.assignTag("chat-1", bug.id);
+
+    const chatIds = repo.listChatIdsWithAllTags([bug.id, bug.id]);
+
+    expect(chatIds).toEqual(["chat-1"]);
+  });
 });

--- a/api/src/metadata/tags.ts
+++ b/api/src/metadata/tags.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { openStore } from "../storage/openStore.js";
 import * as schema from "./schema.js";
 import { chatTags, tags } from "./schema.js";
@@ -30,6 +30,14 @@ export interface TagRepository {
   /** Tags grouped by Chat id in one query — never one query per Chat
    * (ADR-0016). Pass `chatIds` to scope to a subset; omit for every Chat. */
   listTagsByChat(chatIds?: string[]): Map<string, Tag[]>;
+  /**
+   * Chat ids holding ALL of the given Tags — the AND-intersection that backs
+   * the multi-Tag filter (#11 / ADR-0016). `tag_id IN (...) GROUP BY chat_id
+   * HAVING COUNT = N`; the `(chat_id, tag_id)` PK guarantees no duplicate rows
+   * so the count is exact. Duplicate ids in the input are de-duplicated first
+   * so a repeated id can't inflate N past what any Chat can match. An empty
+   * input returns no ids (an AND over nothing has no candidate set here). */
+  listChatIdsWithAllTags(tagIds: string[]): string[];
 }
 
 interface TagRepositoryOptions {
@@ -165,6 +173,19 @@ export function createTagRepository({
         byChat.set(row.chatId, list);
       }
       return byChat;
+    },
+
+    listChatIdsWithAllTags(tagIds) {
+      const distinct = [...new Set(tagIds)];
+      if (distinct.length === 0) return [];
+      return db
+        .select({ chatId: chatTags.chatId })
+        .from(chatTags)
+        .where(inArray(chatTags.tagId, distinct))
+        .groupBy(chatTags.chatId)
+        .having(sql`count(${chatTags.tagId}) = ${distinct.length}`)
+        .all()
+        .map((r) => r.chatId);
     },
   };
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,8 @@ import { useToast } from "@/shared/useToast";
 import { useChatOrder } from "@/chat/sort/useChatOrder";
 import { deriveProjects } from "@/chat/projects/deriveProjects";
 import { filterChatsByProjects } from "@/chat/projects/filterChatsByProjects";
+import { filterChatsByTags } from "@/tags/filterChatsByTags";
+import { toggleTagSelection } from "@/tags/toggleTagSelection";
 import { FilterPanel } from "@/chat/FilterPanel";
 import { ChatList } from "@/chat/ChatList";
 import { SortControl } from "@/chat/sort/SortControl";
@@ -75,24 +77,46 @@ function App() {
       return next;
     });
   }, []);
-  const clearProjects = useCallback(() => setSelectedProjects(new Set()), []);
+
+  // Tag filter: AND within (a chat must hold every selected Tag), combined with
+  // the Project filter (OR within) by intersecting the two filtered sets — AND
+  // across types. An empty selection means "all Tags". The `UNTAGGED` sentinel
+  // selects chats with zero Tags.
+  const [selectedTags, setSelectedTags] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
+  const toggleTag = useCallback((tagId: string) => {
+    setSelectedTags((prev) => toggleTagSelection(prev, tagId));
+  }, []);
+  const clearFilters = useCallback(() => {
+    setSelectedProjects(new Set());
+    setSelectedTags(new Set());
+  }, []);
 
   const projectFacets = useMemo(
     () => deriveProjects(order.orderedChats, { ensure: [...selectedProjects] }),
     [order.orderedChats, selectedProjects]
   );
 
-  const visibleChats = filterChatsByProjects(
-    order.orderedChats,
-    selectedProjects
+  const visibleChats = filterChatsByTags(
+    filterChatsByProjects(order.orderedChats, selectedProjects),
+    selectedTags
   );
   const selectedChat = chats.find((c) => c.id === selectedId) ?? null;
 
+  // Tag and Untagged counts reflect the active view (main vs Trash), deriving
+  // from the same per-view list the Project facet counts use — so the two
+  // sections agree. They state each group's size in this view, not the
+  // post-filter result, so selecting a Tag never moves the numbers.
+  const viewChats = order.orderedChats;
   const countForTag = useCallback(
     (tagId: string) =>
-      chats.filter((c) => !c.isDeleted && c.tags?.some((t) => t.id === tagId))
-        .length,
-    [chats]
+      viewChats.filter((c) => c.tags?.some((t) => t.id === tagId)).length,
+    [viewChats]
+  );
+  const untaggedCount = useMemo(
+    () => viewChats.filter((c) => (c.tags?.length ?? 0) === 0).length,
+    [viewChats]
   );
   // Create a Tag and immediately assign it to the chat the popover is on.
   const createTagForChat = useCallback(
@@ -205,9 +229,12 @@ function App() {
             projectFacets={projectFacets}
             selectedProjects={selectedProjects}
             onToggleProject={toggleProject}
-            onClearFilters={clearProjects}
+            onClearFilters={clearFilters}
             tags={tagCatalog}
             countForTag={countForTag}
+            untaggedCount={untaggedCount}
+            selectedTags={selectedTags}
+            onToggleTag={toggleTag}
             onRenameTag={(id, name) => void renameTag(id, name)}
             onRecolorTag={(id, color) => void recolorTag(id, color)}
             onDeleteTag={(id) => void deleteTag(id)}

--- a/web/src/chat/FilterPanel.tsx
+++ b/web/src/chat/FilterPanel.tsx
@@ -15,6 +15,9 @@ interface FilterPanelProps {
   onClearFilters: () => void;
   tags: Tag[];
   countForTag: (tagId: string) => number;
+  untaggedCount: number;
+  selectedTags: ReadonlySet<string>;
+  onToggleTag: (tagId: string) => void;
   onRenameTag: (id: string, name: string) => void;
   onRecolorTag: (id: string, color: ColorToken) => void;
   onDeleteTag: (id: string) => void;
@@ -29,6 +32,9 @@ export function FilterPanel({
   onClearFilters,
   tags,
   countForTag,
+  untaggedCount,
+  selectedTags,
+  onToggleTag,
   onRenameTag,
   onRecolorTag,
   onDeleteTag,
@@ -41,7 +47,7 @@ export function FilterPanel({
       </div>
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <FilterSummary
-          activeCount={selectedProjects.size}
+          activeCount={selectedProjects.size + selectedTags.size}
           onClear={onClearFilters}
         />
         <ProjectsSection
@@ -52,6 +58,9 @@ export function FilterPanel({
         <TagsSection
           tags={tags}
           countForTag={countForTag}
+          untaggedCount={untaggedCount}
+          selected={selectedTags}
+          onToggle={onToggleTag}
           onRename={onRenameTag}
           onRecolor={onRecolorTag}
           onDelete={onDeleteTag}
@@ -68,9 +77,13 @@ export function FilterPanel({
             <Trash2 size={14} aria-hidden="true" />
             Trash
           </span>
-          <span className="rounded-full bg-card px-2 text-xs font-semibold tabular-nums text-muted-foreground">
-            {deletedCount}
-          </span>
+          {/* A muted, pill-less count that only appears when Trash is non-empty:
+              a quiet "there's something in here" signal, not a headline metric. */}
+          {deletedCount > 0 && (
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {deletedCount}
+            </span>
+          )}
         </button>
       </div>
     </div>

--- a/web/src/tags/TagsSection.tsx
+++ b/web/src/tags/TagsSection.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import {
   ArrowLeft,
+  Check,
   ChevronDown,
   MoreHorizontal,
   Pencil,
@@ -12,11 +13,17 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { TAG_COLOR_HEX, type ColorToken } from "@/tags/palette";
 import { ColorSwatches } from "@/tags/ColorSwatches";
 import { sortTagsByName } from "@/tags/sortTags";
+import { UNTAGGED } from "@/tags/filterChatsByTags";
 
 interface TagsSectionProps {
   tags: Tag[];
   // How many chats carry a given tag — drives the row count and delete-confirm.
   countForTag: (tagId: string) => number;
+  // How many chats hold no tags at all — the count on the `Untagged` row.
+  untaggedCount: number;
+  // The active Tag filter: tag ids plus the `UNTAGGED` sentinel. AND within.
+  selected: ReadonlySet<string>;
+  onToggle: (tagId: string) => void;
   onRename: (id: string, name: string) => void;
   onRecolor: (id: string, color: ColorToken) => void;
   onDelete: (id: string) => void;
@@ -83,7 +90,7 @@ function ManageMenu({
     >
       <PopoverTrigger
         aria-label={`Manage tag ${tag.name}`}
-        className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-white/10 hover:text-foreground focus-visible:opacity-100 group-hover/tag:opacity-100 data-[popup-open]:opacity-100"
+        className="flex h-6 w-6 shrink-0 items-center justify-center rounded bg-card text-muted-foreground opacity-0 transition hover:bg-white/10 hover:text-foreground focus-visible:opacity-100 group-hover/tag:opacity-100 data-[popup-open]:opacity-100 pointer-events-none focus-visible:pointer-events-auto group-hover/tag:pointer-events-auto data-[popup-open]:pointer-events-auto"
       >
         <MoreHorizontal size={14} aria-hidden="true" />
       </PopoverTrigger>
@@ -91,7 +98,11 @@ function ManageMenu({
         data-testid="tag-manage-menu"
         align="end"
         sideOffset={4}
-        className="w-60 gap-1 p-1"
+        // Width is anchored by the Recolor view's 8-swatch palette (~218px on
+        // one row); w-56 keeps it single-row while staying as tight as the
+        // widest view allows. The three views share one width to avoid resizing
+        // jank when switching between them.
+        className="w-56 gap-1 p-1"
       >
         {view === "menu" && (
           <>
@@ -187,30 +198,39 @@ function ManageMenu({
 function TagRow({
   tag,
   count,
+  isSelected,
+  dimmed,
+  onToggle,
   onRename,
   onRecolor,
   onDelete,
 }: {
   tag: Tag;
   count: number;
+  isSelected: boolean;
+  // Dimmed while the `Untagged` group is active: a real Tag can't combine with
+  // it, so the row reads as "not applicable right now". Still clickable —
+  // clicking switches the filter to this Tag (and drops `Untagged`).
+  dimmed: boolean;
+  onToggle: () => void;
   onRename: (name: string) => void;
   onRecolor: (color: ColorToken) => void;
   onDelete: () => void;
 }) {
   const [editing, setEditing] = useState(false);
 
-  return (
-    <li
-      data-testid="tag-manage-row"
-      data-tag-id={tag.id}
-      className="group/tag relative flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground/90 hover:bg-card"
-    >
-      <span
-        aria-hidden="true"
-        className="h-2.5 w-2.5 shrink-0 rounded-full"
-        style={{ backgroundColor: TAG_COLOR_HEX[tag.color] }}
-      />
-      {editing ? (
+  if (editing) {
+    return (
+      <li
+        data-testid="tag-manage-row"
+        data-tag-id={tag.id}
+        className="group/tag relative flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground/90"
+      >
+        <span
+          aria-hidden="true"
+          className="h-2.5 w-2.5 shrink-0 rounded-full"
+          style={{ backgroundColor: TAG_COLOR_HEX[tag.color] }}
+        />
         <RenameRow
           tag={tag}
           onCommit={(name) => {
@@ -219,21 +239,105 @@ function TagRow({
           }}
           onCancel={() => setEditing(false)}
         />
-      ) : (
-        <>
-          <span className="min-w-0 flex-1 truncate">{tag.name}</span>
-          <ManageMenu
-            tag={tag}
-            count={count}
-            onRenameStart={() => setEditing(true)}
-            onRecolor={onRecolor}
-            onDelete={onDelete}
+      </li>
+    );
+  }
+
+  // The row body is a filter toggle; the ⋯ menu floats over the count slot so it
+  // never takes a layout column. That keeps the ✓ and count flush-right, exactly
+  // like a Project row — and matches #10's intent of count and menu sharing one
+  // spot, swapped on hover. We never nest interactive elements (the menu is a
+  // sibling of the toggle, not a child). Selecting AND-narrows the chat list.
+  return (
+    <li
+      data-testid="tag-manage-row"
+      data-tag-id={tag.id}
+      className={`group/tag relative flex items-center rounded-md pr-2 text-sm transition ${
+        isSelected ? "bg-primary/15" : "hover:bg-card"
+      } ${dimmed ? "opacity-40 hover:opacity-100" : ""}`}
+    >
+      <button
+        type="button"
+        data-testid={`tag-filter-${tag.id}`}
+        aria-pressed={isSelected}
+        onClick={onToggle}
+        className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left group-hover/tag:pr-8 ${
+          isSelected ? "text-foreground" : "text-foreground/90"
+        }`}
+      >
+        <span
+          aria-hidden="true"
+          className="h-2.5 w-2.5 shrink-0 rounded-full"
+          style={{ backgroundColor: TAG_COLOR_HEX[tag.color] }}
+        />
+        <span className="min-w-0 flex-1 truncate">{tag.name}</span>
+        {isSelected && (
+          <Check
+            size={14}
+            aria-hidden="true"
+            // Hover hands the trailing slot to the ⋯ control; the row's tint
+            // still carries the selected state, so the ✓ steps aside cleanly
+            // instead of colliding with the menu.
+            className="shrink-0 text-primary group-hover/tag:hidden"
           />
-          <span className="shrink-0 text-xs tabular-nums text-muted-foreground group-hover/tag:hidden">
-            {count}
-          </span>
-        </>
-      )}
+        )}
+      </button>
+      <span className="shrink-0 text-xs tabular-nums text-muted-foreground group-hover/tag:hidden">
+        {count}
+      </span>
+      <span className="absolute right-1.5 top-1/2 -translate-y-1/2">
+        <ManageMenu
+          tag={tag}
+          count={count}
+          onRenameStart={() => setEditing(true)}
+          onRecolor={onRecolor}
+          onDelete={onDelete}
+        />
+      </span>
+    </li>
+  );
+}
+
+// The `Untagged` group is pinned last: no color, no management menu, just a
+// filter toggle for "Chats with zero Tags".
+function UntaggedRow({
+  count,
+  isSelected,
+  onToggle,
+}: {
+  count: number;
+  isSelected: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <li
+      className={`relative flex items-center rounded-md pr-2 text-sm transition-colors ${
+        isSelected ? "bg-primary/15" : "hover:bg-card"
+      }`}
+    >
+      <button
+        type="button"
+        data-testid="tag-filter-untagged"
+        aria-pressed={isSelected}
+        onClick={onToggle}
+        className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-muted-foreground"
+      >
+        <span
+          aria-hidden="true"
+          className="h-2.5 w-2.5 shrink-0 rounded-full border border-muted-foreground/40"
+        />
+        <span className="min-w-0 flex-1 truncate italic">Untagged</span>
+        {isSelected && (
+          <Check
+            size={14}
+            aria-hidden="true"
+            className="shrink-0 text-primary"
+          />
+        )}
+      </button>
+      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+        {count}
+      </span>
     </li>
   );
 }
@@ -241,12 +345,18 @@ function TagRow({
 export function TagsSection({
   tags,
   countForTag,
+  untaggedCount,
+  selected,
+  onToggle,
   onRename,
   onRecolor,
   onDelete,
 }: TagsSectionProps) {
   const [collapsed, setCollapsed] = useState(false);
   const sorted = useMemo(() => sortTagsByName(tags), [tags]);
+  // While Untagged is the active filter, real Tags can't combine with it, so
+  // they read as dimmed-but-available (clicking one switches the filter).
+  const untaggedActive = selected.has(UNTAGGED);
 
   return (
     <div data-testid="tags-section" className="flex flex-col">
@@ -283,11 +393,19 @@ export function TagsSection({
                 key={tag.id}
                 tag={tag}
                 count={countForTag(tag.id)}
+                isSelected={selected.has(tag.id)}
+                dimmed={untaggedActive}
+                onToggle={() => onToggle(tag.id)}
                 onRename={(name) => onRename(tag.id, name)}
                 onRecolor={(color) => onRecolor(tag.id, color)}
                 onDelete={() => onDelete(tag.id)}
               />
             ))}
+            <UntaggedRow
+              count={untaggedCount}
+              isSelected={selected.has(UNTAGGED)}
+              onToggle={() => onToggle(UNTAGGED)}
+            />
           </ul>
         ))}
     </div>

--- a/web/src/tags/filterChatsByTags.test.ts
+++ b/web/src/tags/filterChatsByTags.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import type { Chat, Tag } from "@/types";
+import { filterChatsByTags, UNTAGGED } from "./filterChatsByTags";
+
+const bug: Tag = { id: "t-bug", name: "bug", color: "red" };
+const idea: Tag = { id: "t-idea", name: "idea", color: "violet" };
+
+function chat(id: string, tags: Tag[]): Chat {
+  return {
+    id,
+    sourceId: id,
+    agent: "claude-code",
+    title: "Untitled",
+    project: "",
+    projectPath: null,
+    sourceFilePath: null,
+    createdAt: 0,
+    updatedAt: 0,
+    tags,
+  };
+}
+
+describe("filterChatsByTags", () => {
+  const chats = [
+    chat("both", [bug, idea]),
+    chat("bug-only", [bug]),
+    chat("bare", []),
+  ];
+
+  it("returns every chat when the selection is empty", () => {
+    expect(filterChatsByTags(chats, new Set()).map((c) => c.id)).toEqual([
+      "both",
+      "bug-only",
+      "bare",
+    ]);
+  });
+
+  it("keeps only chats holding ALL selected tags (AND)", () => {
+    expect(
+      filterChatsByTags(chats, new Set([bug.id, idea.id])).map((c) => c.id)
+    ).toEqual(["both"]);
+  });
+
+  it("selects chats with zero tags via the UNTAGGED entry", () => {
+    expect(
+      filterChatsByTags(chats, new Set([UNTAGGED])).map((c) => c.id)
+    ).toEqual(["bare"]);
+  });
+
+  it("yields nothing when UNTAGGED is combined with a real tag", () => {
+    expect(filterChatsByTags(chats, new Set([UNTAGGED, bug.id]))).toEqual([]);
+  });
+
+  it("treats a missing tags array as untagged", () => {
+    const noTagsField = { ...chat("legacy", []) };
+    delete (noTagsField as { tags?: Tag[] }).tags;
+    expect(
+      filterChatsByTags([noTagsField], new Set([UNTAGGED])).map((c) => c.id)
+    ).toEqual(["legacy"]);
+  });
+});

--- a/web/src/tags/filterChatsByTags.ts
+++ b/web/src/tags/filterChatsByTags.ts
@@ -1,0 +1,29 @@
+import type { Chat } from "@/types";
+
+/**
+ * The sentinel selection entry for the `Untagged` group (Chats holding zero
+ * Tags). Matches the API/reader convention where an empty-string entry selects
+ * the no-Tag bucket, so the navigation panel and the wire form read the same.
+ */
+export const UNTAGGED = "";
+
+/**
+ * Keep chats holding ALL of the selected Tags (AND / intersection) — the
+ * asymmetric counterpart to the Project filter's OR. An empty selection means
+ * "all Tags" and returns every chat unchanged. The `UNTAGGED` entry selects
+ * Chats with no Tags; combined with a real Tag it naturally yields nothing.
+ * Pure: preserves input order, never mutates.
+ */
+export function filterChatsByTags(
+  chats: Chat[],
+  selected: ReadonlySet<string>
+): Chat[] {
+  if (selected.size === 0) return chats;
+  const realTagIds = [...selected].filter((id) => id !== UNTAGGED);
+  const wantUntagged = selected.has(UNTAGGED);
+  return chats.filter((chat) => {
+    const tagIds = new Set((chat.tags ?? []).map((t) => t.id));
+    if (wantUntagged && tagIds.size > 0) return false;
+    return realTagIds.every((id) => tagIds.has(id));
+  });
+}

--- a/web/src/tags/toggleTagSelection.test.ts
+++ b/web/src/tags/toggleTagSelection.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { UNTAGGED } from "./filterChatsByTags";
+import { toggleTagSelection } from "./toggleTagSelection";
+
+describe("toggleTagSelection", () => {
+  it("adds a real tag to an empty selection", () => {
+    expect([...toggleTagSelection(new Set(), "t-bug")]).toEqual(["t-bug"]);
+  });
+
+  it("removes a real tag that was already selected", () => {
+    expect([...toggleTagSelection(new Set(["t-bug"]), "t-bug")]).toEqual([]);
+  });
+
+  it("accumulates several real tags (AND within)", () => {
+    expect(
+      [...toggleTagSelection(new Set(["t-bug"]), "t-idea")].sort()
+    ).toEqual(["t-bug", "t-idea"]);
+  });
+
+  it("clears every real tag when Untagged is selected", () => {
+    expect([
+      ...toggleTagSelection(new Set(["t-bug", "t-idea"]), UNTAGGED),
+    ]).toEqual([UNTAGGED]);
+  });
+
+  it("clears Untagged when a real tag is selected", () => {
+    expect([...toggleTagSelection(new Set([UNTAGGED]), "t-bug")]).toEqual([
+      "t-bug",
+    ]);
+  });
+
+  it("deselecting Untagged returns to the unfiltered state", () => {
+    expect([...toggleTagSelection(new Set([UNTAGGED]), UNTAGGED)]).toEqual([]);
+  });
+
+  it("never mutates the input set", () => {
+    const input = new Set(["t-bug"]);
+    toggleTagSelection(input, UNTAGGED);
+    expect([...input]).toEqual(["t-bug"]);
+  });
+});

--- a/web/src/tags/toggleTagSelection.ts
+++ b/web/src/tags/toggleTagSelection.ts
@@ -1,0 +1,27 @@
+import { UNTAGGED } from "@/tags/filterChatsByTags";
+
+/**
+ * Toggle one entry in the Tag filter selection while keeping a single
+ * invariant: the `Untagged` group and real Tags are mutually exclusive. They
+ * can never co-occur because "holds no Tag" and "holds Tag X" can't both be
+ * true — a combined selection would always yield zero chats, a dead end. So:
+ *
+ * - Toggling `Untagged` on clears every real Tag (result is just `{UNTAGGED}`);
+ *   toggling it off clears the selection.
+ * - Toggling any real Tag clears `Untagged` first, then adds/removes that Tag.
+ *
+ * Pure: returns a new Set, never mutates the input.
+ */
+export function toggleTagSelection(
+  selected: ReadonlySet<string>,
+  tagId: string
+): Set<string> {
+  if (tagId === UNTAGGED) {
+    return selected.has(UNTAGGED) ? new Set() : new Set([UNTAGGED]);
+  }
+  const next = new Set(selected);
+  next.delete(UNTAGGED);
+  if (next.has(tagId)) next.delete(tagId);
+  else next.add(tagId);
+  return next;
+}


### PR DESCRIPTION
## Background (Why)

Issue #11: let users narrow the Chat list by Tag. Tags are an existing concept (#10) but could not be used as a filter. This adds multi-Tag filtering with AND (intersection) semantics, an `Untagged` group, and combination with the existing Project filter — so users can precisely find conversations matching several conditions.

## Approach (How)

- **Cross-store intersection in app code (ADR-0016).** Tag associations live in `metadata.db`, chat rows in `archive.db`. The Tag AND-intersection candidate set is computed in `metadata` (`TagRepository.listChatIdsWithAllTags`, `tag_id IN (...) GROUP BY chat_id HAVING COUNT = N`), then intersected in `ChatReader` with the Project-filtered Archive rows — no cross-database JOIN.
- **Untagged = empty-string entry**, mirroring the Project filter's `(No project)` convention, for both the reader option and the `?tags=` query param.
- **Web filtering stays client-side** on the full-loaded list (current scale posture), reusing the same pattern as the Project filter; chats already carry their `tags`.
- **Untagged ↔ real Tags are mutually exclusive** in the UI (a combined selection always yields zero), enforced by a single pure `toggleTagSelection` invariant.
- Search (`q`) combination is **out of scope** — FTS is not yet implemented.

## Changes (What)

- [x] API: `GET /api/chats?tags=id1,id2` (comma-separated; empty = Untagged), combining with `?project=` and `includeTrashed`
- [x] `ChatReader.listChats` gains a `tags` filter (AND within; Untagged group); `TagRepository.listChatIdsWithAllTags`
- [x] Web: Tags section rows become AND filter toggles (highlighted when active) while keeping the manage menu; `Untagged` pinned last
- [x] Mutual exclusion between Untagged and real Tags; dimming of real Tags while Untagged is active
- [x] Manage menu floats over the count slot so the check aligns with Project rows; manage popover width tightened to `w-56`
- [x] Tag/Untagged counts track the active view (main vs Trash), matching Project facets
- [x] Bottom Trash badge demoted to a quiet, pill-less count (hidden at 0)

### Test Verification

- [x] Unit: AND-intersection query (multi-tag, single tag, de-dupes repeated ids) — `api/src/metadata/tags.test.ts`
- [x] Unit: `ChatReader` tag filter — AND, Untagged, Untagged+real = empty, × Project, × Trash visibility — `api/src/chat-reader.test.ts`
- [x] Integration: `GET /api/chats?tags=` — AND, combined with Project, Untagged via empty, unfiltered — `api/src/app.test.ts`
- [x] Web: `filterChatsByTags` and `toggleTagSelection` (mutual exclusion, immutability) — `web/src/tags/*.test.ts`
- [x] Full suites green: 200 api, 149 web; typecheck clean

## Additional Notes

- `filterChatsByTags`'s "Untagged + real = empty" branch is now unreachable from the UI (mutual exclusion) but kept as defensive correctness.
- Pre-existing: in Trash view, Tag counts now follow the view; `countForTag` semantics otherwise unchanged.
- Follow-up (separate): Spotlight Tags picker (#26) should route through this same pipeline; server-side facet counts + keyset pagination (#130/#131).

## Related Links

- Closes #11