### PR TITLE
feat: apply project/tag filtering inside the paginated query

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -173,6 +173,55 @@ describe("GET /api/chats — keyset pagination mode", () => {
     expect(defBody.chats.map((c) => c.sourceId)).toEqual(["c3", "c2"]);
   });
 
+  it("applies the Project and Tag filters server-side in paginated mode", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const alpha1 = seedChat(archive, {
+      sourceId: "alpha1",
+      firstSeenAt: new Date(1_000),
+      project: "alpha",
+    });
+    seedChat(archive, {
+      sourceId: "beta1",
+      firstSeenAt: new Date(2_000),
+      project: "beta",
+    });
+    seedChat(archive, {
+      sourceId: "alpha2",
+      firstSeenAt: new Date(3_000),
+      project: "alpha",
+    });
+    const urgent = tags.createTag("urgent", "violet");
+    tags.assignTag(alpha1, urgent.id);
+
+    const app = createApp({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+
+    // Repeated `?project=` unions; the page is filtered to alpha, newest-first.
+    const byProject = await app.request(
+      "/api/chats?sort=createdAt&limit=10&project=alpha"
+    );
+    expect(byProject.status).toBe(200);
+    const byProjectBody = (await byProject.json()) as { chats: ChatResponse[] };
+    expect(byProjectBody.chats.map((c) => c.sourceId)).toEqual([
+      "alpha2",
+      "alpha1",
+    ]);
+
+    // Comma-separated `?tags=` ANDs; only the chat holding the Tag passes.
+    const byTag = await app.request(
+      `/api/chats?sort=createdAt&limit=10&tags=${urgent.id}`
+    );
+    const byTagBody = (await byTag.json()) as { chats: ChatResponse[] };
+    expect(byTagBody.chats.map((c) => c.sourceId)).toEqual(["alpha1"]);
+  });
+
   it("rejects an invalid sort with 400", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -70,12 +70,23 @@ export function createApp({
       if (direction !== "asc" && direction !== "desc") {
         return c.json({ error: "Invalid direction" }, 400);
       }
+      // The active filter pages server-side alongside the keyset window (#130),
+      // parsed the same way as the legacy full-list branch: repeated `?project=`
+      // unions (OR), a single comma-separated `?tags=` ANDs. An empty value
+      // selects the `(No project)` / `Untagged` group; an absent param is
+      // undefined => unfiltered.
+      const projects = c.req.queries("project");
+      const tagsParam = c.req.query("tags");
+      const tagSelection =
+        tagsParam === undefined ? undefined : tagsParam.split(",");
       const { chats, nextCursor } = reader.listChatsPage({
         sort,
         direction,
         limit,
         cursor: c.req.query("cursor"),
         includeTrashed,
+        projects,
+        tags: tagSelection,
       });
       return c.json({ chats, nextCursor });
     }

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -100,6 +100,18 @@ export interface ChatReader {
     limit: number;
     cursor?: string;
     includeTrashed?: boolean;
+    /**
+     * Project filter (OR / union), applied server-side inside the keyset query
+     * (#130). An empty-string entry selects the `(No project)` group; omitting
+     * it leaves Projects unfiltered.
+     */
+    projects?: string[];
+    /**
+     * Tag filter (AND / intersection), applied server-side inside the keyset
+     * query (#130). An empty-string entry selects the `Untagged` group; omitting
+     * it leaves Tags unfiltered.
+     */
+    tags?: string[];
   }): { chats: ChatResponse[]; nextCursor: string | null };
   /**
    * The filter-panel facet counts and the unfiltered List count for a view
@@ -277,12 +289,16 @@ export function createChatReader({
     limit,
     cursor,
     includeTrashed = false,
+    projects,
+    tags: tagSelection,
   }: {
     sort: ListSort;
     direction?: ListDirection;
     limit: number;
     cursor?: string;
     includeTrashed?: boolean;
+    projects?: string[];
+    tags?: string[];
   }): { chats: ChatResponse[]; nextCursor: string | null } {
     if (!pageQuery) {
       throw new Error("listChatsPage requires a pageQuery dependency");
@@ -296,6 +312,8 @@ export function createChatReader({
       limit,
       cursor: decoded,
       includeTrashed,
+      projects,
+      tags: tagSelection,
     });
 
     // The keyset SQL already applied visibility + ordering; hydration is pure

--- a/api/src/list-pagination.test.ts
+++ b/api/src/list-pagination.test.ts
@@ -453,3 +453,334 @@ describe("ChatReader.listChatsPage — keyset pagination", () => {
     pageQuery.close();
   });
 });
+
+describe("ChatReader.listChatsPage — server-side filtering (#130)", () => {
+  it("filters a page to chats in any of the selected Projects (OR)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "a1",
+      firstSeenAt: new Date(1_000),
+      project: "alpha",
+    });
+    seedChat(archive, {
+      sourceId: "b1",
+      firstSeenAt: new Date(2_000),
+      project: "beta",
+    });
+    seedChat(archive, {
+      sourceId: "g1",
+      firstSeenAt: new Date(3_000),
+      project: "gamma",
+    });
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+    const page = reader.listChatsPage({
+      sort: "createdAt",
+      limit: 10,
+      projects: ["alpha", "gamma"],
+    });
+
+    // Newest-first within the selected Projects; beta is excluded.
+    expect(page.chats.map((c) => c.sourceId)).toEqual(["g1", "a1"]);
+
+    pageQuery.close();
+  });
+
+  it("selects the (No project) group with an empty-string entry", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    // null and "" both belong to the (No project) bucket; "alpha" does not.
+    seedChat(archive, {
+      sourceId: "none1",
+      firstSeenAt: new Date(1_000),
+      project: null,
+    });
+    seedChat(archive, {
+      sourceId: "empty1",
+      firstSeenAt: new Date(2_000),
+      project: "",
+    });
+    seedChat(archive, {
+      sourceId: "a1",
+      firstSeenAt: new Date(3_000),
+      project: "alpha",
+    });
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+    const page = reader.listChatsPage({
+      sort: "createdAt",
+      limit: 10,
+      projects: [""],
+    });
+
+    expect(page.chats.map((c) => c.sourceId)).toEqual(["empty1", "none1"]);
+
+    pageQuery.close();
+  });
+
+  it("filters a page to chats holding every selected Tag (AND)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const both = seedChat(archive, {
+      sourceId: "both",
+      firstSeenAt: new Date(1_000),
+    });
+    const onlyX = seedChat(archive, {
+      sourceId: "onlyX",
+      firstSeenAt: new Date(2_000),
+    });
+    seedChat(archive, { sourceId: "onlyY", firstSeenAt: new Date(3_000) });
+
+    const x = tags.createTag("x", "violet");
+    const y = tags.createTag("y", "blue");
+    tags.assignTag(both, x.id);
+    tags.assignTag(both, y.id);
+    tags.assignTag(onlyX, x.id);
+    // onlyY (sourceId) holds neither in this seed — only "both" has both Tags.
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+    const page = reader.listChatsPage({
+      sort: "createdAt",
+      limit: 10,
+      tags: [x.id, y.id],
+    });
+
+    // Only the chat holding BOTH selected Tags passes the AND filter.
+    expect(page.chats.map((c) => c.sourceId)).toEqual(["both"]);
+
+    pageQuery.close();
+  });
+
+  it("selects the Untagged group with '', and yields nothing when '' is mixed with a real Tag", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    seedChat(archive, { sourceId: "bare", firstSeenAt: new Date(1_000) });
+    const tagged = seedChat(archive, {
+      sourceId: "tagged",
+      firstSeenAt: new Date(2_000),
+    });
+    const x = tags.createTag("x", "violet");
+    tags.assignTag(tagged, x.id);
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+
+    // '' alone keeps only the zero-Tag chat.
+    expect(
+      reader
+        .listChatsPage({ sort: "createdAt", limit: 10, tags: [""] })
+        .chats.map((c) => c.sourceId)
+    ).toEqual(["bare"]);
+
+    // A real Tag AND '' (holds the Tag AND holds zero Tags) is unsatisfiable.
+    expect(
+      reader.listChatsPage({ sort: "createdAt", limit: 10, tags: [x.id, ""] })
+        .chats
+    ).toEqual([]);
+
+    pageQuery.close();
+  });
+
+  it("ANDs the Project and Tag filters across types", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    // alpha+x is the only chat satisfying both the Project and the Tag filter.
+    const alphaX = seedChat(archive, {
+      sourceId: "alphaX",
+      firstSeenAt: new Date(1_000),
+      project: "alpha",
+    });
+    const alphaNoTag = seedChat(archive, {
+      sourceId: "alphaNoTag",
+      firstSeenAt: new Date(2_000),
+      project: "alpha",
+    });
+    const betaX = seedChat(archive, {
+      sourceId: "betaX",
+      firstSeenAt: new Date(3_000),
+      project: "beta",
+    });
+    const x = tags.createTag("x", "violet");
+    tags.assignTag(alphaX, x.id);
+    tags.assignTag(betaX, x.id);
+    void alphaNoTag;
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+    const page = reader.listChatsPage({
+      sort: "createdAt",
+      limit: 10,
+      projects: ["alpha"],
+      tags: [x.id],
+    });
+
+    // betaX has the Tag but the wrong Project; alphaNoTag has the Project but no
+    // Tag — only alphaX clears both.
+    expect(page.chats.map((c) => c.sourceId)).toEqual(["alphaX"]);
+
+    pageQuery.close();
+  });
+
+  it("walks filtered keyset pages with no overlap or gap", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    // Five alpha chats interleaved with beta chats by createdAt. The filter must
+    // page only the alpha set, in full newest-first order, across the cursor.
+    for (let i = 1; i <= 5; i++) {
+      seedChat(archive, {
+        sourceId: `a${i}`,
+        firstSeenAt: new Date(i * 2000),
+        project: "alpha",
+      });
+      seedChat(archive, {
+        sourceId: `b${i}`,
+        firstSeenAt: new Date(i * 2000 + 1000),
+        project: "beta",
+      });
+    }
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    let guard = 0;
+    do {
+      const page = reader.listChatsPage({
+        sort: "createdAt",
+        limit: 2,
+        projects: ["alpha"],
+        cursor,
+      });
+      seen.push(...page.chats.map((c) => c.sourceId));
+      cursor = page.nextCursor ?? undefined;
+    } while (cursor && ++guard < 10);
+
+    // Only alpha chats, newest-first, each exactly once — the cursor stays
+    // strictly past the previous filtered page.
+    expect(seen).toEqual(["a5", "a4", "a3", "a2", "a1"]);
+
+    pageQuery.close();
+  });
+
+  it("composes a filter with the asc direction", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "a1",
+      firstSeenAt: new Date(1_000),
+      project: "alpha",
+    });
+    seedChat(archive, {
+      sourceId: "b1",
+      firstSeenAt: new Date(2_000),
+      project: "beta",
+    });
+    seedChat(archive, {
+      sourceId: "a2",
+      firstSeenAt: new Date(3_000),
+      project: "alpha",
+    });
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+    const page = reader.listChatsPage({
+      sort: "createdAt",
+      direction: "asc",
+      limit: 10,
+      projects: ["alpha"],
+    });
+
+    // Oldest-first within the filtered set; beta excluded.
+    expect(page.chats.map((c) => c.sourceId)).toEqual(["a1", "a2"]);
+
+    pageQuery.close();
+  });
+
+  it("composes a filter with the Trash view (includeTrashed)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "active",
+      firstSeenAt: new Date(1_000),
+      project: "alpha",
+    });
+    const trashed = seedChat(archive, {
+      sourceId: "trashed",
+      firstSeenAt: new Date(2_000),
+      project: "alpha",
+    });
+    seedChat(archive, {
+      sourceId: "betaTrashed",
+      firstSeenAt: new Date(3_000),
+      project: "beta",
+    });
+    metadata.softDelete(trashed);
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+
+    // Main view: the trashed alpha chat is excluded, leaving only the active one.
+    expect(
+      reader
+        .listChatsPage({ sort: "createdAt", limit: 10, projects: ["alpha"] })
+        .chats.map((c) => c.sourceId)
+    ).toEqual(["active"]);
+
+    // includeTrashed opts trashed chats back in (active + trashed, the existing
+    // page-query contract), but the Project filter still applies: both alpha
+    // chats show, the beta chat never does.
+    expect(
+      reader
+        .listChatsPage({
+          sort: "createdAt",
+          limit: 10,
+          projects: ["alpha"],
+          includeTrashed: true,
+        })
+        .chats.map((c) => c.sourceId)
+    ).toEqual(["trashed", "active"]);
+
+    pageQuery.close();
+  });
+
+  it("treats an empty filter selection as unfiltered (clear-all)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "a1",
+      firstSeenAt: new Date(1_000),
+      project: "alpha",
+    });
+    seedChat(archive, {
+      sourceId: "b1",
+      firstSeenAt: new Date(2_000),
+      project: "beta",
+    });
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+
+    // Empty arrays mean "no filter" — every chat shows, exactly as omitting them.
+    expect(
+      reader
+        .listChatsPage({ sort: "createdAt", limit: 10, projects: [], tags: [] })
+        .chats.map((c) => c.sourceId)
+    ).toEqual(["b1", "a1"]);
+
+    pageQuery.close();
+  });
+});

--- a/api/src/list-pagination.ts
+++ b/api/src/list-pagination.ts
@@ -54,6 +54,22 @@ export interface KeysetPageQuery {
   cursor?: KeysetCursor;
   /** Default false: trashed chats are excluded from the page. */
   includeTrashed?: boolean;
+  /**
+   * Project filter (OR / union): the page keeps only chats in any of these
+   * `chats.project` values. An empty-string entry selects the `(No project)`
+   * group (NULL or ''). Omit or pass an empty array to leave Projects
+   * unfiltered. Pushed into the keyset SQL so filtering and the page `LIMIT`
+   * compose at scale (ADR-0017).
+   */
+  projects?: string[];
+  /**
+   * Tag filter (AND / intersection): the page keeps only chats holding every
+   * selected real Tag. An empty-string entry selects the `Untagged` group (zero
+   * Tags) — mixing it with a real Tag id naturally yields nothing. Omit or pass
+   * an empty array to leave Tags unfiltered. Runs as a subquery against the
+   * `ATTACH`ed `meta.chat_tags` (ADR-0017); ANDs across types with `projects`.
+   */
+  tags?: string[];
 }
 
 export interface ChatPageQuery {
@@ -126,6 +142,45 @@ export function createChatPageQuery({
       clauses.push(
         "c.id NOT IN (SELECT id FROM meta.chats_meta WHERE is_deleted = 1)"
       );
+    }
+
+    // Project filter (OR / union): coalesce folds NULL and '' into one
+    // `(No project)` bucket, so an empty-string entry selects it. An empty
+    // selection leaves Projects unfiltered (no clause). The placeholders are a
+    // fixed count built from the array length, never interpolated values.
+    if (query.projects && query.projects.length > 0) {
+      const placeholders = query.projects.map(() => "?").join(", ");
+      clauses.push(`coalesce(c.project, '') IN (${placeholders})`);
+      params.push(...query.projects);
+    }
+
+    // Tag filter (AND / intersection). A real-Tag selection keeps only chats
+    // holding every selected Tag — the grouped subquery counts matched Tags per
+    // chat and requires the full set. The `Untagged` group (the '' marker) keeps
+    // only chats with zero Tags. Both reference the `ATTACH`ed `meta.chat_tags`,
+    // so with no Metadata store there are no tags: a real-Tag filter matches
+    // nothing, and `Untagged` matches everything (no clause). Selecting both a
+    // real Tag and '' at once ANDs to nothing, as intended.
+    if (query.tags && query.tags.length > 0) {
+      const realTagIds = query.tags.filter((t) => t !== "");
+      const wantUntagged = query.tags.includes("");
+      if (realTagIds.length > 0) {
+        if (!hasMetadata) {
+          // No tags exist, so no chat can hold the selected Tag.
+          clauses.push("0");
+        } else {
+          const placeholders = realTagIds.map(() => "?").join(", ");
+          clauses.push(
+            `c.id IN (SELECT chat_id FROM meta.chat_tags
+                      WHERE tag_id IN (${placeholders})
+                      GROUP BY chat_id HAVING count(*) = ?)`
+          );
+          params.push(...realTagIds, realTagIds.length);
+        }
+      }
+      if (wantUntagged && hasMetadata) {
+        clauses.push("c.id NOT IN (SELECT chat_id FROM meta.chat_tags)");
+      }
     }
 
     // The direction flips both the keyset comparison and the ORDER BY in lock

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,9 +48,25 @@ function App() {
     mainPref.field === "createdAt" ? "createdAt" : "updatedAt";
   const pageDirection: ListDirection = mainPref.direction;
 
+  // The active filter is owned here so the paginated read path can push it into
+  // the keyset query (#130): an empty selection means "all". Declared above the
+  // read hooks because `usePaginatedChats` re-anchors on the selection. The
+  // empty-string entry selects the (No project) / Untagged group on each axis.
+  const [selectedProjects, setSelectedProjects] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
+  const [selectedTags, setSelectedTags] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
+
   const full = useChats({ enabled: !paginate });
+  // The paginated path filters server-side: the selection rides the keyset query
+  // and re-anchors the window on change (#130). The full-load path (Title sort,
+  // Trash) keeps filtering its loaded window client-side below.
   const paginated = usePaginatedChats(pageSort, pageDirection, {
     enabled: paginate,
+    projects: [...selectedProjects],
+    tags: [...selectedTags],
   });
   const source = paginate ? paginated : full;
   const { chats, sortEpoch, softDelete, restore, setTitle, reload } = source;
@@ -101,13 +117,11 @@ function App() {
   const mainChats = mainOrder.orderedChats;
   const deletedChats = trashOrder.orderedChats;
 
-  // Project filter: an empty selection means "all Projects". Facets are derived
-  // from the active view's chats (so counts are per-view), and the selected
-  // Projects are ensured into the list so a selected Project stays visible even
-  // after its last chat leaves the view (count 0).
-  const [selectedProjects, setSelectedProjects] = useState<ReadonlySet<string>>(
-    () => new Set()
-  );
+  // Project filter toggles: an empty selection means "all Projects". Facets are
+  // derived from the active view's chats (so counts are per-view), and the
+  // selected Projects are ensured into the list so a selected Project stays
+  // visible even after its last chat leaves the view (count 0). The state itself
+  // is declared above the read hooks so the paginated path can re-anchor on it.
   const toggleProject = useCallback((project: string) => {
     setSelectedProjects((prev) => {
       const next = new Set(prev);
@@ -117,13 +131,10 @@ function App() {
     });
   }, []);
 
-  // Tag filter: AND within (a chat must hold every selected Tag), combined with
-  // the Project filter (OR within) by intersecting the two filtered sets — AND
-  // across types. An empty selection means "all Tags". The `UNTAGGED` sentinel
-  // selects chats with zero Tags.
-  const [selectedTags, setSelectedTags] = useState<ReadonlySet<string>>(
-    () => new Set()
-  );
+  // Tag filter toggles: AND within (a chat must hold every selected Tag),
+  // combined with the Project filter (OR within) — AND across types. An empty
+  // selection means "all Tags". The `UNTAGGED` sentinel selects chats with zero
+  // Tags. The state is declared above the read hooks (see selectedProjects).
   const toggleTag = useCallback((tagId: string) => {
     setSelectedTags((prev) => toggleTagSelection(prev, tagId));
   }, []);
@@ -143,10 +154,16 @@ function App() {
     [counts.counts.projects, selectedProjects]
   );
 
-  const visibleChats = filterChatsByTags(
-    filterChatsByProjects(order.orderedChats, selectedProjects),
-    selectedTags
-  );
+  // The paginated path already filtered server-side inside the keyset query
+  // (#130), so its window is the filtered set — applying the client-side window
+  // filter again would be redundant and would fight pagination. The full-load
+  // path (Title sort, Trash) still filters its loaded window here.
+  const visibleChats = paginate
+    ? order.orderedChats
+    : filterChatsByTags(
+        filterChatsByProjects(order.orderedChats, selectedProjects),
+        selectedTags
+      );
   const selectedChat = chats.find((c) => c.id === selectedId) ?? null;
 
   // Tag and Untagged counts are server-derived per view (main vs Trash). They

--- a/web/src/chat/usePaginatedChats.test.tsx
+++ b/web/src/chat/usePaginatedChats.test.tsx
@@ -122,6 +122,41 @@ describe("usePaginatedChats", () => {
     expect(byId.get("chat-1")!.updatedAt).toBe(1700000400000);
   });
 
+  it("sends the active Project filter to the server (#130)", async () => {
+    // Active by updatedAt desc: chat-2 (backend-api), chat-1 (my-web-app),
+    // chat-3 (my-web-app), chat-missing (some-project). Filtering to my-web-app
+    // server-side leaves only chat-1 and chat-3.
+    const { result } = renderHook(() =>
+      usePaginatedChats("updatedAt", "desc", {
+        pageSize: 10,
+        projects: ["my-web-app"],
+      })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.chats.map((c) => c.id)).toEqual(["chat-1", "chat-3"]);
+  });
+
+  it("re-anchors the window when the active filter changes (#130)", async () => {
+    const { result, rerender } = renderHook(
+      ({ projects }: { projects: string[] }) =>
+        usePaginatedChats("updatedAt", "desc", { pageSize: 10, projects }),
+      { initialProps: { projects: ["my-web-app"] } }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.chats.map((c) => c.id)).toEqual(["chat-1", "chat-3"]);
+
+    // Changing the selection re-anchors: the window refetches the first page for
+    // the new filter rather than appending to or keeping the old one.
+    rerender({ projects: ["backend-api"] });
+
+    await waitFor(() =>
+      expect(result.current.chats.map((c) => c.id)).toEqual(["chat-2"])
+    );
+  });
+
   it("ignores a failed background refresh instead of crashing", async () => {
     const { result } = renderHook(() =>
       usePaginatedChats("updatedAt", "desc", { pageSize: 2 })

--- a/web/src/chat/usePaginatedChats.ts
+++ b/web/src/chat/usePaginatedChats.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { MAX_PAGE_LIMIT } from "@contract";
 import type { Chat } from "@/types";
 import { useChatMutations, type ChatListSource } from "@/chat/useChatMutations";
@@ -42,6 +42,23 @@ interface UsePaginatedChatsOptions {
   // the hook holds an empty window and issues no requests (the full-load path
   // is serving instead).
   enabled?: boolean;
+  /**
+   * Active Project filter (OR / union), sent to the keyset query so filtering
+   * pages server-side (#130). An empty array leaves Projects unfiltered. The
+   * loaded window re-anchors (refetches the first page) whenever this changes.
+   */
+  projects?: readonly string[];
+  /**
+   * Active Tag filter (AND / intersection). The empty-string entry selects the
+   * Untagged group. An empty array leaves Tags unfiltered. Re-anchors on change.
+   */
+  tags?: readonly string[];
+}
+
+/** The active list filter sent to the keyset query alongside sort + cursor. */
+interface ActiveFilter {
+  projects: readonly string[];
+  tags: readonly string[];
 }
 
 // Adds the window-reconciling background refresh to the shared source shape; the
@@ -59,9 +76,19 @@ function pageUrl(
   sort: ListSort,
   direction: ListDirection,
   limit: number,
+  filter: ActiveFilter,
   cursor?: string
 ): string {
-  const base = `/api/chats?sort=${sort}&direction=${direction}&limit=${limit}`;
+  let base = `/api/chats?sort=${sort}&direction=${direction}&limit=${limit}`;
+  // Repeated `?project=` unions (OR); a single comma-separated `?tags=` ANDs.
+  // An empty-string entry rides through as `?project=` / `?tags=`, selecting the
+  // (No project) / Untagged group — the same wire form the server parses (#130).
+  for (const project of filter.projects) {
+    base += `&project=${encodeURIComponent(project)}`;
+  }
+  if (filter.tags.length > 0) {
+    base += `&tags=${filter.tags.map(encodeURIComponent).join(",")}`;
+  }
   return cursor ? `${base}&cursor=${encodeURIComponent(cursor)}` : base;
 }
 
@@ -90,8 +117,25 @@ export function usePaginatedChats(
   {
     pageSize = DEFAULT_PAGE_SIZE,
     enabled = true,
+    projects = [],
+    tags = [],
   }: UsePaginatedChatsOptions = {}
 ): UsePaginatedChatsResult {
+  // The selection arrays change identity every render (App spreads a Set), so a
+  // canonical JSON key drives the effect/callback deps — a re-anchor fires only
+  // when the selection's contents actually change, not on every render. The
+  // memoized filter object is rebuilt from the keys, giving the fetch sites one
+  // stable reference per distinct selection.
+  const projectsKey = JSON.stringify([...projects].sort());
+  const tagsKey = JSON.stringify([...tags].sort());
+  const filter = useMemo<ActiveFilter>(
+    () => ({
+      projects: JSON.parse(projectsKey) as string[],
+      tags: JSON.parse(tagsKey) as string[],
+    }),
+    [projectsKey, tagsKey]
+  );
+
   const [chats, setChats] = useState<Chat[]>([]);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -112,14 +156,15 @@ export function usePaginatedChats(
     chatsRef.current = chats;
   }, [chats]);
 
-  // (Re)load the first page whenever the sort axis changes or the hook is
-  // enabled — resetting the window so the new axis re-anchors from its top.
+  // (Re)load the first page whenever the sort axis, the active filter, or the
+  // enabled flag changes — resetting the window so the new axis or filter
+  // re-anchors from its top (#130).
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
     cursorRef.current = null;
     fetchingRef.current = true;
-    void fetchPage(pageUrl(sort, direction, pageSize)).then((data) => {
+    void fetchPage(pageUrl(sort, direction, pageSize, filter)).then((data) => {
       if (cancelled) return;
       if (data) {
         setChats(data.chats);
@@ -132,21 +177,23 @@ export function usePaginatedChats(
     return () => {
       cancelled = true;
     };
-  }, [sort, direction, pageSize, enabled]);
+  }, [sort, direction, pageSize, enabled, filter]);
 
   const loadMore = useCallback(() => {
     if (fetchingRef.current || cursorRef.current === null) return;
     const cursor = cursorRef.current;
     fetchingRef.current = true;
-    void fetchPage(pageUrl(sort, direction, pageSize, cursor)).then((data) => {
-      if (data) {
-        setChats((prev) => [...prev, ...data.chats]);
-        setNextCursor(data.nextCursor);
-        cursorRef.current = data.nextCursor;
+    void fetchPage(pageUrl(sort, direction, pageSize, filter, cursor)).then(
+      (data) => {
+        if (data) {
+          setChats((prev) => [...prev, ...data.chats]);
+          setNextCursor(data.nextCursor);
+          cursorRef.current = data.nextCursor;
+        }
+        fetchingRef.current = false;
       }
-      fetchingRef.current = false;
-    });
-  }, [sort, direction, pageSize]);
+    );
+  }, [sort, direction, pageSize, filter]);
 
   // Re-read the top of the loaded window. Sized to the current window so a
   // brand-new chat ranking into it is surfaced, but clamped to the page-limit
@@ -158,9 +205,9 @@ export function usePaginatedChats(
       Math.max(chatsRef.current.length, pageSize),
       MAX_PAGE_LIMIT
     );
-    const data = await fetchPage(pageUrl(sort, direction, limit));
+    const data = await fetchPage(pageUrl(sort, direction, limit, filter));
     if (data) setChats((prev) => mergeWindow(prev, data.chats));
-  }, [sort, direction, pageSize]);
+  }, [sort, direction, pageSize, filter]);
 
   useEffect(() => {
     if (!enabled) return;

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -244,9 +244,30 @@ export const handlers = [
       const dir = direction === "asc" ? -1 : 1;
       const sortKeyOf = (c: FakeChat) =>
         sort === "createdAt" ? c.createdAt : c.updatedAt;
+      // Project (OR) + Tag (AND) filtering inside the paginated query, mirroring
+      // the server (#130). Repeated `?project=` unions; `?tags=` is one
+      // comma-separated AND set. An empty value selects the (No project) /
+      // Untagged group. Absent params leave that axis unfiltered.
+      const projectSel = url.searchParams.getAll("project");
+      const tagsParam = url.searchParams.get("tags");
+      const tagSel = tagsParam === null ? null : tagsParam.split(",");
+      const filtered = visible.filter((c) => {
+        if (projectSel.length > 0 && !projectSel.includes(c.project)) {
+          return false;
+        }
+        if (tagSel) {
+          const ids = new Set(fakeChatTags[c.id] ?? []);
+          const wantUntagged = tagSel.includes("");
+          if (wantUntagged && ids.size > 0) return false;
+          if (!tagSel.filter((t) => t !== "").every((t) => ids.has(t))) {
+            return false;
+          }
+        }
+        return true;
+      });
       // dir flips the sort and the tiebreak together: desc is (sortKey DESC, id
       // DESC), asc is (sortKey ASC, id ASC).
-      const sorted = [...visible].sort(
+      const sorted = [...filtered].sort(
         (a, b) =>
           dir * (sortKeyOf(b) - sortKeyOf(a)) ||
           dir * (a.id < b.id ? 1 : a.id > b.id ? -1 : 0)


### PR DESCRIPTION
## Background (Why)

The list previously filtered by Project (OR) and Tag (AND) at the app level: load every candidate id from each store, intersect, sort, then slice in JavaScript (ADR-0016). That model cannot push the page `LIMIT` into SQL, so the default unfiltered list pays a candidate-set-sized cost on every page — the floor ADR-0017 set out to remove. With server-side sort + keyset pagination already in place (#129/#143), filtering had to move into the same query so the two compose at scale. The frontend was still filtering the loaded window client-side, which fights pagination once the window is only a page deep.

## Approach (How)

Graduate ADR-0017's already-designed `WHERE` clauses into the real `listChatsPage` keyset query, and have the frontend send the active filter and re-anchor on change instead of filtering its window.

- Project filter folds NULL and `''` into one `(No project)` bucket via `coalesce(c.project,'') IN (…)` (OR).
- Tag filter is a grouped subquery against the `ATTACH`ed `meta.chat_tags` with `HAVING count(*) = ?` (AND); the `Untagged` group is `NOT IN (SELECT chat_id FROM meta.chat_tags)`. With no Metadata store, a real-Tag filter matches nothing and `Untagged` matches everything.
- An empty-string entry selects the `(No project)` / `Untagged` group on each axis; the two filters AND across types and compose with both sort directions, the keyset cursor, and the Trash view.
- The frontend hook rides the selection on the keyset request and re-anchors the window (refetches the first page) only when the selection's contents actually change, driven by a canonical JSON key.

## Changes (What)

- [x] `list-pagination.ts`: `KeysetPageQuery` gains `projects`/`tags`; `queryPage` builds the ADR-0017 filter clauses, parameterized and placeholder-counted (no interpolated values).
- [x] `chat-reader.ts`: `listChatsPage` threads the filter through to the page query.
- [x] `app.ts`: the paginated branch parses `?project=` (repeated, OR) and `?tags=` (comma, AND), matching the legacy full-list branch.
- [x] `usePaginatedChats.ts`: accepts the active filter, sends it on the request, and re-anchors on change.
- [x] `App.tsx`: owns the selection above the read hooks, passes it in, and drops the client-side window filter on the paginated path (the full-load Title/Trash path keeps it).
- [x] `test/handlers.ts`: the MSW fake mirrors the server-side filter in paginated mode.

### Test Verification

Built test-first (13 red→green slices). Full suite green: 423 tests, typecheck clean.

- [x] Project OR filter returns only chats in the selected Projects
- [x] `''` selects the `(No project)` group (NULL and empty project)
- [x] Tag AND returns only chats holding every selected Tag
- [x] `''` selects `Untagged`; a real Tag mixed with `''` yields nothing
- [x] Project + Tag compose (AND across types)
- [x] Filtered keyset pages walk with no overlap or gap
- [x] Filter composes with `direction=asc` and with the Trash view (`includeTrashed`)
- [x] Empty selection = unfiltered (clear-all)
- [x] Route applies `?project=` / `?tags=` in paginated mode
- [x] Hook sends the active filter and re-anchors the window on filter change

## Additional Notes

- The "~50,000 Chats" acceptance criterion is covered structurally by ADR-0017's benchmark — this PR graduates the same `WHERE` clauses and covering indexes into the real query; page stability is covered here by the multi-page filtered walk test.
- The filtered List count (the "Chats N" header when a filter is active) is **out of scope**, deferred to #131 Phase B, which this PR unblocks. A filtered list still falls back to the loaded-window count, unchanged.
- Search was removed from #130's scope (deferred to the Spotlight epic #5); the keyset query can grow a search predicate later with no structural change.

## Related Links

- Closes #130
- ADR-0017 (cross-store paginated listing via ATTACH)
- Part of the list-pipeline refactor (#126–#132, #143–#146); merges into `integration/server-side-list-pipeline`