### PR TITLE
chore(api): decide cross-store pagination strategy (ATTACH)

### DIFF
--- a/api/scripts/bench-cross-store-pagination.ts
+++ b/api/scripts/bench-cross-store-pagination.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { createArchiveRepository } from "../src/archive/repository.js";
+import { createTagRepository } from "../src/metadata/tags.js";
+import { seedArchive } from "../src/seed/seed.js";
+import {
+  createAppLevelStrategy,
+  createAttachStrategy,
+  type PageCursor,
+  type PageQuery,
+  type PaginatedQueryStrategy,
+} from "../src/spike/cross-store-pagination.js";
+
+// Spike benchmark (issue #128). Seeds a large throwaway Archive once, then times
+// the two cross-store paginated-query strategies — ATTACH vs app-level
+// intersection — across representative query shapes and page depths. Run with:
+//
+//   pnpm --filter @chat-logbook/api exec tsx scripts/bench-cross-store-pagination.ts
+//
+// Reuses a cached seed dir so re-runs are fast; pass --reseed to rebuild it.
+
+const COUNT = Number(process.env.BENCH_COUNT ?? 50_000);
+const ITERATIONS = Number(process.env.BENCH_ITER ?? 50);
+const PAGE = 50;
+const SEED_DIR = path.join(os.tmpdir(), `chat-logbook-bench-${COUNT}`);
+
+function ensureSeed(): void {
+  const reseed = process.argv.includes("--reseed");
+  const archiveFile = path.join(SEED_DIR, "archive.db");
+  if (reseed) fs.rmSync(SEED_DIR, { recursive: true, force: true });
+  if (fs.existsSync(archiveFile)) {
+    console.log(`Reusing seeded dir ${SEED_DIR} (${COUNT} chats).`);
+    return;
+  }
+  console.log(`Seeding ${COUNT} chats into ${SEED_DIR} ...`);
+  const t0 = Date.now();
+  const archive = createArchiveRepository({ dataDir: SEED_DIR });
+  const tags = createTagRepository({ dataDir: SEED_DIR });
+  const summary = seedArchive(
+    { archive, tags },
+    { count: COUNT, seed: 1, projects: 50, tagRatio: 0.3, tagPool: 10 }
+  );
+  archive.close();
+  console.log(
+    `Seeded in ${((Date.now() - t0) / 1000).toFixed(1)}s: ` +
+      `${summary.chats} chats, ${summary.tags} tags, ` +
+      `${summary.taggedChats} tagged.`
+  );
+}
+
+/** The (first_seen_at, id) cursor sitting `offset` rows into the full order. */
+function cursorAtOffset(offset: number): PageCursor {
+  const db = new Database(path.join(SEED_DIR, "archive.db"), {
+    readonly: true,
+  });
+  const row = db
+    .prepare(
+      `SELECT id, first_seen_at AS sortKey FROM chats
+       ORDER BY first_seen_at DESC, id DESC LIMIT 1 OFFSET ?`
+    )
+    .get(offset) as { id: string; sortKey: number };
+  db.close();
+  return { sortKey: row.sortKey, id: row.id };
+}
+
+function median(ns: number[]): number {
+  const s = [...ns].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+function timeMs(strategy: PaginatedQueryStrategy, query: PageQuery): number {
+  const samples: number[] = [];
+  for (let i = 0; i < ITERATIONS; i++) {
+    const t0 = performance.now();
+    strategy.listChatsPage(query);
+    samples.push(performance.now() - t0);
+  }
+  return median(samples);
+}
+
+function tagIds(): string[] {
+  const tags = createTagRepository({ dataDir: SEED_DIR });
+  return tags.listTags().map((t) => t.id);
+}
+
+function main(): void {
+  ensureSeed();
+  const tags = tagIds();
+  const deepCursor = cursorAtOffset(COUNT - PAGE - 1);
+
+  const cases: { name: string; query: PageQuery }[] = [
+    { name: "unfiltered, first page", query: { limit: PAGE } },
+    {
+      name: "unfiltered, deep page",
+      query: { limit: PAGE, cursor: deepCursor },
+    },
+    {
+      name: "one Project (~1.7k rows)",
+      query: { limit: PAGE, projects: ["Project 0"] },
+    },
+    {
+      name: "Tag AND (two tags)",
+      query: { limit: PAGE, tags: [tags[0], tags[1]] },
+    },
+    {
+      name: "Untagged group",
+      query: { limit: PAGE, tags: [""] },
+    },
+    {
+      name: "Project + Tag combined",
+      query: { limit: PAGE, projects: ["Project 0"], tags: [tags[0]] },
+    },
+  ];
+
+  const attach = createAttachStrategy({ dataDir: SEED_DIR });
+  const appLevel = createAppLevelStrategy({ dataDir: SEED_DIR });
+
+  console.log(
+    `\nMedian of ${ITERATIONS} runs, page size ${PAGE}, ${COUNT} chats:\n`
+  );
+  console.log(
+    "query".padEnd(28) +
+      "ATTACH (ms)".padStart(14) +
+      "app-level (ms)".padStart(16) +
+      "  ratio"
+  );
+  console.log("-".repeat(64));
+  for (const c of cases) {
+    const a = timeMs(attach, c.query);
+    const b = timeMs(appLevel, c.query);
+    const ratio = (b / a).toFixed(1);
+    console.log(
+      c.name.padEnd(28) +
+        a.toFixed(2).padStart(14) +
+        b.toFixed(2).padStart(16) +
+        `  ${ratio}x`
+    );
+  }
+
+  attach.close();
+  appLevel.close();
+}
+
+main();

--- a/api/src/spike/cross-store-pagination.test.ts
+++ b/api/src/spike/cross-store-pagination.test.ts
@@ -1,0 +1,276 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createArchiveRepository } from "../archive/repository.js";
+import { createTagRepository } from "../metadata/tags.js";
+import { TAG_COLORS } from "../metadata/tag-colors.js";
+import { seedArchive } from "../seed/seed.js";
+import type { PageQuery } from "./cross-store-pagination.js";
+import {
+  createAppLevelStrategy,
+  createAttachStrategy,
+  type PageCursor,
+  type PaginatedQueryStrategy,
+} from "./cross-store-pagination.js";
+
+const AGENT = "claude-code";
+
+let dataDir: string;
+const open: PaginatedQueryStrategy[] = [];
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-spike-"));
+});
+
+afterEach(() => {
+  for (const s of open.splice(0)) s.close();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+/** Seed a chat through the real write seam; returns the internal id. */
+function seedChat(opts: {
+  sourceId: string;
+  firstSeenAtMs: number;
+  project?: string | null;
+}): string {
+  const archive = createArchiveRepository({ dataDir });
+  const id = archive.ensureChat(
+    AGENT,
+    opts.sourceId,
+    new Date(opts.firstSeenAtMs),
+    opts.project ?? undefined
+  );
+  archive.close();
+  return id;
+}
+
+/** Create a Tag; returns its id. */
+function seedTag(name: string, colorIndex = 0): string {
+  const tags = createTagRepository({ dataDir });
+  return tags.createTag(name, TAG_COLORS[colorIndex]).id;
+}
+
+/** Assign Tags to a Chat by internal id. */
+function assignTags(chatInternalId: string, tagIds: string[]): void {
+  const tags = createTagRepository({ dataDir });
+  for (const tagId of tagIds) tags.assignTag(chatInternalId, tagId);
+}
+
+describe("cross-store paginated query — app-level strategy", () => {
+  it("returns the newest page first, capped at limit, with a nextCursor", () => {
+    const c300 = seedChat({ sourceId: "s-300", firstSeenAtMs: 300 });
+    const c200 = seedChat({ sourceId: "s-200", firstSeenAtMs: 200 });
+    seedChat({ sourceId: "s-100", firstSeenAtMs: 100 });
+
+    const strategy = createAppLevelStrategy({ dataDir });
+    open.push(strategy);
+
+    const page = strategy.listChatsPage({ limit: 2 });
+
+    expect(page.items.map((i) => i.id)).toEqual([c300, c200]);
+    expect(page.items.map((i) => i.sortKey)).toEqual([300, 200]);
+    expect(page.nextCursor).toEqual({ sortKey: 200, id: c200 });
+  });
+
+  it("walks every chat across pages via the cursor — no overlap, no gap", () => {
+    const ids = [500, 400, 300, 200, 100].map((ms) =>
+      seedChat({ sourceId: `s-${ms}`, firstSeenAtMs: ms })
+    );
+
+    const strategy = createAppLevelStrategy({ dataDir });
+    open.push(strategy);
+
+    const seen: string[] = [];
+    let cursor: PageCursor | undefined;
+    let pages = 0;
+    do {
+      const page = strategy.listChatsPage({ limit: 2, cursor });
+      seen.push(...page.items.map((i) => i.id));
+      cursor = page.nextCursor ?? undefined;
+      pages++;
+    } while (cursor);
+
+    // 5 chats at limit 2 → pages of 2, 2, 1; the last page has no nextCursor.
+    expect(pages).toBe(3);
+    expect(seen).toEqual(ids); // newest-first, every id exactly once
+  });
+
+  it("filters by Project (OR), with '' selecting the (No project) group", () => {
+    const a = seedChat({ sourceId: "a", firstSeenAtMs: 400, project: "Alpha" });
+    const b = seedChat({ sourceId: "b", firstSeenAtMs: 300, project: "Beta" });
+    seedChat({ sourceId: "g", firstSeenAtMs: 200, project: "Gamma" });
+    const none = seedChat({ sourceId: "n", firstSeenAtMs: 100, project: null });
+
+    const strategy = createAppLevelStrategy({ dataDir });
+    open.push(strategy);
+
+    const named = strategy.listChatsPage({
+      limit: 10,
+      projects: ["Alpha", "Beta"],
+    });
+    expect(named.items.map((i) => i.id)).toEqual([a, b]);
+
+    const withNoProject = strategy.listChatsPage({
+      limit: 10,
+      projects: ["Alpha", ""],
+    });
+    expect(withNoProject.items.map((i) => i.id)).toEqual([a, none]);
+  });
+
+  it("filters by Tag (AND), with '' selecting the Untagged group", () => {
+    const both = seedChat({ sourceId: "both", firstSeenAtMs: 400 });
+    const xOnly = seedChat({ sourceId: "x", firstSeenAtMs: 300 });
+    const yBare = seedChat({ sourceId: "y", firstSeenAtMs: 200 });
+    const bare = seedChat({ sourceId: "bare", firstSeenAtMs: 100 });
+
+    const tagX = seedTag("X", 0);
+    const tagY = seedTag("Y", 1);
+    assignTags(both, [tagX, tagY]);
+    assignTags(xOnly, [tagX]);
+    // `bare` holds no Tags.
+
+    const strategy = createAppLevelStrategy({ dataDir });
+    open.push(strategy);
+
+    // AND within: only a Chat holding both X and Y passes.
+    const andBoth = strategy.listChatsPage({ limit: 10, tags: [tagX, tagY] });
+    expect(andBoth.items.map((i) => i.id)).toEqual([both]);
+
+    // '' selects the Untagged group (holds no Tag at all): both y and bare.
+    const untagged = strategy.listChatsPage({ limit: 10, tags: [""] });
+    expect(untagged.items.map((i) => i.id)).toEqual([yBare, bare]);
+
+    // Mixing a real Tag with '' ANDs to nothing (can't hold X yet be untagged).
+    const contradiction = strategy.listChatsPage({
+      limit: 10,
+      tags: [tagX, ""],
+    });
+    expect(contradiction.items).toEqual([]);
+  });
+
+  it("ANDs Project and Tag filters across types", () => {
+    const tag = seedTag("Pinned", 0);
+    const alphaPinned = seedChat({
+      sourceId: "ap",
+      firstSeenAtMs: 400,
+      project: "Alpha",
+    });
+    seedChat({ sourceId: "au", firstSeenAtMs: 300, project: "Alpha" }); // Alpha, no tag
+    const betaPinned = seedChat({
+      sourceId: "bp",
+      firstSeenAtMs: 200,
+      project: "Beta",
+    });
+    assignTags(alphaPinned, [tag]);
+    assignTags(betaPinned, [tag]);
+
+    const strategy = createAppLevelStrategy({ dataDir });
+    open.push(strategy);
+
+    // In Project Alpha (OR) AND holding Tag Pinned (AND) → only alphaPinned.
+    const page = strategy.listChatsPage({
+      limit: 10,
+      projects: ["Alpha"],
+      tags: [tag],
+    });
+    expect(page.items.map((i) => i.id)).toEqual([alphaPinned]);
+  });
+});
+
+describe("cross-store paginated query — ATTACH strategy", () => {
+  it("runs a combined Project + Tag query in one cross-database pass", () => {
+    const tag = seedTag("Pinned", 0);
+    const alphaPinned = seedChat({
+      sourceId: "ap",
+      firstSeenAtMs: 400,
+      project: "Alpha",
+    });
+    const alphaPinned2 = seedChat({
+      sourceId: "ap2",
+      firstSeenAtMs: 350,
+      project: "Alpha",
+    });
+    seedChat({ sourceId: "au", firstSeenAtMs: 300, project: "Alpha" }); // no tag
+    const betaPinned = seedChat({
+      sourceId: "bp",
+      firstSeenAtMs: 200,
+      project: "Beta",
+    });
+    assignTags(alphaPinned, [tag]);
+    assignTags(alphaPinned2, [tag]);
+    assignTags(betaPinned, [tag]);
+
+    const strategy = createAttachStrategy({ dataDir });
+    open.push(strategy);
+
+    // First page: Alpha ∧ Pinned, newest first, limit 1 → alphaPinned + cursor.
+    const first = strategy.listChatsPage({
+      limit: 1,
+      projects: ["Alpha"],
+      tags: [tag],
+    });
+    expect(first.items.map((i) => i.id)).toEqual([alphaPinned]);
+    expect(first.nextCursor).toEqual({ sortKey: 400, id: alphaPinned });
+
+    // Next page via the cursor → alphaPinned2, then no more.
+    const second = strategy.listChatsPage({
+      limit: 1,
+      projects: ["Alpha"],
+      tags: [tag],
+      cursor: first.nextCursor ?? undefined,
+    });
+    expect(second.items.map((i) => i.id)).toEqual([alphaPinned2]);
+    expect(second.nextCursor).toBeNull();
+  });
+});
+
+describe("cross-store paginated query — strategy equivalence", () => {
+  /** Page through the whole result set, collecting the id sequence. */
+  function walkAll(
+    strategy: PaginatedQueryStrategy,
+    base: Omit<PageQuery, "cursor">
+  ): string[] {
+    const ids: string[] = [];
+    let cursor: PageCursor | undefined;
+    do {
+      const page = strategy.listChatsPage({ ...base, cursor });
+      ids.push(...page.items.map((i) => i.id));
+      cursor = page.nextCursor ?? undefined;
+    } while (cursor);
+    return ids;
+  }
+
+  it("ATTACH and app-level return identical pages for every query shape", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+    seedArchive(
+      { archive, tags },
+      { count: 80, seed: 7, projects: 4, tagRatio: 0.5, tagPool: 4 }
+    );
+    const tagIds = tags.listTags().map((t) => t.id);
+    archive.close();
+
+    const attach = createAttachStrategy({ dataDir });
+    const appLevel = createAppLevelStrategy({ dataDir });
+    open.push(attach, appLevel);
+
+    const queries: Omit<PageQuery, "cursor">[] = [
+      { limit: 7 }, // unfiltered
+      { limit: 7, projects: ["Project 0", "Project 2"] }, // project OR
+      { limit: 7, projects: [""] }, // (No project) group
+      { limit: 7, tags: [tagIds[0]] }, // single tag
+      { limit: 7, tags: [tagIds[0], tagIds[1]] }, // tag AND
+      { limit: 7, tags: [""] }, // Untagged group
+      { limit: 7, projects: ["Project 1"], tags: [tagIds[2]] }, // combined
+      { limit: 1, tags: [tagIds[3]] }, // tiny pages
+      { limit: 1000, projects: ["Project 0"] }, // single big page
+    ];
+
+    for (const q of queries) {
+      const fromAttach = walkAll(attach, q);
+      const fromApp = walkAll(appLevel, q);
+      expect(fromApp, JSON.stringify(q)).toEqual(fromAttach);
+    }
+  });
+});

--- a/api/src/spike/cross-store-pagination.ts
+++ b/api/src/spike/cross-store-pagination.ts
@@ -1,0 +1,288 @@
+import fs from "node:fs";
+import path from "node:path";
+import Database from "better-sqlite3";
+
+/**
+ * Spike (issue #128): prototype + benchmark two ways to run a filtered + sorted
+ * + keyset-paginated Chat listing across the separate Archive and Metadata
+ * SQLite stores.
+ *
+ *   (a) ATTACH the Metadata DB onto the Archive connection — one cross-database
+ *       SQL pass does intersection + ORDER BY + keyset LIMIT.
+ *   (b) App-level intersection of per-store candidate id sets (ADR-0016),
+ *       extended with the sort + keyset slice the pagination slice needs.
+ *
+ * Throwaway code: it opens its own raw connections to `archive.db` /
+ * `metadata.db` rather than going through the repositories, so the two
+ * strategies can be compared side by side. The chosen shape graduates into a
+ * real module in the pagination slice; this file does not.
+ *
+ * Sort key for the benchmark is `chats.first_seen_at` (createdAt) DESC with the
+ * internal `chats.id` as a stable tiebreaker — both are real columns on the
+ * Archive's `chats` table, so the variable under study stays the cross-store
+ * intersection cost, not the cost of deriving `updatedAt` from `messages`.
+ */
+
+const ARCHIVE_DB = "archive.db";
+const METADATA_DB = "metadata.db";
+
+/** Keyset cursor: the (sortKey, id) of the last item on the previous page. */
+export interface PageCursor {
+  /** `chats.first_seen_at` in epoch ms. */
+  sortKey: number;
+  /** Internal `chats.id` (UUID) tiebreaker. */
+  id: string;
+}
+
+export interface PageItem {
+  /** Internal `chats.id` (UUID). */
+  id: string;
+  /** `chats.first_seen_at` in epoch ms. */
+  sortKey: number;
+}
+
+export interface Page {
+  items: PageItem[];
+  /** Cursor to fetch the next page, or null when this is the last page. */
+  nextCursor: PageCursor | null;
+}
+
+export interface PageQuery {
+  limit: number;
+  cursor?: PageCursor;
+  /**
+   * Project filter (OR / union). A Chat passes if its project is in the set.
+   * An empty-string entry selects the `(No project)` group (project NULL or
+   * ''). Omitting it leaves Projects unfiltered.
+   */
+  projects?: string[];
+  /**
+   * Tag filter (AND within). A Chat must hold every selected Tag to pass. An
+   * empty-string entry selects the `Untagged` group (zero Tags) — mixing it
+   * with a real Tag id naturally yields nothing. Omitting it leaves Tags
+   * unfiltered.
+   */
+  tags?: string[];
+}
+
+export interface PaginatedQueryStrategy {
+  listChatsPage(query: PageQuery): Page;
+  close(): void;
+}
+
+export interface StrategyOptions {
+  dataDir: string;
+}
+
+interface ChatRow {
+  id: string;
+  sortKey: number;
+}
+
+/** Newest first: first_seen_at DESC, id DESC. */
+function compareDesc(a: ChatRow, b: ChatRow): number {
+  if (a.sortKey !== b.sortKey) return b.sortKey - a.sortKey;
+  return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+}
+
+/** True when `row` sorts strictly after `cursor` in the DESC order. */
+function isAfterCursor(row: ChatRow, cursor: PageCursor): boolean {
+  if (row.sortKey !== cursor.sortKey) return row.sortKey < cursor.sortKey;
+  return row.id < cursor.id;
+}
+
+/** Slice a fully sorted candidate list into one keyset page. */
+function paginate(sorted: ChatRow[], query: PageQuery): Page {
+  const start = query.cursor
+    ? sorted.filter((r) => isAfterCursor(r, query.cursor as PageCursor))
+    : sorted;
+  const items = start.slice(0, query.limit);
+  const last = items[items.length - 1];
+  const nextCursor =
+    items.length === query.limit && last
+      ? { sortKey: last.sortKey, id: last.id }
+      : null;
+  return { items, nextCursor };
+}
+
+export function createAppLevelStrategy(
+  opts: StrategyOptions
+): PaginatedQueryStrategy {
+  const archive = new Database(path.join(opts.dataDir, ARCHIVE_DB), {
+    readonly: true,
+  });
+  // The Metadata store may not exist yet when nothing has been tagged; treat an
+  // absent file as "no Tags assigned" rather than failing to open it.
+  const metadataPath = path.join(opts.dataDir, METADATA_DB);
+  const metadata = fs.existsSync(metadataPath)
+    ? new Database(metadataPath, { readonly: true })
+    : null;
+
+  function listChatsPage(query: PageQuery): Page {
+    // An empty project set filters to nothing (an OR over no options).
+    if (query.projects && query.projects.length === 0) {
+      return { items: [], nextCursor: null };
+    }
+
+    // The Project filter is the Archive store's own indexed query (OR / union);
+    // COALESCE folds NULL and '' into one `(No project)` bucket.
+    let sql = "SELECT id, first_seen_at AS sortKey FROM chats";
+    const params: string[] = [];
+    if (query.projects) {
+      const placeholders = query.projects.map(() => "?").join(", ");
+      sql += ` WHERE coalesce(project, '') IN (${placeholders})`;
+      params.push(...query.projects);
+    }
+    let rows = archive.prepare(sql).all(...params) as ChatRow[];
+
+    // The Tag filter is the Metadata store's own indexed query; its candidate
+    // id set is intersected with the Archive rows here in app code — the
+    // cross-store intersection ADR-0016 mandates instead of one cross-database
+    // JOIN. This is the work the ATTACH strategy pushes into a single SQL pass.
+    const allowed = tagAllowedIds(query.tags);
+    if (allowed) rows = rows.filter((r) => allowed.has(r.id));
+
+    rows.sort(compareDesc);
+    return paginate(rows, query);
+  }
+
+  /**
+   * The set of Chat ids passing the Tag filter, or null when Tags are
+   * unfiltered. Real Tag ids and the '' (Untagged) marker are ANDed: each
+   * present condition narrows the set, so real + '' yields the empty set — a
+   * Chat can't both hold every real Tag and hold none (matches the ChatReader
+   * predicate established in ADR-0016).
+   */
+  function tagAllowedIds(tags: string[] | undefined): Set<string> | null {
+    if (!tags) return null;
+    const realTags = tags.filter((t) => t !== "");
+    const wantUntagged = tags.includes("");
+
+    let allowed: Set<string> | null = null; // null = no condition applied yet
+    if (realTags.length > 0) {
+      const holdingAll = new Set<string>();
+      if (metadata) {
+        const placeholders = realTags.map(() => "?").join(", ");
+        const rows = metadata
+          .prepare(
+            `SELECT chat_id FROM chat_tags WHERE tag_id IN (${placeholders})
+             GROUP BY chat_id HAVING count(*) = ?`
+          )
+          .all(...realTags, realTags.length) as { chat_id: string }[];
+        for (const r of rows) holdingAll.add(r.chat_id);
+      }
+      allowed = holdingAll;
+    }
+    if (wantUntagged) {
+      const tagged = new Set(
+        metadata
+          ? (
+              metadata
+                .prepare("SELECT DISTINCT chat_id FROM chat_tags")
+                .all() as { chat_id: string }[]
+            ).map((r) => r.chat_id)
+          : []
+      );
+      const untagged = (
+        archive.prepare("SELECT id FROM chats").all() as { id: string }[]
+      )
+        .map((r) => r.id)
+        .filter((id) => !tagged.has(id));
+      allowed =
+        allowed === null
+          ? new Set(untagged)
+          : new Set(untagged.filter((id) => allowed!.has(id)));
+    }
+    return allowed;
+  }
+
+  return {
+    listChatsPage,
+    close() {
+      archive.close();
+      metadata?.close();
+    },
+  };
+}
+
+/**
+ * Strategy (a): ATTACH the Metadata DB onto the Archive connection and run one
+ * cross-database SQL pass — intersection + ORDER BY + keyset LIMIT in a single
+ * query, pushing the page limit down into SQLite instead of materializing the
+ * full filtered list in app code.
+ */
+export function createAttachStrategy(
+  opts: StrategyOptions
+): PaginatedQueryStrategy {
+  const archive = new Database(path.join(opts.dataDir, ARCHIVE_DB));
+  const metadataPath = path.join(opts.dataDir, METADATA_DB);
+  const hasMetadata = fs.existsSync(metadataPath);
+  if (hasMetadata) {
+    archive.prepare("ATTACH DATABASE ? AS meta").run(metadataPath);
+  }
+
+  function listChatsPage(query: PageQuery): Page {
+    if (query.projects && query.projects.length === 0) {
+      return { items: [], nextCursor: null };
+    }
+
+    const clauses: string[] = [];
+    const params: (string | number)[] = [];
+
+    if (query.projects) {
+      const ph = query.projects.map(() => "?").join(", ");
+      clauses.push(`coalesce(c.project, '') IN (${ph})`);
+      params.push(...query.projects);
+    }
+
+    if (query.tags) {
+      const realTags = query.tags.filter((t) => t !== "");
+      const wantUntagged = query.tags.includes("");
+      if (realTags.length > 0) {
+        if (!hasMetadata) return { items: [], nextCursor: null };
+        const ph = realTags.map(() => "?").join(", ");
+        clauses.push(
+          `c.id IN (SELECT chat_id FROM meta.chat_tags WHERE tag_id IN (${ph})
+                    GROUP BY chat_id HAVING count(*) = ?)`
+        );
+        params.push(...realTags, realTags.length);
+      }
+      if (wantUntagged && hasMetadata) {
+        clauses.push("c.id NOT IN (SELECT chat_id FROM meta.chat_tags)");
+      }
+    }
+
+    if (query.cursor) {
+      clauses.push(
+        "(c.first_seen_at < ? OR (c.first_seen_at = ? AND c.id < ?))"
+      );
+      params.push(query.cursor.sortKey, query.cursor.sortKey, query.cursor.id);
+    }
+
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    // Fetch one extra row to tell whether a next page exists without a count.
+    const rows = archive
+      .prepare(
+        `SELECT c.id AS id, c.first_seen_at AS sortKey
+         FROM chats c ${where}
+         ORDER BY c.first_seen_at DESC, c.id DESC
+         LIMIT ?`
+      )
+      .all(...params, query.limit + 1) as ChatRow[];
+
+    const items = rows.slice(0, query.limit);
+    const last = items[items.length - 1];
+    const nextCursor =
+      rows.length > query.limit && last
+        ? { sortKey: last.sortKey, id: last.id }
+        : null;
+    return { items, nextCursor };
+  }
+
+  return {
+    listChatsPage,
+    close() {
+      archive.close();
+    },
+  };
+}

--- a/docs/adr/0016-combined-filtering-app-level-intersection.md
+++ b/docs/adr/0016-combined-filtering-app-level-intersection.md
@@ -5,5 +5,5 @@ Combined Project + Tag + search filtering computes a candidate Chat id set per s
 ## Consequences
 
 - Each store keeps its own indexes: `chat_tags` with PK `(chat_id, tag_id)` plus a secondary index on `(tag_id)`; the Archive's `chats.project` gets an index. Tag display batches one grouped query into a `Map`, never one query per Chat.
-- The `ATTACH`-based single-query approach (one SQL pass doing intersection + `ORDER BY` + keyset pagination across stores) is deferred to the later list-pipeline refactor, where server-side sort + pagination actually needs it. That is the point to revisit this decision and weigh `ATTACH` against the ADR-0001 isolation it would relax.
+- The `ATTACH`-based single-query approach (one SQL pass doing intersection + `ORDER BY` + keyset pagination across stores) is deferred to the later list-pipeline refactor, where server-side sort + pagination actually needs it. That is the point to revisit this decision and weigh `ATTACH` against the ADR-0001 isolation it would relax. **Resolved by [ADR-0017](0017-cross-store-pagination-uses-attach.md):** the paginated path uses `ATTACH`; this app-level intersection stays the shape for the full-list model.
 - Trade-off: app-side intersection is fine while the frontend loads the full filtered list (the current model), but is not the final shape once the server paginates.

--- a/docs/adr/0017-cross-store-pagination-uses-attach.md
+++ b/docs/adr/0017-cross-store-pagination-uses-attach.md
@@ -1,0 +1,52 @@
+# Cross-store paginated listing runs one ATTACH query
+
+Server-side sorted, keyset-paginated Chat listing — filtered across the Archive store (`chats.project`, OR/union) and the Metadata store (`chat_tags`, AND/intersection) — runs as a single SQL pass on the Archive connection with the Metadata DB `ATTACH`ed, rather than the app-level intersection of per-store id sets that [ADR-0016](0016-combined-filtering-app-level-intersection.md) established for the full-list model. ADR-0016 deferred this choice to "the later list-pipeline refactor, where server-side sort + pagination actually needs it"; this is that point, and this ADR resolves the deferral.
+
+The deciding factor is that app-level intersection cannot push the page `LIMIT` into SQL. It must load every candidate id from each store, intersect, sort, then slice in application code — so its cost scales with the size of the filtered candidate set and is independent of page depth. `ATTACH` does intersection + `ORDER BY` + keyset `LIMIT` in one pass, so with the right index it is an index range scan that stops after one page.
+
+## Benchmark
+
+Spike code: `api/src/spike/cross-store-pagination.ts` (both strategies behind one interface, proven to return identical pages by `cross-store-pagination.test.ts`) and `api/scripts/bench-cross-store-pagination.ts`. Measured on a seeded Archive of 50,000 Chats (50 Projects, 30% tagged, 10-Tag pool), page size 50, median of 50 runs.
+
+With the supporting indexes below in place:
+
+| Query (page size 50)     | ATTACH | App-level | App-level / ATTACH |
+| ------------------------ | ------ | --------- | ------------------ |
+| Unfiltered, first page   | 0.02ms | 6.47ms    | ~390x              |
+| Unfiltered, deep page    | 0.93ms | 6.67ms    | ~7x                |
+| One Project (~1.7k rows) | 0.52ms | 1.40ms    | ~3x                |
+| Tag AND (two Tags)       | 1.78ms | 10.03ms   | ~6x                |
+| Untagged group           | 0.03ms | 25.28ms   | ~800x              |
+| Project + Tag combined   | 2.00ms | 2.55ms    | ~1.3x              |
+
+The unfiltered list — the default view, and the largest candidate set — is where the gap is widest and most structural: app-level holds a ~6.5ms floor (materializing and sorting 50k rows in JS) that does not shrink with page size, while ATTACH stays bounded by the page. When a Project filter already narrows the set the two converge, but the common case is the one that matters, and ATTACH never loses.
+
+## Considered options
+
+- **App-level intersection (ADR-0016), extended with sort + keyset.** Preserves the four-store isolation of [ADR-0001](0001-four-store-split.md) — no connection ever sees another store's tables. Rejected for the paginated path: it cannot push `LIMIT` down, so the default unfiltered list pays a candidate-set-sized cost on every page. Still the right shape for the full-list model it was written for.
+- **`ATTACH` single cross-database query.** One pass, page-bounded latency. Relaxes ADR-0001 isolation: the Archive connection must hold a path to `metadata.db` and reference `meta.chat_tags`. Chosen — the isolation it relaxes is read-only and one-directional (Archive reads Metadata; no writes cross, no schema merges), and the latency win on the common path is large and structural.
+
+## Consequences
+
+- **Isolation is relaxed, narrowly.** The read path `ATTACH`es `metadata.db` onto the Archive connection read-only and references `meta.chat_tags` in `SELECT`s only. No writes cross stores, schemas are not merged, and the four `.db` files stay physically separate — so [ADR-0001](0001-four-store-split.md), [ADR-0002](0002-never-cascade-delete-archive.md), and the backup model are untouched. The pagination module owns the `ATTACH` and detaches/closes on teardown; ingestion and the write seams never `ATTACH`.
+- **Required indexes.** `chats(first_seen_at DESC, id DESC)` — a covering keyset index so the sort + `LIMIT` is an index range scan, not a full sort (this is what takes the unfiltered first page from ~1.3ms to ~0.02ms). `chat_tags(chat_id)` on the Metadata side for the Tag subquery (the existing `chat_tags` PK is `(chat_id, tag_id)`, which already leads with `chat_id`, so a separate index may be redundant — confirm with `EXPLAIN QUERY PLAN` before adding). The existing `chats_project_idx` covers the Project filter.
+- **Query shape** the pagination slice implements against:
+  ```sql
+  SELECT c.id, c.first_seen_at AS sort_key
+  FROM chats c
+  WHERE 1=1
+    -- Project filter (optional, OR): coalesce folds NULL and '' into (No project)
+    [ AND coalesce(c.project, '') IN (?, ...) ]
+    -- Tag filter (optional, AND): every selected real Tag must be held
+    [ AND c.id IN (SELECT chat_id FROM meta.chat_tags WHERE tag_id IN (?, ...)
+                   GROUP BY chat_id HAVING count(*) = ?) ]
+    -- Untagged group ('' marker): ANDs with the above, so real + '' yields nothing
+    [ AND c.id NOT IN (SELECT chat_id FROM meta.chat_tags) ]
+    -- Keyset cursor (optional): strictly after the last row of the previous page
+    [ AND (c.first_seen_at < ? OR (c.first_seen_at = ? AND c.id < ?)) ]
+  ORDER BY c.first_seen_at DESC, c.id DESC
+  LIMIT ? + 1;  -- one extra row signals whether a next page exists
+  ```
+- **Cursor design.** The keyset cursor is `(first_seen_at, id)` — the sort key plus the internal `chats.id` as a stable, unique tiebreaker — opaque to clients (encode as an opaque token, not the raw pair). It is page-bounded and stateless: no `OFFSET`, so deep pages cost the same as the first. Fetching `LIMIT + 1` rows yields the next cursor without a separate count.
+- **Sort key is `first_seen_at` (createdAt), not derived `updatedAt`.** The benchmark sorts on `chats.first_seen_at`, a real indexable column, to isolate the cross-store cost. Sorting by "most recent activity" (`max(messages.ts)`) is the likely product default and is **not** covered here: it needs either a denormalized `updated_at` column on `chats` (kept current at ingest) or an aggregate that defeats the keyset index. Decide that separately before the list UI commits to an activity sort — the `ATTACH` shape above carries over, only the sort column and its index change.
+- **The spike code is throwaway.** `api/src/spike/` and the bench script document the decision; the chosen shape graduates into the real pagination module in the implementing slice. Delete the spike once that lands.


### PR DESCRIPTION
## Background (Why)

[#128](https://github.com/evaaaaawu/chat-logbook/issues/128) is a decision spike. The "server-side sort + keyset pagination" slice needs filtered Chat listing across two separate SQLite stores — Projects live on `archive.db` (`chats.project`, OR), Tags on `metadata.db` (`chat_tags`, AND). [ADR-0016](docs/adr/0016-combined-filtering-app-level-intersection.md) intersects per-store id sets in app code and explicitly deferred the `ATTACH` single-query alternative to "the later list-pipeline refactor, where server-side sort + pagination actually needs it." This is that point. We need a measured decision and an ADR the pagination slice can implement against.

## Approach (How)

Two strategies behind one shared interface (`listChatsPage`), TDD'd for correctness one behavior at a time, with an equivalence test asserting both return byte-identical pages — so the benchmark only times code already proven equivalent.

- **(a) ATTACH** — `ATTACH metadata.db` onto the Archive connection, one cross-database SQL pass: intersection + `ORDER BY` + keyset `LIMIT`.
- **(b) App-level** — per-store candidate id sets intersected in JS (the ADR-0016 shape), then sorted and keyset-sliced.

Sort key is `chats.first_seen_at` + `id` tiebreaker — real indexable columns — so the variable under study stays the cross-store intersection cost, not the cost of deriving `updatedAt`. The bench seeds 50,000 Chats and reports median latency per query shape and page depth.

The decision: **ATTACH.** App-level cannot push the page `LIMIT` down, so its cost scales with the candidate set and is independent of page depth; ATTACH with a keyset index is page-bounded. The gap on the default unfiltered list is ~390x and structural.

## Changes (What)

- [x] `api/src/spike/cross-store-pagination.ts` — both strategies behind one interface (throwaway)
- [x] `api/src/spike/cross-store-pagination.test.ts` — per-behavior tests + ATTACH/app-level equivalence
- [x] `api/scripts/bench-cross-store-pagination.ts` — 50k seeded benchmark harness
- [x] `docs/adr/0017-cross-store-pagination-uses-attach.md` — decision, query shape, indexes, cursor design
- [x] `docs/adr/0016-...md` — marked its deferral resolved by ADR-0017

### Recordings

Benchmark, 50,000 Chats, page size 50, median of 50 runs, with the keyset index in place:

| Query | ATTACH | App-level | ratio |
| --- | --- | --- | --- |
| Unfiltered, first page | 0.02ms | 6.47ms | ~390x |
| Unfiltered, deep page | 0.93ms | 6.67ms | ~7x |
| One Project (~1.7k rows) | 0.52ms | 1.40ms | ~3x |
| Tag AND (two Tags) | 1.78ms | 10.03ms | ~6x |
| Untagged group | 0.03ms | 25.28ms | ~800x |
| Project + Tag combined | 2.00ms | 2.55ms | ~1.3x |

### Test Verification

- [x] First page sorted newest-first, capped at limit, with a `nextCursor`
- [x] Keyset cursor walks every Chat across pages — no overlap, no gap, last page has no cursor
- [x] Project OR filter, with `''` selecting the `(No project)` group
- [x] Tag AND filter, with `''` selecting the `Untagged` group; real Tag + `''` ANDs to empty
- [x] Project ∧ Tag combined across types
- [x] ATTACH runs a combined Project + Tag query in one cross-database pass with cursor paging
- [x] ATTACH and app-level return identical pages for every query shape (equivalence)
- [x] Full suite green: api 224 + web 149, typecheck clean (pre-commit hook)

## Additional Notes

Two follow-ups recorded in ADR-0017, deliberately out of scope here:

- **Activity sort.** The benchmark sorts on `first_seen_at` (createdAt). Sorting by "most recent activity" (`max(messages.ts)`) — the likely product default — needs either a denormalized `updated_at` column on `chats` or an aggregate that defeats the keyset index. The ATTACH shape carries over; only the sort column and its index change.
- **Spike is throwaway.** `api/src/spike/` and the bench document the decision; the chosen shape graduates into the real pagination module in the implementing slice, which then deletes the spike.

## Related Links

- Closes #128
- [ADR-0017](docs/adr/0017-cross-store-pagination-uses-attach.md) · [ADR-0016](docs/adr/0016-combined-filtering-app-level-intersection.md) · [ADR-0001](docs/adr/0001-four-store-split.md)