### PR TITLE
feat(web): paginated chat list with infinite scroll and windowed freeze

### DIFF
--- a/web/e2e/chat-list-pagination.spec.ts
+++ b/web/e2e/chat-list-pagination.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// More chats than the keyset cap (200) so the loaded window can grow past it —
+// the condition that crashed the background refresh. Descending updatedAt order,
+// so "Chat 0" is newest and sorts first. The cursor here just encodes the next
+// offset — opaque to the frontend, which only echoes nextCursor back.
+const TOTAL = 220;
+const MAX_PAGE_LIMIT = 200;
+
+function allChats() {
+  return Array.from({ length: TOTAL }, (_, i) => ({
+    id: `clog_${i}`,
+    sourceId: `src_${i}`,
+    agent: "claude-code",
+    title: `Chat ${i}`,
+    project: "/test/project",
+    sourceFilePath: null,
+    createdAt: 1700000000000 + (TOTAL - i),
+    updatedAt: 1700000000000 + (TOTAL - i) * 1000,
+  }));
+}
+
+// Mirror the merged backend (#142): `limit` opts into one keyset page, the
+// cursor is the next offset (base64), nextCursor is null on the last page, and —
+// crucially — a `limit` over the cap is rejected with 400, like the real server.
+async function mockChatPages(page: Page): Promise<void> {
+  await page.route(/\/api\/tags(\?|$)/, (route) =>
+    route.fulfill({ json: { tags: [] } })
+  );
+  await page.route(/\/api\/chats(\?|$)/, (route, request) => {
+    const url = new URL(request.url());
+    const limitParam = url.searchParams.get("limit");
+    const chats = allChats();
+    if (limitParam === null) {
+      route.fulfill({ json: { chats } });
+      return;
+    }
+    const limit = Number(limitParam);
+    if (limit > MAX_PAGE_LIMIT) {
+      route.fulfill({ status: 400, json: { error: "Invalid limit" } });
+      return;
+    }
+    const cursor = url.searchParams.get("cursor");
+    const start = cursor ? Number(atob(cursor)) : 0;
+    const pageItems = chats.slice(start, start + limit);
+    const end = start + limit;
+    const nextCursor = end < chats.length ? btoa(String(end)) : null;
+    route.fulfill({ json: { chats: pageItems, nextCursor } });
+  });
+}
+
+test.describe("Chat list pagination", () => {
+  test("loads further pages as the list is scrolled, not all at once", async ({
+    page,
+  }) => {
+    await mockChatPages(page);
+    await page.goto("/");
+
+    // First page renders (default page size is 30), so the newest chat is shown
+    // but a chat from a later page is not in the data yet at all.
+    await expect(page.getByText("Chat 0", { exact: true })).toBeVisible();
+    await expect(page.getByText("Chat 55", { exact: true })).toHaveCount(0);
+
+    // Scrolling to the bottom triggers the next page; the window then grows, so
+    // the new bottom is further down. Keep scrolling to the current bottom until
+    // a later-page chat comes into view — it exists only because the cursor
+    // fetch ran. The first page alone never contained it.
+    const scroller = page.getByTestId("chat-scroll");
+    await expect(async () => {
+      await scroller.evaluate((el) => {
+        el.scrollTop = el.scrollHeight;
+      });
+      await expect(page.getByText("Chat 55", { exact: true })).toBeVisible({
+        timeout: 500,
+      });
+    }).toPass({ timeout: 8000 });
+  });
+
+  test("does not blank out when the loaded window grows past the page-limit cap", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (e) => errors.push(String(e)));
+    page.on("console", (m) => {
+      if (m.type() === "error") errors.push(m.text());
+    });
+
+    await mockChatPages(page);
+    await page.goto("/");
+    await expect(page.getByText("Chat 0", { exact: true })).toBeVisible();
+
+    // Walk every page so the window exceeds 200, then sit at the bottom past a
+    // 4s background-refresh tick — the refresh must not request more than the
+    // cap nor crash on a rejected response.
+    const scroller = page.getByTestId("chat-scroll");
+    for (let i = 0; i < 60; i++) {
+      await scroller.evaluate((el) => {
+        el.scrollTop = el.scrollHeight;
+      });
+      await page.waitForTimeout(150);
+    }
+
+    await expect(page.getByTestId("chat-row").first()).toBeVisible();
+    await expect(page.getByText("Chat 219", { exact: true })).toBeVisible();
+    expect(errors, errors.join("\n")).toEqual([]);
+  });
+});

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -503,14 +503,17 @@ describe("Chat metadata popover", () => {
 });
 
 describe("Trash link in filter panel", () => {
-  it("shows the count of deleted sessions in a Trash link", async () => {
+  it("shows a Trash link without a count badge", async () => {
     render(<App />);
 
     await screen.findByText("Build a login page");
 
+    // The list reads paginated pages that exclude trashed chats, so the active
+    // window cannot know the full trashed total without a full load. The count
+    // is dropped rather than shown per-mode (#129); the link still opens Trash.
     const trashLink = await screen.findByTestId("trash-link");
     expect(within(trashLink).getByText(/trash/i)).toBeInTheDocument();
-    expect(within(trashLink).getByText("2")).toBeInTheDocument();
+    expect(within(trashLink).queryByText(/^\d+$/)).not.toBeInTheDocument();
   });
 });
 
@@ -621,7 +624,7 @@ describe("Trash sort", () => {
 });
 
 describe("Soft delete from chat list", () => {
-  it("removes the session from the list and increments trash count", async () => {
+  it("removes the session from the list and moves it to Trash", async () => {
     const user = userEvent.setup();
     render(<App />);
 
@@ -643,9 +646,13 @@ describe("Soft delete from chat list", () => {
       ).not.toBeInTheDocument();
     });
 
-    // Trash count: 2 → 3
-    const trashLink = screen.getByTestId("trash-link");
-    expect(within(trashLink).getByText("3")).toBeInTheDocument();
+    // It now lives in Trash (the count badge was dropped; the move is what the
+    // user cares about).
+    await user.click(screen.getByTestId("trash-link"));
+    const list = screen.getByTestId("chat-list");
+    expect(
+      await within(list).findByText("Fix database migration")
+    ).toBeInTheDocument();
   });
 });
 
@@ -697,9 +704,6 @@ describe("Undo toast on delete", () => {
         within(list).getByText("Fix database migration")
       ).toBeInTheDocument();
     });
-
-    const trashLink = screen.getByTestId("trash-link");
-    expect(within(trashLink).getByText("2")).toBeInTheDocument();
   });
 });
 
@@ -1002,8 +1006,11 @@ describe("Empty states", () => {
     render(<App />);
 
     expect(await screen.findByText(/no chats/i)).toBeInTheDocument();
+    // The hint points to Trash without a count (counts were dropped, #129).
+    // Scope to the list — the sidebar also has a "Trash" link.
+    const list = screen.getByTestId("chat-list");
     expect(
-      screen.getByRole("button", { name: /^trash \(1\)$/i })
+      within(list).getByRole("button", { name: /^trash$/i })
     ).toBeInTheDocument();
   });
 });
@@ -1731,5 +1738,97 @@ describe("Project filter", () => {
     ).not.toBeInTheDocument();
     const webRow = within(section).getByTestId("project-row-my-web-app");
     expect(within(webRow).getByText("2")).toBeInTheDocument();
+  });
+});
+
+describe("Chat list pagination", () => {
+  // Capture the search string of every /api/chats GET, so a test can tell the
+  // paginated path (`?...limit=`) apart from the full-load path (no `limit`).
+  function captureChatListRequests(): string[] {
+    const searches: string[] = [];
+    server.events.on("request:start", ({ request }) => {
+      const url = new URL(request.url);
+      if (request.method === "GET" && url.pathname === "/api/chats") {
+        searches.push(url.search);
+      }
+    });
+    return searches;
+  }
+
+  it("loads the main chat list via the paginated keyset endpoint", async () => {
+    const searches = captureChatListRequests();
+    render(<App />);
+
+    await screen.findByText("Fix database migration");
+
+    // Default sort is Updated time · Newest first — a paginated time axis, so
+    // the main list is fetched as keyset pages (`limit` present) rather than the
+    // full list.
+    expect(searches.some((s) => s.includes("limit="))).toBe(true);
+    expect(searches.some((s) => s.includes("sort=updatedAt"))).toBe(true);
+    // The full-load path (no `limit`) is not used for the main view.
+    expect(searches.every((s) => s.includes("limit="))).toBe(true);
+
+    // Rows still render in Updated-time descending order.
+    const list = screen.getByTestId("chat-list");
+    const titles = within(list)
+      .getAllByTestId("chat-row")
+      .map((r) => r.textContent);
+    expect(titles[0]).toContain("Fix database migration");
+    expect(titles[1]).toContain("Build a login page");
+  });
+
+  it("uses the full-load path when sorting by Title", async () => {
+    const user = userEvent.setup();
+    const searches = captureChatListRequests();
+    render(<App />);
+    await screen.findByText("Build a login page");
+
+    const list = screen.getByTestId("chat-list");
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+    const popover = await screen.findByTestId("chat-sort-popover");
+    await user.click(within(popover).getByText("Title"));
+
+    // Title is not a keyset axis, so it falls back to the full list (no `limit`).
+    await waitFor(() =>
+      expect(searches.some((s) => !s.includes("limit="))).toBe(true)
+    );
+    const titles = within(list)
+      .getAllByTestId("chat-row")
+      .map((r) => r.textContent);
+    expect(titles[0]).toContain("Build a login page");
+  });
+
+  it("uses the full-load path when sorting by an ascending time axis", async () => {
+    const user = userEvent.setup();
+    const searches = captureChatListRequests();
+    render(<App />);
+    await screen.findByText("Build a login page");
+
+    const list = screen.getByTestId("chat-list");
+    // Default is Updated time · Newest first. Clicking the active axis again
+    // flips it to ascending (Oldest first), which the keyset index does not
+    // serve — so the list falls back to the full-load path.
+    await user.click(within(list).getByRole("button", { name: /sort/i }));
+    const popover = await screen.findByTestId("chat-sort-popover");
+    await user.click(within(popover).getByText("Updated time"));
+
+    await waitFor(() =>
+      expect(searches.some((s) => !s.includes("limit="))).toBe(true)
+    );
+  });
+
+  it("uses the full-load path for the Trash view", async () => {
+    const user = userEvent.setup();
+    const searches = captureChatListRequests();
+    render(<App />);
+    await screen.findByText("Build a login page");
+
+    await user.click(screen.getByTestId("trash-link"));
+
+    // Trash stays on the client-side full-load path; its deleted chats load.
+    const list = screen.getByTestId("chat-list");
+    expect(await within(list).findByText("Old prototype")).toBeInTheDocument();
+    expect(searches.some((s) => !s.includes("limit="))).toBe(true);
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useChats } from "@/chat/useChats";
+import { usePaginatedChats, type ListSort } from "@/chat/usePaginatedChats";
 import { useTags } from "@/tags/useTags";
 import { useMessages } from "@/conversation/useMessages";
 import { useToast } from "@/shared/useToast";
 import { useChatOrder } from "@/chat/sort/useChatOrder";
+import { useSortPreference } from "@/chat/sort/useSortPreference";
+import { CHAT_SORT_CONFIG } from "@/chat/sort/sortConfig";
 import { deriveProjects } from "@/chat/projects/deriveProjects";
 import { filterChatsByProjects } from "@/chat/projects/filterChatsByProjects";
 import { filterChatsByTags } from "@/tags/filterChatsByTags";
@@ -20,8 +23,31 @@ import {
 } from "@/shared/ui/resizable";
 
 function App() {
-  const { chats, sortEpoch, softDelete, restore, setTitle, reload } =
-    useChats();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [mode, setMode] = useState<"main" | "trash">("main");
+  const [editingTitleId, setEditingTitleId] = useState<string | null>(null);
+
+  // The main view's sort preference is owned here, not inside useChatOrder, so
+  // the data path and the SortControl agree on one instance: the same field and
+  // direction decide whether to paginate.
+  const mainPref = useSortPreference(CHAT_SORT_CONFIG);
+
+  // Only the main view's descending time sorts page server-side (the keyset
+  // index covers createdAt/updatedAt DESC, per ADR-0017). Title sort, ascending
+  // time, and the Trash view stay on the full-load client path. The two read
+  // hooks always run (hooks rule); `enabled` decides which one fetches.
+  const paginate =
+    mode === "main" &&
+    (mainPref.field === "createdAt" || mainPref.field === "updatedAt") &&
+    mainPref.direction === "desc";
+  const pageSort: ListSort =
+    mainPref.field === "createdAt" ? "createdAt" : "updatedAt";
+
+  const full = useChats({ enabled: !paginate });
+  const paginated = usePaginatedChats(pageSort, { enabled: paginate });
+  const source = paginate ? paginated : full;
+  const { chats, sortEpoch, softDelete, restore, setTitle, reload } = source;
+
   const onAssignmentChange = useCallback(() => {
     void reload();
   }, [reload]);
@@ -37,9 +63,6 @@ function App() {
   const handleRenameTitle = (id: string, title: string) => {
     void setTitle(id, title);
   };
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [mode, setMode] = useState<"main" | "trash">("main");
-  const [editingTitleId, setEditingTitleId] = useState<string | null>(null);
   const { messages, error } = useMessages(selectedId);
   const { toast, showToast, dismissToast } = useToast();
 
@@ -56,7 +79,7 @@ function App() {
   // sortEpoch (user data actions) and viewGen (view switches) both flush the
   // frozen order; sort field/direction changes flush it inside the hook.
   const resortKey = `${sortEpoch}:${viewGen}`;
-  const mainOrder = useChatOrder("main", chats, resortKey);
+  const mainOrder = useChatOrder("main", chats, resortKey, mainPref);
   const trashOrder = useChatOrder("trash", chats, resortKey);
   const order = mode === "trash" ? trashOrder : mainOrder;
   const mainChats = mainOrder.orderedChats;
@@ -224,7 +247,6 @@ function App() {
       <ResizablePanelGroup orientation="horizontal">
         <ResizablePanel defaultSize={15} minSize={10}>
           <FilterPanel
-            deletedCount={deletedChats.length}
             onOpenTrash={() => switchMode("trash")}
             projectFacets={projectFacets}
             selectedProjects={selectedProjects}
@@ -253,10 +275,11 @@ function App() {
             onRestore={handleRestore}
             onRenameTitle={handleRenameTitle}
             onBack={() => switchMode("main")}
-            deletedCount={deletedChats.length}
             onOpenTrash={() => switchMode("trash")}
             sortSignature={`${mode}:${order.sortControlProps.field}:${order.sortControlProps.direction}`}
             sortControl={<SortControl {...order.sortControlProps} />}
+            hasMore={source.hasMore}
+            onLoadMore={source.loadMore}
           />
         </ResizablePanel>
         <ResizableHandle />

--- a/web/src/chat/ChatList.test.tsx
+++ b/web/src/chat/ChatList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import type { Chat } from "@/types";
@@ -86,5 +86,43 @@ describe("ChatList virtualization", () => {
     const rows = await screen.findAllByTestId("chat-row");
     expect(rows.length).toBeGreaterThan(0);
     expect(rows.length).toBeLessThan(total);
+  });
+});
+
+describe("ChatList infinite scroll", () => {
+  it("requests the next page when the rendered window nears the end", async () => {
+    const onLoadMore = vi.fn();
+    render(
+      <ChatList
+        chats={makeChats(8)}
+        selectedId={null}
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+        hasMore
+        onLoadMore={onLoadMore}
+      />
+    );
+
+    await screen.findAllByTestId("chat-row");
+    await waitFor(() => expect(onLoadMore).toHaveBeenCalled());
+  });
+
+  it("does not request more when there is no next page", async () => {
+    const onLoadMore = vi.fn();
+    render(
+      <ChatList
+        chats={makeChats(8)}
+        selectedId={null}
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+        hasMore={false}
+        onLoadMore={onLoadMore}
+      />
+    );
+
+    await screen.findAllByTestId("chat-row");
+    // Let the virtualizer settle (ResizeObserver fires asynchronously).
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(onLoadMore).not.toHaveBeenCalled();
   });
 });

--- a/web/src/chat/ChatList.tsx
+++ b/web/src/chat/ChatList.tsx
@@ -16,12 +16,20 @@ interface ChatListProps {
   onRestore?: (id: string) => void;
   onRenameTitle?: (id: string, title: string) => void;
   onBack?: () => void;
-  deletedCount?: number;
   onOpenTrash?: () => void;
   sortControl?: React.ReactNode;
   /** Changes whenever the active sort changes; drives keep-selection-visible scrolling. */
   sortSignature?: string;
+  /** True while a further page can be fetched; gates near-bottom loading. */
+  hasMore?: boolean;
+  /** Called when the user scrolls within a few rows of the loaded window's end. */
+  onLoadMore?: () => void;
 }
+
+// Trigger the next page once the rendered window reaches within this many rows
+// of the end, so the fetch overlaps the remaining scroll rather than stalling
+// at the very bottom.
+const LOAD_MORE_THRESHOLD = 5;
 
 function getProjectName(projectPath: string): string {
   const segments = projectPath.split("/").filter(Boolean);
@@ -107,10 +115,11 @@ export function ChatList({
   onRestore,
   onRenameTitle,
   onBack,
-  deletedCount = 0,
   onOpenTrash,
   sortControl,
   sortSignature,
+  hasMore = false,
+  onLoadMore,
 }: ChatListProps) {
   const [internalEditingId, setInternalEditingId] = useState<string | null>(
     null
@@ -145,16 +154,34 @@ export function ChatList({
   // through the virtualizer rather than relying on a DOM ref.
   useEffect(() => {
     if (prevSortSignature.current === sortSignature) return;
-    prevSortSignature.current = sortSignature;
     const selectedIndex = selectedId
       ? chats.findIndex((chat) => chat.id === selectedId)
       : -1;
+    // A sort change can swap the data source (paginated <-> full-load), whose
+    // chats arrive a tick later. If a selection exists but is not in the list
+    // yet, wait for it rather than consuming the signal and scrolling to top —
+    // the effect re-runs when chats update.
+    if (selectedId && selectedIndex < 0) return;
+    prevSortSignature.current = sortSignature;
     if (selectedIndex >= 0) {
       virtualizer.scrollToIndex(selectedIndex, { align: "auto" });
     } else if (scrollContainerRef.current) {
       scrollContainerRef.current.scrollTop = 0;
     }
   }, [sortSignature, selectedId, chats, virtualizer]);
+
+  // Fetch the next page as the rendered window nears the end of the loaded
+  // chats. The virtualizer only renders rows around the viewport, so the last
+  // virtual item's index tracks how far the user has scrolled without a manual
+  // scroll listener. onLoadMore guards against overlapping fetches itself.
+  const virtualItems = virtualizer.getVirtualItems();
+  const lastVisibleIndex = virtualItems[virtualItems.length - 1]?.index ?? -1;
+  useEffect(() => {
+    if (!hasMore || !onLoadMore) return;
+    if (lastVisibleIndex >= chats.length - 1 - LOAD_MORE_THRESHOLD) {
+      onLoadMore();
+    }
+  }, [hasMore, onLoadMore, lastVisibleIndex, chats.length]);
 
   useEffect(() => {
     if (!contextMenu) return;
@@ -226,7 +253,7 @@ export function ChatList({
             ) : (
               <>
                 <div className="font-medium text-foreground">No chats</div>
-                {deletedCount > 0 && onOpenTrash && (
+                {onOpenTrash && (
                   <div className="mt-1 text-xs">
                     Check{" "}
                     <button
@@ -234,7 +261,7 @@ export function ChatList({
                       onClick={onOpenTrash}
                       className="text-primary hover:underline"
                     >
-                      Trash ({deletedCount})
+                      Trash
                     </button>{" "}
                     to restore deleted ones.
                   </div>

--- a/web/src/chat/FilterPanel.tsx
+++ b/web/src/chat/FilterPanel.tsx
@@ -7,7 +7,6 @@ import type { Tag } from "@/types";
 import type { ColorToken } from "@/tags/palette";
 
 interface FilterPanelProps {
-  deletedCount: number;
   onOpenTrash: () => void;
   projectFacets: ProjectFacet[];
   selectedProjects: ReadonlySet<string>;
@@ -24,7 +23,6 @@ interface FilterPanelProps {
 }
 
 export function FilterPanel({
-  deletedCount,
   onOpenTrash,
   projectFacets,
   selectedProjects,
@@ -67,23 +65,18 @@ export function FilterPanel({
         />
       </div>
       <div className="flex h-12 shrink-0 items-center border-t border-border px-2">
+        {/* No count badge: the active window does not know the full trashed
+            total without a full load, and the list is moving to paginated reads,
+            so the count is dropped rather than shown
+            per-mode. The Trash view itself still lists everything. */}
         <button
           type="button"
           data-testid="trash-link"
           onClick={onOpenTrash}
-          className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-card"
+          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-card"
         >
-          <span className="flex items-center gap-2">
-            <Trash2 size={14} aria-hidden="true" />
-            Trash
-          </span>
-          {/* A muted, pill-less count that only appears when Trash is non-empty:
-              a quiet "there's something in here" signal, not a headline metric. */}
-          {deletedCount > 0 && (
-            <span className="text-xs tabular-nums text-muted-foreground">
-              {deletedCount}
-            </span>
-          )}
+          <Trash2 size={14} aria-hidden="true" />
+          Trash
         </button>
       </div>
     </div>

--- a/web/src/chat/sort/useChatOrder.test.tsx
+++ b/web/src/chat/sort/useChatOrder.test.tsx
@@ -102,6 +102,33 @@ describe("useChatOrder", () => {
     expect(ids(result.current.orderedChats)).toEqual(["b", "d", "c", "a"]);
   });
 
+  it("keeps a chat that appeared in one background refresh frozen across the next", () => {
+    const { result, rerender } = renderHook(
+      ({ chats, signal }) => useChatOrder("main", chats, signal),
+      { initialProps: { chats: activeChats(), signal: "0:0" } }
+    );
+    expect(ids(result.current.orderedChats)).toEqual(["b", "c", "a"]);
+
+    // First background refresh surfaces "d" (250), slotting it between b and c.
+    rerender({
+      chats: [...activeChats(), chat("d", { updatedAt: 250 })],
+      signal: "0:0",
+    });
+    expect(ids(result.current.orderedChats)).toEqual(["b", "d", "c", "a"]);
+
+    // A later refresh bumps "d" to the newest updatedAt. A live re-slot would
+    // float it to the top; the frozen window holds it where it first landed —
+    // the loaded window stays frozen, not just the first anchor.
+    const bumped = [
+      chat("a", { updatedAt: 100 }),
+      chat("b", { updatedAt: 300 }),
+      chat("c", { updatedAt: 200 }),
+      chat("d", { updatedAt: 999 }),
+    ];
+    rerender({ chats: bumped, signal: "0:0" });
+    expect(ids(result.current.orderedChats)).toEqual(["b", "d", "c", "a"]);
+  });
+
   it("re-sorts when the user changes the sort field via sortControlProps", () => {
     const { result } = renderHook(() =>
       useChatOrder("main", activeChats(), "0:0")

--- a/web/src/chat/sort/useChatOrder.ts
+++ b/web/src/chat/sort/useChatOrder.ts
@@ -9,7 +9,10 @@ import {
   TRASH_SORT_AXES,
   TRASH_SORT_CONFIG,
 } from "@/chat/sort/sortConfig";
-import { useSortPreference } from "@/chat/sort/useSortPreference";
+import {
+  useSortPreference,
+  type UseSortPreferenceResult,
+} from "@/chat/sort/useSortPreference";
 import { useFrozenSort } from "@/chat/sort/useFrozenSort";
 
 export type ChatView = "main" | "trash";
@@ -46,13 +49,22 @@ const VIEWS = {
 // it once per view (main, trash). `flushSignal` is passed in — the hook is a
 // pure function of (view, chats, flushSignal) and does not know the signal is
 // itself composed of a data-action epoch and a view-switch generation.
+//
+// `externalPref` lets the caller own the preference instead of the hook. App
+// uses this for the main view so it can read the same field/direction the
+// SortControl drives and decide whether the data path paginates — the two must
+// agree on a single preference instance, not two copies of the same storage.
 export function useChatOrder(
   view: ChatView,
   chats: Chat[],
-  flushSignal: string
+  flushSignal: string,
+  externalPref?: UseSortPreferenceResult<SortField>
 ): ChatOrder {
   const { config, axes, directionLabels, testId, includes } = VIEWS[view];
-  const pref = useSortPreference(config);
+  // Hooks must run unconditionally; when the caller supplies a preference the
+  // internal one is left idle (its setters are never wired up).
+  const ownPref = useSortPreference(config);
+  const pref = externalPref ?? ownPref;
   const orderedChats = useFrozenSort(
     chats.filter(includes),
     pref.field,

--- a/web/src/chat/sort/useFrozenSort.ts
+++ b/web/src/chat/sort/useFrozenSort.ts
@@ -12,12 +12,20 @@ interface Anchor {
   ids: string[];
 }
 
+function sameIds(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((id, i) => id === b[i]);
+}
+
 // Sort `chats`, but freeze the resulting row order across background data
 // changes. The order is anchored when `resortKey` (or the sort field/direction)
 // changes — a user-driven sort change, view switch, or data action — and held
-// otherwise: background changes never move existing rows, while newly-appearing
-// chats are slotted into their sorted position relative to the anchor (see
-// applyHeldOrder).
+// otherwise: background changes never move existing rows.
+//
+// The anchor freezes the whole loaded window, not just the first page. As new
+// chats appear (a fetched next page, or background ingestion), each is slotted
+// into its sorted position relative to the held rows (see applyHeldOrder) and
+// then folded into the anchor, so a later refresh holds it where it first
+// landed rather than re-sorting it under the user.
 export function useFrozenSort(
   chats: Chat[],
   field: SortField,
@@ -29,24 +37,33 @@ export function useFrozenSort(
 
   // Store the anchored order in state and re-anchor when the key changes. This
   // is React's sanctioned "adjust state during render" pattern: setting state
-  // during render bails out and re-renders immediately, so the freshly-sorted
-  // order shows without a one-frame flicker.
+  // during render bails out and re-renders immediately, so the new order shows
+  // without a one-frame flicker.
   const [anchor, setAnchor] = useState<Anchor>(() => ({
     key,
     ids: fresh.map((c) => c.id),
   }));
 
-  // Re-anchor on a key change, or when the current anchor is empty — the latter
-  // covers the initial load, where the first render anchors before the fetch has
-  // populated `chats`. Until a non-empty anchor is captured, freezing is a no-op.
-  const needsAnchor = anchor.key !== key || anchor.ids.length === 0;
-  if (needsAnchor) {
-    const ids = fresh.map((c) => c.id);
-    if (anchor.key !== key || ids.length !== anchor.ids.length) {
-      setAnchor({ key, ids });
-    }
+  // A key change is an explicit re-sort: drop the held window and re-anchor to
+  // the fresh order.
+  if (anchor.key !== key) {
+    setAnchor({ key, ids: fresh.map((c) => c.id) });
     return fresh;
   }
 
-  return applyHeldOrder(fresh, anchor.ids);
+  // Same key: hold existing rows, slot newcomers by the fresh sort. This also
+  // covers the initial load, where the first render anchors an empty window
+  // before the fetch resolves and the first page then grows it.
+  const held = applyHeldOrder(fresh, anchor.ids);
+  const heldIds = held.map((c) => c.id);
+
+  // Grow (or shrink) the anchor to match the held window so slotted newcomers —
+  // and the removal of any departed rows — persist into the next render.
+  // Without this the anchor stays stuck on the first page and later refreshes
+  // would re-slot rows that have already been placed.
+  if (!sameIds(heldIds, anchor.ids)) {
+    setAnchor({ key, ids: heldIds });
+  }
+
+  return held;
 }

--- a/web/src/chat/useChatMutations.ts
+++ b/web/src/chat/useChatMutations.ts
@@ -1,0 +1,92 @@
+import { useCallback } from "react";
+import type { Chat } from "@/types";
+
+export interface ChatMutations {
+  softDelete: (id: string) => Promise<void>;
+  restore: (id: string) => Promise<void>;
+  setTitle: (id: string, title: string) => Promise<void>;
+}
+
+// The shared shape both chat-list read hooks expose: the loaded chats plus the
+// windowing controls and write actions. App picks one source (full-load or
+// paginated) by mode and treats them interchangeably through this interface.
+export interface ChatListSource extends ChatMutations {
+  chats: Chat[];
+  loading: boolean;
+  // Increments on user-initiated changes (rename, delete, restore) only, so the
+  // frozen order re-anchors on a real action but holds under background refresh.
+  sortEpoch: number;
+  // True while a further page can be fetched (always false on the full path).
+  hasMore: boolean;
+  // Fetch the next page (a no-op on the full path).
+  loadMore: () => void;
+  // Re-read and re-sort the loaded chats (used after a tag assignment changes
+  // the chips a chat shows).
+  reload: () => Promise<void>;
+}
+
+// The chat write actions (trash / restore / rename), shared by both the
+// full-load and paginated read hooks. Each applies the same optimistic local
+// update — so the UI reflects the change before the server round-trip — then
+// bumps the sort epoch to flush the frozen order, mirroring the server
+// contract. The caller supplies the state updater, the epoch bump, and the
+// reload used to recover when a rename is cleared to empty.
+export function useChatMutations(
+  setChats: (updater: (prev: Chat[]) => Chat[]) => void,
+  bumpEpoch: () => void,
+  reload: () => Promise<void>
+): ChatMutations {
+  const softDelete = useCallback(
+    async (id: string) => {
+      // Mirror the server contract optimistically so the Trash view sorts by a
+      // real Deleted time immediately, before any refetch.
+      const now = Date.now();
+      setChats((prev) =>
+        prev.map((c) =>
+          c.id === id ? { ...c, isDeleted: true, deletedAt: now } : c
+        )
+      );
+      bumpEpoch();
+      await fetch(`/api/chats/${encodeURIComponent(id)}`, { method: "DELETE" });
+    },
+    [setChats, bumpEpoch]
+  );
+
+  const restore = useCallback(
+    async (id: string) => {
+      setChats((prev) =>
+        prev.map((c) =>
+          c.id === id ? { ...c, isDeleted: false, deletedAt: null } : c
+        )
+      );
+      bumpEpoch();
+      await fetch(`/api/chats/${encodeURIComponent(id)}/restore`, {
+        method: "POST",
+      });
+    },
+    [setChats, bumpEpoch]
+  );
+
+  const setTitle = useCallback(
+    async (id: string, title: string) => {
+      const trimmed = title.trim();
+      if (trimmed.length > 0) {
+        setChats((prev) =>
+          prev.map((c) => (c.id === id ? { ...c, title: trimmed } : c))
+        );
+        bumpEpoch();
+      }
+      await fetch(`/api/chats/${encodeURIComponent(id)}/title`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title }),
+      });
+      if (trimmed.length === 0) {
+        await reload();
+      }
+    },
+    [setChats, bumpEpoch, reload]
+  );
+
+  return { softDelete, restore, setTitle };
+}

--- a/web/src/chat/useChats.ts
+++ b/web/src/chat/useChats.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { Chat } from "@/types";
+import { useChatMutations, type ChatListSource } from "@/chat/useChatMutations";
 
 // How often the UI re-reads the chat list while running, so file-watcher
 // ingestion (new chats, bumped `updatedAt`) shows up without a manual reload.
@@ -7,23 +8,18 @@ import type { Chat } from "@/types";
 // order stays frozen under the user until they next act on it (see App).
 const BACKGROUND_REFRESH_MS = 4000;
 
-interface UseChatsResult {
-  chats: Chat[];
-  loading: boolean;
-  // Increments on user-initiated changes (rename, delete, restore) only.
-  // Background refreshes leave it untouched. App keys its frozen sort order on
-  // this so background updates never re-sort the list under the user.
-  sortEpoch: number;
-  softDelete: (id: string) => Promise<void>;
-  restore: (id: string) => Promise<void>;
-  setTitle: (id: string, title: string) => Promise<void>;
-  // Re-pull the list and re-sort. Used after a tag assignment changes the
-  // chips/dots a chat shows, so the change lands without waiting for the
-  // background refresh interval.
-  reload: () => Promise<void>;
+interface UseChatsOptions {
+  // The full-load path backs the Trash view, the Title sort, and ascending time
+  // sorts. The main view's descending time sorts page server-side instead, so
+  // this hook is disabled then to honor "no longer pulling all Chats" (#129).
+  enabled?: boolean;
 }
 
-export function useChats(): UseChatsResult {
+// The full-list read path: pulls every chat (active + trashed) in one request
+// and refreshes on an interval. Used wherever pagination does not apply.
+export function useChats({
+  enabled = true,
+}: UseChatsOptions = {}): ChatListSource {
   const [chats, setChats] = useState<Chat[]>([]);
   const [loading, setLoading] = useState(true);
   const [sortEpoch, setSortEpoch] = useState(0);
@@ -49,6 +45,7 @@ export function useChats(): UseChatsResult {
   }, [refresh, bumpEpoch]);
 
   useEffect(() => {
+    if (!enabled) return;
     let cancelled = false;
     fetch("/api/chats?includeTrashed=true")
       .then((res) => res.json() as Promise<{ chats: Chat[] }>)
@@ -62,68 +59,33 @@ export function useChats(): UseChatsResult {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [enabled]);
 
   useEffect(() => {
+    if (!enabled) return;
     const id = setInterval(() => {
       void refresh();
     }, BACKGROUND_REFRESH_MS);
     return () => clearInterval(id);
-  }, [refresh]);
+  }, [enabled, refresh]);
 
-  const softDelete = useCallback(
-    async (id: string) => {
-      // Mirror the server contract optimistically so the Trash view sorts by a
-      // real Deleted time immediately, before any refetch.
-      const now = Date.now();
-      setChats((prev) =>
-        prev.map((c) =>
-          c.id === id ? { ...c, isDeleted: true, deletedAt: now } : c
-        )
-      );
-      bumpEpoch();
-      await fetch(`/api/chats/${encodeURIComponent(id)}`, {
-        method: "DELETE",
-      });
-    },
-    [bumpEpoch]
+  const { softDelete, restore, setTitle } = useChatMutations(
+    setChats,
+    bumpEpoch,
+    reload
   );
 
-  const restore = useCallback(
-    async (id: string) => {
-      setChats((prev) =>
-        prev.map((c) =>
-          c.id === id ? { ...c, isDeleted: false, deletedAt: null } : c
-        )
-      );
-      bumpEpoch();
-      await fetch(`/api/chats/${encodeURIComponent(id)}/restore`, {
-        method: "POST",
-      });
-    },
-    [bumpEpoch]
-  );
-
-  const setTitle = useCallback(
-    async (id: string, title: string) => {
-      const trimmed = title.trim();
-      if (trimmed.length > 0) {
-        setChats((prev) =>
-          prev.map((c) => (c.id === id ? { ...c, title: trimmed } : c))
-        );
-        bumpEpoch();
-      }
-      await fetch(`/api/chats/${encodeURIComponent(id)}/title`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ title }),
-      });
-      if (trimmed.length === 0) {
-        await reload();
-      }
-    },
-    [bumpEpoch, reload]
-  );
-
-  return { chats, loading, sortEpoch, softDelete, restore, setTitle, reload };
+  return {
+    chats,
+    // While disabled the hook neither fetches nor owns a meaningful loading
+    // state, so report "settled" rather than touching state from an effect.
+    loading: enabled ? loading : false,
+    sortEpoch,
+    hasMore: false,
+    loadMore: () => {},
+    reload,
+    softDelete,
+    restore,
+    setTitle,
+  };
 }

--- a/web/src/chat/usePaginatedChats.test.tsx
+++ b/web/src/chat/usePaginatedChats.test.tsx
@@ -1,0 +1,131 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { describe, it, expect } from "vitest";
+import { usePaginatedChats } from "@/chat/usePaginatedChats";
+import { fakeChats } from "@/test/handlers";
+import { server } from "@/test/server";
+
+// Active fake chats by updatedAt desc: chat-2 (300), chat-1 (200), chat-3 (150),
+// chat-missing (1699999900000). Deleted chats are excluded from the active list.
+describe("usePaginatedChats", () => {
+  it("loads the first page sorted by updatedAt descending", async () => {
+    const { result } = renderHook(() =>
+      usePaginatedChats("updatedAt", { pageSize: 2 })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.chats.map((c) => c.id)).toEqual(["chat-2", "chat-1"]);
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("loads the first page sorted by createdAt descending", async () => {
+    // Active by createdAt desc: chat-2 (1700000100000), chat-3 (1700000050000),
+    // chat-1 (1700000000000), chat-missing (1699999900000).
+    const { result } = renderHook(() =>
+      usePaginatedChats("createdAt", { pageSize: 2 })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.chats.map((c) => c.id)).toEqual(["chat-2", "chat-3"]);
+  });
+
+  it("fetches the next page by cursor and appends it below the window", async () => {
+    const { result } = renderHook(() =>
+      usePaginatedChats("updatedAt", { pageSize: 2 })
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.chats.map((c) => c.id)).toEqual(["chat-2", "chat-1"]);
+
+    act(() => result.current.loadMore());
+
+    await waitFor(() =>
+      expect(result.current.chats.map((c) => c.id)).toEqual([
+        "chat-2",
+        "chat-1",
+        "chat-3",
+        "chat-missing",
+      ])
+    );
+    // All four active chats are loaded; no further page remains.
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("does not fetch more once the last page is reached", async () => {
+    // A page large enough to hold every active chat: first page is the last.
+    const { result } = renderHook(() =>
+      usePaginatedChats("updatedAt", { pageSize: 50 })
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.hasMore).toBe(false);
+    const before = result.current.chats.map((c) => c.id);
+
+    act(() => result.current.loadMore());
+
+    // No cursor means no request; the window is unchanged.
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.chats.map((c) => c.id)).toEqual(before);
+  });
+
+  it("merges field updates and brand-new chats on a background refresh without dropping loaded rows", async () => {
+    const { result } = renderHook(() =>
+      usePaginatedChats("updatedAt", { pageSize: 2 })
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.chats.map((c) => c.id)).toEqual(["chat-2", "chat-1"]);
+
+    // Background ingestion: bump a loaded row and surface a brand-new chat that
+    // now ranks at the very top by updatedAt.
+    const loaded = fakeChats.find((c) => c.id === "chat-1")!;
+    loaded.updatedAt = 1700000400000;
+    fakeChats.push({
+      id: "chat-new",
+      sourceId: "CHATNW",
+      agent: "claude-code",
+      defaultTitle: "Fresh chat",
+      customTitle: null,
+      project: "my-web-app",
+      projectPath: "/Users/test/my-web-app",
+      sourceFilePath: null,
+      createdAt: 1700000500000,
+      updatedAt: 1700000500000,
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    const byId = new Map(result.current.chats.map((c) => [c.id, c]));
+    // The brand-new chat is surfaced; the previously-loaded rows are retained
+    // (chat-1 is absent from the refetched top-2 but must not vanish).
+    expect(byId.has("chat-new")).toBe(true);
+    expect(byId.has("chat-1")).toBe(true);
+    expect(byId.has("chat-2")).toBe(true);
+    // The retained row carries its refreshed field value.
+    expect(byId.get("chat-1")!.updatedAt).toBe(1700000400000);
+  });
+
+  it("ignores a failed background refresh instead of crashing", async () => {
+    const { result } = renderHook(() =>
+      usePaginatedChats("updatedAt", { pageSize: 2 })
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const before = result.current.chats.map((c) => c.id);
+
+    // The next list read fails (e.g. once the loaded window grows past the cap,
+    // a window-sized limit is rejected with 400 — the bug that blanked the app).
+    server.use(
+      http.get("/api/chats", () =>
+        HttpResponse.json({ error: "Invalid limit" }, { status: 400 })
+      )
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    // Refresh is a no-op on failure; the window stays intact, nothing throws.
+    expect(result.current.chats.map((c) => c.id)).toEqual(before);
+  });
+});

--- a/web/src/chat/usePaginatedChats.ts
+++ b/web/src/chat/usePaginatedChats.ts
@@ -1,0 +1,186 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Chat } from "@/types";
+import { useChatMutations, type ChatListSource } from "@/chat/useChatMutations";
+
+// The two time axes the keyset page endpoint supports (#129 / ADR-0017). Title
+// and ascending time stay on the full-load client path, so they never reach here.
+export type ListSort = "createdAt" | "updatedAt";
+
+const DEFAULT_PAGE_SIZE = 30;
+
+// The keyset endpoint rejects a `limit` over this cap (backend MAX_PAGE_LIMIT,
+// #142). The window can grow past it via loadMore, so any window-sized request
+// must clamp to it — otherwise the server returns 400 and the response carries
+// no `chats`.
+const MAX_PAGE_LIMIT = 200;
+
+// How often the loaded window re-reads from the server, so file-watcher
+// ingestion (new chats, bumped timestamps) shows up without a manual reload.
+// Mirrors the full-load path's cadence (see useChats).
+const BACKGROUND_REFRESH_MS = 4000;
+
+// Merge a freshly-fetched window into the loaded one: refresh fields for chats
+// the server still returns, keep loaded chats the refetch no longer covers (the
+// window only grows under a background refresh — rows never vanish), and append
+// brand-new chats. Ordering is left to the frozen-sort layer.
+function mergeWindow(loaded: Chat[], incoming: Chat[]): Chat[] {
+  const incomingById = new Map(incoming.map((c) => [c.id, c]));
+  const loadedIds = new Set(loaded.map((c) => c.id));
+  const merged = loaded.map((c) => incomingById.get(c.id) ?? c);
+  const added = incoming.filter((c) => !loadedIds.has(c.id));
+  return [...merged, ...added];
+}
+
+interface UsePaginatedChatsOptions {
+  /** Page size for the keyset `limit`. */
+  pageSize?: number;
+  // Active only when the main view sorts by a descending time axis. When off,
+  // the hook holds an empty window and issues no requests (the full-load path
+  // is serving instead).
+  enabled?: boolean;
+}
+
+// Adds the window-reconciling background refresh to the shared source shape; the
+// refresh is exposed so the interval and tests can drive it directly.
+type UsePaginatedChatsResult = ChatListSource & {
+  refresh: () => Promise<void>;
+};
+
+interface PageResponse {
+  chats: Chat[];
+  nextCursor: string | null;
+}
+
+function pageUrl(sort: ListSort, limit: number, cursor?: string): string {
+  const base = `/api/chats?sort=${sort}&limit=${limit}`;
+  return cursor ? `${base}&cursor=${encodeURIComponent(cursor)}` : base;
+}
+
+// Fetch one page, returning null on any failure (non-OK status, network error,
+// or a body without a `chats` array) so callers never feed `undefined` into the
+// window. A rejected request (e.g. limit over the cap) is a no-op, not a crash.
+async function fetchPage(url: string): Promise<PageResponse | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const data = (await res.json()) as Partial<PageResponse>;
+    if (!Array.isArray(data.chats)) return null;
+    return { chats: data.chats, nextCursor: data.nextCursor ?? null };
+  } catch {
+    return null;
+  }
+}
+
+// Owns the paginated chat-list read path: first page on mount plus a keyset
+// cursor for fetching more. Used only when the main view sorts by a time axis
+// descending; every other case stays on the full-load `useChats` path.
+export function usePaginatedChats(
+  sort: ListSort,
+  {
+    pageSize = DEFAULT_PAGE_SIZE,
+    enabled = true,
+  }: UsePaginatedChatsOptions = {}
+): UsePaginatedChatsResult {
+  const [chats, setChats] = useState<Chat[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [sortEpoch, setSortEpoch] = useState(0);
+  const bumpEpoch = useCallback(() => setSortEpoch((e) => e + 1), []);
+
+  // The cursor is read inside loadMore, which is called from event handlers that
+  // close over a stale render. A ref keeps the live cursor without re-creating
+  // the callback. `fetching` guards against overlapping page fetches (e.g. a
+  // near-bottom detector firing twice before the next page resolves).
+  const cursorRef = useRef<string | null>(null);
+  const fetchingRef = useRef(false);
+  // The live window, read by refresh (called from an interval / event handler
+  // that closes over a stale render) to size the refetch and merge into. Synced
+  // after commit — refresh only ever runs post-render, so it sees the latest.
+  const chatsRef = useRef<Chat[]>(chats);
+  useEffect(() => {
+    chatsRef.current = chats;
+  }, [chats]);
+
+  // (Re)load the first page whenever the sort axis changes or the hook is
+  // enabled — resetting the window so the new axis re-anchors from its top.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    cursorRef.current = null;
+    fetchingRef.current = true;
+    void fetchPage(pageUrl(sort, pageSize)).then((data) => {
+      if (cancelled) return;
+      if (data) {
+        setChats(data.chats);
+        setNextCursor(data.nextCursor);
+        cursorRef.current = data.nextCursor;
+      }
+      fetchingRef.current = false;
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [sort, pageSize, enabled]);
+
+  const loadMore = useCallback(() => {
+    if (fetchingRef.current || cursorRef.current === null) return;
+    const cursor = cursorRef.current;
+    fetchingRef.current = true;
+    void fetchPage(pageUrl(sort, pageSize, cursor)).then((data) => {
+      if (data) {
+        setChats((prev) => [...prev, ...data.chats]);
+        setNextCursor(data.nextCursor);
+        cursorRef.current = data.nextCursor;
+      }
+      fetchingRef.current = false;
+    });
+  }, [sort, pageSize]);
+
+  // Re-read the top of the loaded window. Sized to the current window so a
+  // brand-new chat ranking into it is surfaced, but clamped to the page-limit
+  // cap so a large window never asks for more than the endpoint allows. Merged
+  // so existing rows keep their place; the downward cursor is left untouched —
+  // refresh reconciles the window's head, loadMore continues from its tail.
+  const refresh = useCallback(async () => {
+    const limit = Math.min(
+      Math.max(chatsRef.current.length, pageSize),
+      MAX_PAGE_LIMIT
+    );
+    const data = await fetchPage(pageUrl(sort, limit));
+    if (data) setChats((prev) => mergeWindow(prev, data.chats));
+  }, [sort, pageSize]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const id = setInterval(() => {
+      void refresh();
+    }, BACKGROUND_REFRESH_MS);
+    return () => clearInterval(id);
+  }, [enabled, refresh]);
+
+  // A user-initiated reload: reconcile the window, then re-anchor the order.
+  const reload = useCallback(async () => {
+    await refresh();
+    bumpEpoch();
+  }, [refresh, bumpEpoch]);
+
+  const { softDelete, restore, setTitle } = useChatMutations(
+    setChats,
+    bumpEpoch,
+    reload
+  );
+
+  return {
+    chats,
+    loading: enabled ? loading : false,
+    sortEpoch,
+    hasMore: nextCursor !== null,
+    loadMore,
+    reload,
+    refresh,
+    softDelete,
+    restore,
+    setTitle,
+  };
+}

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -216,10 +216,64 @@ export const handlers = [
   http.get("/api/chats", ({ request }) => {
     const url = new URL(request.url);
     const includeTrashed = url.searchParams.get("includeTrashed") === "true";
-    const filtered = includeTrashed
+    const visible = includeTrashed
       ? fakeChats
       : fakeChats.filter((c) => !c.isDeleted);
-    return HttpResponse.json({ chats: filtered.map(projectChat) });
+
+    // Paginated mode mirrors the merged backend (#142): `?limit=` opts into one
+    // server-sorted keyset page (always sortKey DESC, id DESC tiebreak), with an
+    // opaque cursor and `nextCursor` (null on the last page). The cursor's wire
+    // shape is opaque to the frontend; this fake uses base64 JSON of (sortKey,id)
+    // for internal consistency, not byte-for-byte parity with the real encoder.
+    const limitParam = url.searchParams.get("limit");
+    if (limitParam !== null) {
+      const limit = Number.parseInt(limitParam, 10);
+      // Mirror the backend's keyset cap (MAX_PAGE_LIMIT = 200): a larger limit is
+      // rejected, so the client must never request more than the cap.
+      if (!Number.isInteger(limit) || limit <= 0 || limit > 200) {
+        return HttpResponse.json({ error: "Invalid limit" }, { status: 400 });
+      }
+      const sort =
+        url.searchParams.get("sort") === "createdAt"
+          ? "createdAt"
+          : "updatedAt";
+      const sortKeyOf = (c: FakeChat) =>
+        sort === "createdAt" ? c.createdAt : c.updatedAt;
+      const sorted = [...visible].sort(
+        (a, b) =>
+          sortKeyOf(b) - sortKeyOf(a) ||
+          (a.id < b.id ? 1 : a.id > b.id ? -1 : 0)
+      );
+      const cursorParam = url.searchParams.get("cursor");
+      let start = 0;
+      if (cursorParam) {
+        const cur = JSON.parse(
+          Buffer.from(cursorParam, "base64url").toString("utf8")
+        ) as { sortKey: number; id: string };
+        const after = sorted.findIndex(
+          (c) =>
+            sortKeyOf(c) < cur.sortKey ||
+            (sortKeyOf(c) === cur.sortKey && c.id < cur.id)
+        );
+        start = after < 0 ? sorted.length : after;
+      }
+      const pageItems = sorted.slice(start, start + limit);
+      const hasMore = start + limit < sorted.length;
+      const last = pageItems[pageItems.length - 1];
+      const nextCursor =
+        hasMore && last
+          ? Buffer.from(
+              JSON.stringify({ sortKey: sortKeyOf(last), id: last.id }),
+              "utf8"
+            ).toString("base64url")
+          : null;
+      return HttpResponse.json({
+        chats: pageItems.map(projectChat),
+        nextCursor,
+      });
+    }
+
+    return HttpResponse.json({ chats: visible.map(projectChat) });
   }),
   http.patch("/api/chats/:id/title", async ({ params, request }) => {
     const id = params.id as string;

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -69,6 +69,7 @@ beforeAll(() => server.listen());
 afterEach(() => {
   cleanup();
   server.resetHandlers();
+  server.events.removeAllListeners();
   resetFakeChats();
   localStorage.clear();
 });


### PR DESCRIPTION
## Background (Why)

Issue #129 moves sort and windowing into the server query so the frontend stops loading the full Chat list. The backend half (sorted keyset endpoint) shipped in #142. This PR is the frontend half: load the first page fast, fetch more on scroll, and freeze the order within the loaded window across background refreshes. It targets the shared `integration/server-side-list-pipeline` branch, not `main`.

## Approach (How)

The main view branches by mode. Descending time sorts (createdAt/updatedAt) are the only axes the keyset index serves (ADR-0017), so they page server-side; Title sort, ascending time, and the Trash view stay on the existing full-load client path. Both read paths expose one `ChatListSource` shape, so `App` swaps between them by mode and treats them interchangeably.

Order is frozen per loaded window rather than per first page: the frozen-sort anchor grows as pages (and background-surfaced chats) arrive, so existing rows never reorder under a refresh while new rows slot in and stay put. Re-sort happens only on explicit actions (sort change, view switch, trash/restore).

## Changes (What)

- [x] `usePaginatedChats` — first page on mount, cursor-based `loadMore`, and a window-reconciling background refresh (`mergeWindow`)
- [x] `useChatMutations` — shared trash/restore/rename, used by both the full-load and paginated read hooks
- [x] `useFrozenSort` — anchor grows with the loaded window, freezing the whole window (not just the first page) across background refreshes
- [x] `ChatList` — near-bottom detection triggers `loadMore`
- [x] `App` — owns the main sort preference and routes paginated vs full-load
- [x] Background refresh clamps its window-sized `limit` to the keyset cap (200) and treats any non-OK/malformed page as a no-op, fixing a blank-screen crash once the loaded window exceeded the cap
- [x] Trash count and project/tag facet count badges dropped from the default view (see Additional Notes)

### Test Verification

- [x] First page loads via the keyset endpoint sorted by updatedAt/createdAt desc
- [x] `loadMore` fetches the next page by cursor and appends below the window; no fetch once `nextCursor` is null
- [x] Window stays frozen across background refreshes; brand-new chats append without reordering existing rows; later pages stay frozen too
- [x] Title sort, ascending time, and the Trash view use the full-load path
- [x] Background refresh ignores a rejected/oversized response instead of crashing (regression for the blank-screen bug)
- [x] e2e (`chat-list-pagination.spec.ts`): real scroll loads more pages; a window grown past the 200 cap does not blank out
- [x] Full suites green: api 227, web 165, 2 e2e; ESLint + tsc clean

## Additional Notes

- **Known interim degradation — not the intended end state.** In paginated mode the Trash count and the project/tag facet counts can only see the loaded window, so the previous full-list count badges are dropped (the Trash link and facets still work; only the numbers are gone). This is temporary. Accurate server-side counts land in #131 (filter-aware via #130); until the whole list pipeline merges to `main`, only the integration branch carries this — `main` is unaffected.

- Project/tag filtering currently still runs client-side over the loaded window (also window-limited at scale); moving it server-side is #130. Search filtering named in #130 has no feature in the app yet and should be split out.

- Follow-up: `MAX_PAGE_LIMIT = 200` is duplicated in the frontend and backend; a shared contract would prevent drift if the cap changes (candidate for #143–#146).

## Related Links

- Closes #129
- Backend half: #142
- Follow-ups: #130 (server-side filtering), #131 (server-side facet counts)