### PR TITLE
feat(api): synthetic large-scale chat dataset generator

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx scripts/dev.ts",
+    "seed": "tsx scripts/seed.ts",
     "build": "tsup",
     "test": "vitest run",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",

--- a/api/scripts/seed.ts
+++ b/api/scripts/seed.ts
@@ -1,0 +1,68 @@
+import os from "node:os";
+import { resolveDataDir } from "../src/config/data-dir.js";
+import { assertSeedDataDirSafe } from "../src/seed/guard.js";
+import { createArchiveRepository } from "../src/archive/repository.js";
+import { createTagRepository } from "../src/metadata/tags.js";
+import { seedArchive } from "../src/seed/seed.js";
+import { DEFAULT_SEED_CONFIG, type SeedConfig } from "../src/seed/generator.js";
+
+// Developer-only seed script. Fills a throwaway dev Archive with N synthetic
+// Chats (default ~50,000) so the list-pipeline refactor can be validated at the
+// tens-of-thousands scale this milestone targets. Targets the directory
+// resolved from CHAT_LOGBOOK_DATA_DIR and refuses to touch the real archive.
+//
+//   CHAT_LOGBOOK_DATA_DIR=~/.chat-logbook-dev pnpm --filter @chat-logbook/api seed
+//   ... seed --count 50000 --seed 1 --projects 50 --tag-ratio 0.3 --tag-pool 10
+
+function parseArgs(argv: string[]): Partial<SeedConfig> {
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) continue;
+    const eq = arg.indexOf("=");
+    if (eq !== -1) {
+      flags[arg.slice(2, eq)] = arg.slice(eq + 1);
+    } else {
+      flags[arg.slice(2)] = argv[++i] ?? "";
+    }
+  }
+  const num = (key: string): number | undefined =>
+    flags[key] === undefined ? undefined : Number(flags[key]);
+
+  const config: Partial<SeedConfig> = {};
+  const count = num("count");
+  const seed = num("seed");
+  const projects = num("projects");
+  const tagRatio = num("tag-ratio");
+  const tagPool = num("tag-pool");
+  if (count !== undefined) config.count = count;
+  if (seed !== undefined) config.seed = seed;
+  if (projects !== undefined) config.projects = projects;
+  if (tagRatio !== undefined) config.tagRatio = tagRatio;
+  if (tagPool !== undefined) config.tagPool = tagPool;
+  return config;
+}
+
+const config = parseArgs(process.argv.slice(2));
+const dataDir = resolveDataDir(process.env, os.homedir());
+assertSeedDataDirSafe(dataDir, os.homedir());
+
+const resolved = { ...DEFAULT_SEED_CONFIG, ...config };
+console.log(
+  `Seeding ${resolved.count} chats (seed=${resolved.seed}, ` +
+    `projects=${resolved.projects}, tagRatio=${resolved.tagRatio}, ` +
+    `tagPool=${resolved.tagPool}) into ${dataDir} ...`
+);
+
+const start = Date.now();
+const archive = createArchiveRepository({ dataDir });
+const tags = createTagRepository({ dataDir });
+const summary = seedArchive({ archive, tags }, config);
+archive.close();
+
+const seconds = ((Date.now() - start) / 1000).toFixed(1);
+console.log(
+  `Done in ${seconds}s: ${summary.chats} chats, ` +
+    `${summary.namedProjects} named projects, ${summary.tags} tags, ` +
+    `${summary.taggedChats} tagged chats.`
+);

--- a/api/src/seed/generator.test.ts
+++ b/api/src/seed/generator.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { generateDataset } from "./generator.js";
+
+describe("generateDataset", () => {
+  it("generates exactly the requested number of chats", () => {
+    expect(generateDataset({ count: 5 })).toHaveLength(5);
+    expect(generateDataset({ count: 0 })).toHaveLength(0);
+  });
+
+  it("is reproducible: same seed yields identical data, different seed differs", () => {
+    const a = generateDataset({ count: 30, seed: 7 });
+    const b = generateDataset({ count: 30, seed: 7 });
+    const c = generateDataset({ count: 30, seed: 8 });
+    expect(a).toEqual(b);
+    expect(a).not.toEqual(c);
+  });
+
+  it("spreads chats across many distinct projects including the (No project) group", () => {
+    const chats = generateDataset({ count: 500, projects: 10 });
+    const named = new Set(
+      chats.map((c) => c.project).filter((p): p is string => p !== null)
+    );
+    expect(named.size).toBeGreaterThan(1);
+    expect(named.size).toBeLessThanOrEqual(10);
+    expect(chats.some((c) => c.project === null)).toBe(true);
+  });
+
+  it("gives each chat timestamped messages that spread across chats, updatedAt >= createdAt", () => {
+    const chats = generateDataset({ count: 200 });
+    expect(chats.every((c) => c.messages.length >= 1)).toBe(true);
+
+    const createdAts = new Set<number>();
+    for (const c of chats) {
+      const times = c.messages.map((m) => Date.parse(m.ts));
+      expect(times.every((t) => Number.isFinite(t))).toBe(true);
+      const min = Math.min(...times);
+      const max = Math.max(...times);
+      expect(max).toBeGreaterThanOrEqual(min);
+      createdAts.add(min);
+    }
+    // A realistic spread: createdAt is not the same instant for every chat.
+    expect(createdAts.size).toBeGreaterThan(10);
+  });
+
+  it("assigns tags to about the configured ratio of chats, none when ratio is 0", () => {
+    const chats = generateDataset({ count: 1000, tagRatio: 0.3, tagPool: 8 });
+    const taggedCount = chats.filter((c) => c.tagNames.length > 0).length;
+    expect(taggedCount).toBeGreaterThan(150);
+    expect(taggedCount).toBeLessThan(450);
+
+    const names = new Set(chats.flatMap((c) => c.tagNames));
+    expect(names.size).toBeGreaterThan(1);
+    expect(names.size).toBeLessThanOrEqual(8);
+
+    const none = generateDataset({ count: 200, tagRatio: 0 });
+    expect(none.every((c) => c.tagNames.length === 0)).toBe(true);
+  });
+});

--- a/api/src/seed/generator.ts
+++ b/api/src/seed/generator.ts
@@ -1,0 +1,111 @@
+/**
+ * Deterministic synthetic-dataset generator. Given a config it produces the
+ * same Chats, Projects, and Tag assignments every time, so a seeded Archive is
+ * reproducible. Pure: no IO, no clock, no randomness beyond the seeded PRNG —
+ * the writer ({@link ./seed.js}) turns this output into real repository rows.
+ */
+
+export interface SyntheticMessage {
+  messageId: string;
+  role: "user" | "assistant";
+  /** ISO-8601 timestamp; drives the Chat's derived createdAt/updatedAt. */
+  ts: string;
+  text: string;
+}
+
+export interface SyntheticChat {
+  sourceId: string;
+  /** `null` places the Chat in the `(No project)` group. */
+  project: string | null;
+  messages: SyntheticMessage[];
+  /** Names of the Tags assigned to this Chat (a subset of the Tag pool). */
+  tagNames: string[];
+}
+
+export interface SeedConfig {
+  count: number;
+  seed: number;
+  /** Number of distinct named Projects to spread Chats across. */
+  projects: number;
+  /** Portion of Chats (0..1) that receive at least one Tag. */
+  tagRatio: number;
+  /** Number of distinct Tags in the pool. */
+  tagPool: number;
+}
+
+export const DEFAULT_SEED_CONFIG: SeedConfig = {
+  count: 50_000,
+  seed: 1,
+  projects: 50,
+  tagRatio: 0.3,
+  tagPool: 10,
+};
+
+/** Deterministic 32-bit PRNG (mulberry32): same seed yields the same stream. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function generateDataset(
+  config: Partial<SeedConfig> = {}
+): SyntheticChat[] {
+  const cfg: SeedConfig = { ...DEFAULT_SEED_CONFIG, ...config };
+  const rng = mulberry32(cfg.seed);
+
+  // ~15% of Chats land in the `(No project)` group; the rest spread evenly
+  // across the named Project pool.
+  const NO_PROJECT_RATE = 0.15;
+  // Timestamps spread back from a fixed reference instant (no wall clock, so the
+  // dataset stays reproducible) over a two-year window.
+  const REFERENCE_END_MS = Date.parse("2026-01-01T00:00:00.000Z");
+  const WINDOW_MS = 2 * 365 * 24 * 60 * 60 * 1000;
+  const MAX_GAP_MS = 30 * 60 * 1000; // up to 30 min between messages
+
+  const chats: SyntheticChat[] = [];
+  for (let i = 0; i < cfg.count; i++) {
+    const project =
+      cfg.projects > 0 && rng() >= NO_PROJECT_RATE
+        ? `Project ${Math.floor(rng() * cfg.projects)}`
+        : null;
+
+    const sourceId = `seed-${cfg.seed}-${i}`;
+    const startMs = REFERENCE_END_MS - Math.floor(rng() * WINDOW_MS);
+    const messageCount = 1 + Math.floor(rng() * 8); // 1..8 messages
+    const messages: SyntheticMessage[] = [];
+    let cursor = startMs;
+    for (let m = 0; m < messageCount; m++) {
+      if (m > 0) cursor += Math.floor(rng() * MAX_GAP_MS);
+      messages.push({
+        messageId: `${sourceId}-m${m}`,
+        role: m % 2 === 0 ? "user" : "assistant",
+        ts: new Date(cursor).toISOString(),
+        text:
+          m % 2 === 0
+            ? `Synthetic question ${m} for ${sourceId}`
+            : `Synthetic answer ${m} for ${sourceId}`,
+      });
+    }
+
+    // A portion of Chats (tagRatio) get 1..3 distinct Tags from the pool, so
+    // tag filtering and counts can be exercised at scale.
+    const tagNames: string[] = [];
+    if (cfg.tagPool > 0 && rng() < cfg.tagRatio) {
+      const wanted = 1 + Math.floor(rng() * Math.min(3, cfg.tagPool));
+      const picked = new Set<number>();
+      while (picked.size < wanted) {
+        picked.add(Math.floor(rng() * cfg.tagPool));
+      }
+      for (const k of picked) tagNames.push(`Tag ${k}`);
+    }
+
+    chats.push({ sourceId, project, messages, tagNames });
+  }
+  return chats;
+}

--- a/api/src/seed/guard.test.ts
+++ b/api/src/seed/guard.test.ts
@@ -1,0 +1,21 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { assertSeedDataDirSafe } from "./guard.js";
+
+describe("assertSeedDataDirSafe", () => {
+  it("refuses to seed the real ~/.chat-logbook archive", () => {
+    const real = path.join("/home/eva", ".chat-logbook");
+    expect(() => assertSeedDataDirSafe(real, "/home/eva")).toThrow(
+      /chat-logbook/
+    );
+  });
+
+  it("allows an isolated dev or throwaway directory", () => {
+    expect(() =>
+      assertSeedDataDirSafe("/home/eva/.chat-logbook-dev", "/home/eva")
+    ).not.toThrow();
+    expect(() =>
+      assertSeedDataDirSafe("/tmp/seed-bench", "/home/eva")
+    ).not.toThrow();
+  });
+});

--- a/api/src/seed/guard.ts
+++ b/api/src/seed/guard.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+
+/**
+ * Refuses to seed the real, backup-worthy archive. The synthetic dataset
+ * generator only ever targets a throwaway dev directory; writing tens of
+ * thousands of fake Chats into `~/.chat-logbook` would corrupt the developer's
+ * real history. Compares resolved paths so a relative or `..`-laden override
+ * can't sneak past the check.
+ */
+export function assertSeedDataDirSafe(dataDir: string, homeDir: string): void {
+  const target = path.resolve(dataDir);
+  const real = path.join(path.resolve(homeDir), ".chat-logbook");
+  if (target === real) {
+    throw new Error(
+      `Refusing to seed the real archive at ${real}. Point ` +
+        `CHAT_LOGBOOK_DATA_DIR at a throwaway directory (e.g. ~/.chat-logbook-dev).`
+    );
+  }
+}

--- a/api/src/seed/seed.test.ts
+++ b/api/src/seed/seed.test.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createArchiveRepository } from "../archive/repository.js";
+import { createMetadataRepository } from "../metadata/repository.js";
+import { createTagRepository } from "../metadata/tags.js";
+import { createChatReader } from "../chat-reader.js";
+import { seedArchive } from "./seed.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-seed-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+function openReader() {
+  const archive = createArchiveRepository({ dataDir });
+  const metadata = createMetadataRepository({ dataDir });
+  const tags = createTagRepository({ dataDir });
+  return {
+    archive,
+    metadata,
+    tags,
+    reader: createChatReader({ archive, metadata, tags }),
+  };
+}
+
+describe("seedArchive", () => {
+  it("seeds chats that the read path lists end-to-end", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+    const summary = seedArchive({ archive, tags }, { count: 25, seed: 3 });
+    archive.close();
+
+    expect(summary.chats).toBe(25);
+
+    const { reader } = openReader();
+    const listed = reader.listChats({ includeTrashed: false });
+    expect(listed).toHaveLength(25);
+  });
+
+  it("seeds chats spanning many projects including the (No project) group", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+    const summary = seedArchive(
+      { archive, tags },
+      { count: 300, seed: 5, projects: 8 }
+    );
+    archive.close();
+    expect(summary.namedProjects).toBeGreaterThan(1);
+
+    const { reader } = openReader();
+    const noProject = reader.listChats({
+      includeTrashed: false,
+      projects: [""],
+    });
+    expect(noProject.length).toBeGreaterThan(0);
+    expect(noProject.every((c) => c.project === "")).toBe(true);
+
+    const all = reader.listChats({ includeTrashed: false });
+    expect(all.some((c) => c.project !== "")).toBe(true);
+  });
+
+  it("assigns tags reproducibly and supports tag filtering", () => {
+    function seedInto(dir: string) {
+      const archive = createArchiveRepository({ dataDir: dir });
+      const tags = createTagRepository({ dataDir: dir });
+      seedArchive(
+        { archive, tags },
+        { count: 400, seed: 9, tagRatio: 0.5, tagPool: 6 }
+      );
+      archive.close();
+
+      const archive2 = createArchiveRepository({ dataDir: dir });
+      const metadata2 = createMetadataRepository({ dataDir: dir });
+      const tags2 = createTagRepository({ dataDir: dir });
+      const reader = createChatReader({
+        archive: archive2,
+        metadata: metadata2,
+        tags: tags2,
+      });
+      return { reader, tags: tags2 };
+    }
+
+    const first = seedInto(dataDir);
+
+    // A tag filter returns a non-empty subset, every member holding that tag.
+    const someTag = first.tags.listTags()[0];
+    const filtered = first.reader.listChats({
+      includeTrashed: false,
+      tags: [someTag.id],
+    });
+    expect(filtered.length).toBeGreaterThan(0);
+    expect(filtered.every((c) => c.tags.some((t) => t.id === someTag.id))).toBe(
+      true
+    );
+
+    // Same seed in a fresh directory yields the same sourceId -> tag-names map.
+    const tagFingerprint = (r: ReturnType<typeof seedInto>["reader"]) =>
+      new Map(
+        r.listChats({ includeTrashed: false }).map((c) => [
+          c.sourceId,
+          c.tags
+            .map((t) => t.name)
+            .sort()
+            .join(","),
+        ])
+      );
+
+    const dir2 = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-seed2-"));
+    try {
+      const second = seedInto(dir2);
+      expect(tagFingerprint(second.reader)).toEqual(
+        tagFingerprint(first.reader)
+      );
+    } finally {
+      fs.rmSync(dir2, { recursive: true, force: true });
+    }
+  });
+});

--- a/api/src/seed/seed.test.ts
+++ b/api/src/seed/seed.test.ts
@@ -49,7 +49,7 @@ describe("seedArchive", () => {
     const tags = createTagRepository({ dataDir });
     const summary = seedArchive(
       { archive, tags },
-      { count: 300, seed: 5, projects: 8 }
+      { count: 80, seed: 5, projects: 6 }
     );
     archive.close();
     expect(summary.namedProjects).toBeGreaterThan(1);
@@ -64,7 +64,9 @@ describe("seedArchive", () => {
 
     const all = reader.listChats({ includeTrashed: false });
     expect(all.some((c) => c.project !== "")).toBe(true);
-  });
+    // Generous margin: these seed through the repos one autocommit at a time,
+    // which is slower on shared CI runners than locally.
+  }, 30000);
 
   it("assigns tags reproducibly and supports tag filtering", () => {
     function seedInto(dir: string) {
@@ -72,7 +74,7 @@ describe("seedArchive", () => {
       const tags = createTagRepository({ dataDir: dir });
       seedArchive(
         { archive, tags },
-        { count: 400, seed: 9, tagRatio: 0.5, tagPool: 6 }
+        { count: 100, seed: 9, tagRatio: 0.5, tagPool: 6 }
       );
       archive.close();
 
@@ -121,5 +123,5 @@ describe("seedArchive", () => {
     } finally {
       fs.rmSync(dir2, { recursive: true, force: true });
     }
-  });
+  }, 30000);
 });

--- a/api/src/seed/seed.ts
+++ b/api/src/seed/seed.ts
@@ -1,0 +1,115 @@
+import type { ArchiveRepository } from "../archive/repository.js";
+import type { TagRepository } from "../metadata/tags.js";
+import { TAG_COLORS } from "../metadata/tag-colors.js";
+import {
+  generateDataset,
+  type SeedConfig,
+  type SyntheticChat,
+} from "./generator.js";
+
+/** Every synthetic Chat is attributed to this Agent. */
+const SEED_AGENT = "claude-code";
+
+export interface SeedSummary {
+  chats: number;
+  /** Distinct named Projects (excludes the `(No project)` group). */
+  namedProjects: number;
+  tags: number;
+  taggedChats: number;
+}
+
+export interface SeedDeps {
+  archive: ArchiveRepository;
+  tags: TagRepository;
+}
+
+/**
+ * Writes a deterministic synthetic dataset into the Archive and Metadata stores
+ * through the real repositories — never hand-rolled SQL — so the seeded data
+ * always matches the live schema and the same write path real ingestion uses.
+ * Returns a summary for the CLI to print.
+ */
+export function seedArchive(
+  { archive, tags }: SeedDeps,
+  config: Partial<SeedConfig> = {}
+): SeedSummary {
+  const dataset = generateDataset(config);
+
+  // Create the Tag pool once, mapping each name to its id. Colors cycle through
+  // the closed token vocabulary deterministically so a re-seed is identical.
+  const tagIdByName = createTagPool(tags, dataset);
+
+  const namedProjects = new Set<string>();
+  let taggedChats = 0;
+
+  for (const chat of dataset) {
+    const firstSeenAt = new Date(chat.messages[0]?.ts ?? 0);
+    const internalId = archive.ensureChat(
+      SEED_AGENT,
+      chat.sourceId,
+      firstSeenAt,
+      chat.project ?? undefined
+    );
+    if (chat.project !== null) namedProjects.add(chat.project);
+
+    writeMessages(archive, chat);
+
+    if (chat.tagNames.length > 0) taggedChats++;
+    for (const name of chat.tagNames) {
+      const tagId = tagIdByName.get(name);
+      if (tagId) tags.assignTag(internalId, tagId);
+    }
+  }
+
+  return {
+    chats: dataset.length,
+    namedProjects: namedProjects.size,
+    tags: tagIdByName.size,
+    taggedChats,
+  };
+}
+
+function createTagPool(
+  tags: TagRepository,
+  dataset: SyntheticChat[]
+): Map<string, string> {
+  const names = [...new Set(dataset.flatMap((c) => c.tagNames))].sort();
+  const tagIdByName = new Map<string, string>();
+  names.forEach((name, i) => {
+    const color = TAG_COLORS[i % TAG_COLORS.length];
+    tagIdByName.set(name, tags.createTag(name, color).id);
+  });
+  return tagIdByName;
+}
+
+function writeMessages(archive: ArchiveRepository, chat: SyntheticChat): void {
+  const sourcePath = `/seed/${chat.sourceId}.jsonl`;
+  chat.messages.forEach((message, i) => {
+    const payload = {
+      messageId: message.messageId,
+      role: message.role,
+      ts: message.ts,
+      text: message.text,
+    };
+    const raw = archive.insertRawMessage({
+      agent: SEED_AGENT,
+      sourceId: chat.sourceId,
+      sourcePath,
+      sourceLocator: `line:${i}`,
+      payload,
+      ingestedAt: new Date(message.ts),
+    });
+    archive.upsertNormalizedMessage({
+      agent: SEED_AGENT,
+      sourceId: chat.sourceId,
+      message: {
+        messageId: message.messageId,
+        role: message.role,
+        ts: message.ts,
+        text: message.text,
+        blocks: [{ type: "text", text: message.text }],
+      },
+      rawId: raw.id,
+    });
+  });
+}


### PR DESCRIPTION
## Background (Why)

The #126–#132 milestone refactors the Chat list pipeline (virtualization, server-side sort + keyset pagination, server-side filtering and facet counts, live push) to hold up at the "tens of thousands of Chats" scale. None of those slices can be validated honestly without a large, realistic Archive to run against. This PR builds that test harness: a developer-only seed that fills a throwaway dev Archive with N synthetic Chats (default ~50,000).

## Approach (How)

The seed writes through the **real repositories**, never hand-rolled SQL, so synthetic data always matches the live schema, migrations, and the same write path real ingestion uses. It is split into three small, separately testable pieces plus thin CLI wiring:

- **`generator.ts`** — a pure, deterministic dataset producer driven by a seeded PRNG (mulberry32). No IO, no wall clock. The same `seed` yields the same Chats, Projects, and Tag assignments, so a seeded Archive is reproducible. Timestamps spread back from a fixed reference instant over a two-year window (a clock would break reproducibility).
- **`seed.ts`** — `seedArchive({ archive, tags }, config)` turns the generated dataset into rows via `ensureChat` / `insertRawMessage` / `upsertNormalizedMessage` / `assignTag`, and returns a summary.
- **`guard.ts`** — `assertSeedDataDirSafe` refuses to write to the real `~/.chat-logbook`. The target directory is resolved from `CHAT_LOGBOOK_DATA_DIR` (#136); an unset variable resolves to the real archive and is therefore rejected, forcing an explicit throwaway target.
- **`scripts/seed.ts`** — thin CLI wiring (mirrors `scripts/dev.ts`), exposed as `pnpm seed`. Not covered by tests; all logic lives in the modules above.

Built with TDD, one behavior per vertical slice (guard → generator → writer), each verified through the public interface.

## Changes (What)

- [x] `pnpm --filter @chat-logbook/api seed` seeds N synthetic Chats, N configurable, default ~50,000
- [x] Chats span many distinct Projects including the `(No project)` group, with a realistic spread of timestamps
- [x] A configurable portion of Chats receive Tags (`--tag-ratio`, `--tag-pool`) so tag filtering and counts can be exercised at scale
- [x] Targets the directory from `CHAT_LOGBOOK_DATA_DIR`; a guard refuses to write to the real `~/.chat-logbook`
- [x] Reproducible: the same `--seed` produces the same Chats, Projects, and Tag assignments
- [x] The read path lists the seeded Chats end-to-end (verified through `ChatReader`)

### Test Verification

10 behaviors, each its own RED→GREEN slice. Full suite green (api 217, web 149); `tsc --noEmit` clean.

- [x] guard: refuses the real `~/.chat-logbook`
- [x] guard: allows an isolated dev / throwaway directory
- [x] generator: produces exactly N chats
- [x] generator: reproducible — same seed identical, different seed differs
- [x] generator: spans many distinct Projects including the `(No project)` group
- [x] generator: timestamped messages spread across chats, updatedAt >= createdAt
- [x] generator: assigns Tags to ~`tagRatio` of chats, none when ratio is 0
- [x] writer: seeded chats are listed end-to-end by `ChatReader.listChats`
- [x] writer: seeded chats span Projects incl. `(No project)` via `listChats({ projects })`
- [x] writer: Tag assignment is reproducible and tag filtering returns the correct subset

## Additional Notes

### How to run it

The script lives in the `api` package and **deliberately refuses to seed without an explicit throwaway target** — there is no way to accidentally fill your real archive.

1. Seed a dedicated throwaway directory (kept separate from the `~/.chat-logbook-dev` that `pnpm dev` uses, so synthetic data never mixes with your real dev conversations):

   ```bash
   CHAT_LOGBOOK_DATA_DIR=~/.chat-logbook-seed pnpm --filter @chat-logbook/api seed --count 50000
   ```

   Flags (all optional): `--count` (default 50000), `--seed` (default 1), `--projects` (default 50), `--tag-ratio` (default 0.3), `--tag-pool` (default 10). Start small with `--count 500` to try it.

   Expected output:

   ```
   Seeding 50000 chats (seed=1, projects=50, tagRatio=0.3, tagPool=10) into /Users/<you>/.chat-logbook-seed ...
   Done in ~150s: 50000 chats, ~50 named projects, 10 tags, ~15000 tagged chats.
   ```

2. Run the app against the seeded Archive to see the synthetic Chats end-to-end:

   ```bash
   CHAT_LOGBOOK_DATA_DIR=~/.chat-logbook-seed pnpm dev
   ```

3. Clean up when done — it is a throwaway directory:

   ```bash
   rm -rf ~/.chat-logbook-seed
   ```

If you run `pnpm seed` **without** `CHAT_LOGBOOK_DATA_DIR`, the variable resolves to the real `~/.chat-logbook` and the guard stops it:

```
Error: Refusing to seed the real archive at /Users/<you>/.chat-logbook.
Point CHAT_LOGBOOK_DATA_DIR at a throwaway directory (e.g. ~/.chat-logbook-dev).
```

### Known limitation: speed at 50k

Writes go through the repositories one statement at a time, and SQLite auto-commits (and fsyncs) each one, so ~50,000 Chats take roughly 2–3 minutes. Fine for a tool you run once before testing. Wrapping the whole seed in a single transaction would cut that to seconds, but that needs the Archive repository to expose a transaction entry point — a change to a contract shared with real ingestion, intentionally left out of this dev-only PR. Worth doing later if re-seeding becomes a frequent loop.

## Related Links

- Closes #126
- Builds on #136 (`CHAT_LOGBOOK_DATA_DIR` data-directory resolution)
- Validates the #127–#132 list-pipeline refactor at scale