### PR TITLE
feat: server-side filtered List count

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -326,6 +326,51 @@ describe("GET /api/chats/counts — server-side facet counts", () => {
   });
 });
 
+describe("GET /api/chats/list-total — filtered List count (Phase B)", () => {
+  it("returns the post-filter total for the active Project/Tag filter", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const a1 = seedChat(archive, {
+      sourceId: "a1",
+      firstSeenAt: new Date(1000),
+      project: "alpha",
+    });
+    seedChat(archive, {
+      sourceId: "a2",
+      firstSeenAt: new Date(2000),
+      project: "alpha",
+    });
+    seedChat(archive, {
+      sourceId: "b1",
+      firstSeenAt: new Date(3000),
+      project: "beta",
+    });
+    const work = tags.createTag("work", "blue");
+    tags.assignTag(a1, work.id);
+
+    const app = createApp({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+      countsQuery: createChatCountsQuery({ dataDir }),
+    });
+
+    // Project filter (repeated ?project=): alpha has 2.
+    const byProject = await app.request("/api/chats/list-total?project=alpha");
+    expect(byProject.status).toBe(200);
+    expect(((await byProject.json()) as { total: number }).total).toBe(2);
+
+    // Project AND Tag across types: alpha AND work → only a1.
+    const byBoth = await app.request(
+      `/api/chats/list-total?project=alpha&tags=${work.id}`
+    );
+    expect(((await byBoth.json()) as { total: number }).total).toBe(1);
+  });
+});
+
 describe("Chat id is the public API handle", () => {
   it("GET /api/chats exposes id as the wire-form chat id plus sourceId", async () => {
     const archive = createArchiveRepository({ dataDir });

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -118,6 +118,24 @@ export function createApp({
     return c.json(reader.listCounts({ includeTrashed }));
   });
 
+  // The filtered List count ("Chats N" when a filter is active; issue #131
+  // Phase B). Separate from the static facet counts so toggling a filter does
+  // not refetch the per-view facets. The filter is parsed the same way as the
+  // list routes: repeated `?project=` unions (OR), a single comma-separated
+  // `?tags=` ANDs; an empty value selects the `(No project)` / `Untagged` group.
+  // Registered before `/api/chats/:id` so the literal segment is not an id.
+  app.get("/api/chats/list-total", (c) => {
+    if (!countsQuery) {
+      return c.json({ error: "Counts are not available" }, 501);
+    }
+    const includeTrashed = c.req.query("includeTrashed") === "true";
+    const projects = c.req.queries("project");
+    const tagsParam = c.req.query("tags");
+    const tags = tagsParam === undefined ? undefined : tagsParam.split(",");
+    const total = reader.listFilteredTotal({ includeTrashed, projects, tags });
+    return c.json({ total });
+  });
+
   app.delete("/api/chats/:id", (c) => {
     const row = reader.findChat(c.req.param("id"));
     if (!row) {

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -122,6 +122,18 @@ export interface ChatReader {
    */
   listCounts(opts: { includeTrashed?: boolean }): ListCounts;
   /**
+   * The filtered List count ("Chats N" when a filter is active; issue #131
+   * Phase B). Applies the active Project (OR) / Tag (AND) / Untagged filter and
+   * returns the post-filter result count, server-derived so the paginated
+   * frontend need not hold the filtered window to count from. Requires a
+   * `countsQuery` dependency.
+   */
+  listFilteredTotal(opts: {
+    includeTrashed?: boolean;
+    projects?: string[];
+    tags?: string[];
+  }): number;
+  /**
    * Messages for a Chat resolved by its public wire-form chat id (`clog_…`).
    * Returns null when the id is malformed, no chat matches, or it is not visible
    * — the caller maps all of these to 404 (the 404 paths collapse into one).
@@ -346,6 +358,21 @@ export function createChatReader({
     return countsQuery.queryCounts({ includeTrashed });
   }
 
+  function listFilteredTotal({
+    includeTrashed = false,
+    projects,
+    tags,
+  }: {
+    includeTrashed?: boolean;
+    projects?: string[];
+    tags?: string[];
+  }): number {
+    if (!countsQuery) {
+      throw new Error("listFilteredTotal requires a countsQuery dependency");
+    }
+    return countsQuery.queryFilteredTotal({ includeTrashed, projects, tags });
+  }
+
   function getMessages(
     id: string,
     { includeTrashed }: { includeTrashed: boolean }
@@ -365,5 +392,12 @@ export function createChatReader({
     }));
   }
 
-  return { listChats, listChatsPage, listCounts, getMessages, findChat };
+  return {
+    listChats,
+    listChatsPage,
+    listCounts,
+    listFilteredTotal,
+    getMessages,
+    findChat,
+  };
 }

--- a/api/src/list-counts.test.ts
+++ b/api/src/list-counts.test.ts
@@ -271,3 +271,216 @@ describe("ChatCountsQuery.queryCounts — no Metadata store yet", () => {
     countsQuery.close();
   });
 });
+
+describe("ChatCountsQuery.queryFilteredTotal — Project filter", () => {
+  it("counts only chats in the selected project", () => {
+    const archive = createArchiveRepository({ dataDir });
+    createMetadataRepository({ dataDir });
+    createTagRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "a1",
+      firstSeenAt: new Date(1_000),
+      project: "alpha",
+    });
+    seedChat(archive, {
+      sourceId: "a2",
+      firstSeenAt: new Date(2_000),
+      project: "alpha",
+    });
+    seedChat(archive, {
+      sourceId: "b1",
+      firstSeenAt: new Date(3_000),
+      project: "beta",
+    });
+
+    const countsQuery = createChatCountsQuery({ dataDir });
+    const total = countsQuery.queryFilteredTotal({ projects: ["alpha"] });
+
+    expect(total).toBe(2);
+
+    countsQuery.close();
+  });
+});
+
+describe("ChatCountsQuery.queryFilteredTotal — Project filter unions and groups", () => {
+  it("unions multiple selected projects (OR)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    createMetadataRepository({ dataDir });
+    createTagRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "a1",
+      firstSeenAt: new Date(1),
+      project: "alpha",
+    });
+    seedChat(archive, {
+      sourceId: "b1",
+      firstSeenAt: new Date(2),
+      project: "beta",
+    });
+    seedChat(archive, {
+      sourceId: "g1",
+      firstSeenAt: new Date(3),
+      project: "gamma",
+    });
+
+    const countsQuery = createChatCountsQuery({ dataDir });
+    const total = countsQuery.queryFilteredTotal({
+      projects: ["alpha", "beta"],
+    });
+
+    expect(total).toBe(2);
+
+    countsQuery.close();
+  });
+
+  it("selects the (No project) group via the empty-string entry", () => {
+    const archive = createArchiveRepository({ dataDir });
+    createMetadataRepository({ dataDir });
+    createTagRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "a1",
+      firstSeenAt: new Date(1),
+      project: "alpha",
+    });
+    seedChat(archive, {
+      sourceId: "n1",
+      firstSeenAt: new Date(2),
+      project: null,
+    });
+    seedChat(archive, {
+      sourceId: "n2",
+      firstSeenAt: new Date(3),
+      project: "",
+    });
+
+    const countsQuery = createChatCountsQuery({ dataDir });
+    const total = countsQuery.queryFilteredTotal({ projects: [""] });
+
+    // null and '' both fold into (No project).
+    expect(total).toBe(2);
+
+    countsQuery.close();
+  });
+});
+
+describe("ChatCountsQuery.queryFilteredTotal — Tag filter", () => {
+  it("intersects multiple selected tags (AND)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const c1 = seedChat(archive, { sourceId: "c1", firstSeenAt: new Date(1) });
+    const c2 = seedChat(archive, { sourceId: "c2", firstSeenAt: new Date(2) });
+    seedChat(archive, { sourceId: "c3", firstSeenAt: new Date(3) });
+
+    const work = tags.createTag("work", "blue");
+    const fun = tags.createTag("fun", "violet");
+    tags.assignTag(c1, work.id);
+    tags.assignTag(c1, fun.id);
+    tags.assignTag(c2, work.id);
+
+    const countsQuery = createChatCountsQuery({ dataDir });
+    // Only c1 holds BOTH work and fun.
+    const total = countsQuery.queryFilteredTotal({ tags: [work.id, fun.id] });
+
+    expect(total).toBe(1);
+
+    countsQuery.close();
+  });
+
+  it("selects the Untagged group via the empty-string entry", () => {
+    const archive = createArchiveRepository({ dataDir });
+    createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const c1 = seedChat(archive, { sourceId: "c1", firstSeenAt: new Date(1) });
+    seedChat(archive, { sourceId: "c2", firstSeenAt: new Date(2) });
+    seedChat(archive, { sourceId: "c3", firstSeenAt: new Date(3) });
+
+    const work = tags.createTag("work", "blue");
+    tags.assignTag(c1, work.id);
+
+    const countsQuery = createChatCountsQuery({ dataDir });
+    const total = countsQuery.queryFilteredTotal({ tags: [""] });
+
+    // c2, c3 hold zero tags.
+    expect(total).toBe(2);
+
+    countsQuery.close();
+  });
+});
+
+describe("ChatCountsQuery.queryFilteredTotal — cross-type and view", () => {
+  it("ANDs a Project and a Tag filter across types", () => {
+    const archive = createArchiveRepository({ dataDir });
+    createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const a1 = seedChat(archive, {
+      sourceId: "a1",
+      firstSeenAt: new Date(1),
+      project: "alpha",
+    });
+    seedChat(archive, {
+      sourceId: "a2",
+      firstSeenAt: new Date(2),
+      project: "alpha",
+    });
+    const b1 = seedChat(archive, {
+      sourceId: "b1",
+      firstSeenAt: new Date(3),
+      project: "beta",
+    });
+
+    const work = tags.createTag("work", "blue");
+    tags.assignTag(a1, work.id);
+    tags.assignTag(b1, work.id);
+
+    const countsQuery = createChatCountsQuery({ dataDir });
+    // alpha AND work → only a1.
+    const total = countsQuery.queryFilteredTotal({
+      projects: ["alpha"],
+      tags: [work.id],
+    });
+
+    expect(total).toBe(1);
+
+    countsQuery.close();
+  });
+
+  it("scopes the filtered total to the view (main excludes trashed)", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    createTagRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "a1",
+      firstSeenAt: new Date(1),
+      project: "alpha",
+    });
+    const trashed = seedChat(archive, {
+      sourceId: "a2",
+      firstSeenAt: new Date(2),
+      project: "alpha",
+    });
+    metadata.softDelete(trashed);
+
+    const countsQuery = createChatCountsQuery({ dataDir });
+    const main = countsQuery.queryFilteredTotal({
+      projects: ["alpha"],
+      includeTrashed: false,
+    });
+    const trash = countsQuery.queryFilteredTotal({
+      projects: ["alpha"],
+      includeTrashed: true,
+    });
+
+    expect(main).toBe(1);
+    expect(trash).toBe(1);
+
+    countsQuery.close();
+  });
+});

--- a/api/src/list-counts.ts
+++ b/api/src/list-counts.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import Database from "better-sqlite3";
+import { buildFilterClauses } from "./list-filter.js";
 
 /**
  * The facet-count aggregation (issue #131 Phase A, ADR-0017). Owns one Archive
@@ -42,6 +43,19 @@ export interface ListCounts {
 
 export interface ChatCountsQuery {
   queryCounts(opts: { includeTrashed?: boolean }): ListCounts;
+  /**
+   * The filtered List count ("Chats N" when a filter is active; issue #131
+   * Phase B). Applies the same Project (OR) / Tag (AND) / Untagged filter
+   * semantics as the keyset page query (#130) but returns `COUNT(*)` instead of
+   * a page — so the post-filter total is accurate at scale without loading the
+   * filtered window. An empty-string entry selects the `(No project)` /
+   * `Untagged` group; an empty or omitted array leaves that type unfiltered.
+   */
+  queryFilteredTotal(opts: {
+    includeTrashed?: boolean;
+    projects?: string[];
+    tags?: string[];
+  }): number;
   close(): void;
 }
 
@@ -130,8 +144,47 @@ export function createChatCountsQuery({
     return { total, projects, tags, untagged };
   }
 
+  function queryFilteredTotal({
+    includeTrashed = false,
+    projects,
+    tags,
+  }: {
+    includeTrashed?: boolean;
+    projects?: string[];
+    tags?: string[];
+  }): number {
+    const clauses: string[] = [];
+    const params: (string | number)[] = [];
+
+    // View predicate: main excludes soft-deleted, Trash keeps only soft-deleted.
+    if (hasMetadata) {
+      clauses.push(
+        includeTrashed
+          ? "c.id IN (SELECT id FROM meta.chats_meta WHERE is_deleted = 1)"
+          : "c.id NOT IN (SELECT id FROM meta.chats_meta WHERE is_deleted = 1)"
+      );
+    } else if (includeTrashed) {
+      // No Metadata store: nothing is trashed, so the Trash view is empty.
+      return 0;
+    }
+
+    // The Project/Tag filter is the same predicate the keyset page applies
+    // (#130); it lives in `buildFilterClauses` so the two read paths share it.
+    const filter = buildFilterClauses({ projects, tags, hasMetadata });
+    clauses.push(...filter.clauses);
+    params.push(...filter.params);
+
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    return (
+      archive
+        .prepare(`SELECT count(*) AS n FROM chats c ${where}`)
+        .get(...params) as { n: number }
+    ).n;
+  }
+
   return {
     queryCounts,
+    queryFilteredTotal,
     close() {
       archive.close();
     },

--- a/api/src/list-filter.ts
+++ b/api/src/list-filter.ts
@@ -1,0 +1,79 @@
+/**
+ * The shared Project/Tag filter predicate (issue #130, ADR-0017). Both the
+ * keyset page query and the filtered List count apply the same filter
+ * semantics over the cross-store `chats c` + `ATTACH`ed `meta.*` shape — the
+ * page adds an `ORDER BY` + keyset `LIMIT`, the count wraps a `count(*)`, but
+ * the WHERE that picks which chats match is identical. It lives here so the two
+ * read paths can never drift apart.
+ *
+ * The returned clauses assume the `chats` table is aliased `c` and that the
+ * Metadata DB (when present) is attached as `meta`. The caller owns the view
+ * predicate and the keyset cursor; this only contributes the filter, ANDed onto
+ * whatever else the caller has pushed.
+ */
+export interface FilterClauses {
+  /** SQL fragments to AND into the caller's WHERE; empty when nothing filters. */
+  clauses: string[];
+  /** Bind params, in the order the clauses reference them. */
+  params: (string | number)[];
+}
+
+/**
+ * Build the Project (OR / union) and Tag (AND / intersection) filter clauses.
+ *
+ * An empty-string Project entry selects the `(No project)` group (NULL or '');
+ * an empty-string Tag entry selects the `Untagged` group (zero Tags). Omitting
+ * a filter (undefined or empty array) leaves that axis unfiltered. With no
+ * Metadata store there are no tags, so a real-Tag filter matches nothing and
+ * `Untagged` matches everything (no clause). The placeholders are a fixed count
+ * built from each array's length — caller values are bound, never interpolated.
+ */
+export function buildFilterClauses({
+  projects,
+  tags,
+  hasMetadata,
+}: {
+  projects?: string[];
+  tags?: string[];
+  hasMetadata: boolean;
+}): FilterClauses {
+  const clauses: string[] = [];
+  const params: (string | number)[] = [];
+
+  // Project filter (OR / union): coalesce folds NULL and '' into the
+  // `(No project)` bucket, so an empty-string entry selects it.
+  if (projects && projects.length > 0) {
+    const placeholders = projects.map(() => "?").join(", ");
+    clauses.push(`coalesce(c.project, '') IN (${placeholders})`);
+    params.push(...projects);
+  }
+
+  // Tag filter (AND / intersection). A real-Tag selection keeps only chats
+  // holding every selected Tag — the grouped subquery counts matched Tags per
+  // chat and requires the full set. The `Untagged` group (the '' marker) keeps
+  // only chats with zero Tags. Selecting both a real Tag and '' at once ANDs to
+  // nothing, as intended.
+  if (tags && tags.length > 0) {
+    const realTagIds = tags.filter((t) => t !== "");
+    const wantUntagged = tags.includes("");
+    if (realTagIds.length > 0) {
+      if (!hasMetadata) {
+        // No tags exist, so no chat can hold the selected Tag.
+        clauses.push("0");
+      } else {
+        const placeholders = realTagIds.map(() => "?").join(", ");
+        clauses.push(
+          `c.id IN (SELECT chat_id FROM meta.chat_tags
+                    WHERE tag_id IN (${placeholders})
+                    GROUP BY chat_id HAVING count(*) = ?)`
+        );
+        params.push(...realTagIds, realTagIds.length);
+      }
+    }
+    if (wantUntagged && hasMetadata) {
+      clauses.push("c.id NOT IN (SELECT chat_id FROM meta.chat_tags)");
+    }
+  }
+
+  return { clauses, params };
+}

--- a/api/src/list-pagination.ts
+++ b/api/src/list-pagination.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import Database from "better-sqlite3";
+import { buildFilterClauses } from "./list-filter.js";
 
 /**
  * The keyset page query (issue #129, ADR-0017). Owns one Archive connection with
@@ -144,44 +145,16 @@ export function createChatPageQuery({
       );
     }
 
-    // Project filter (OR / union): coalesce folds NULL and '' into one
-    // `(No project)` bucket, so an empty-string entry selects it. An empty
-    // selection leaves Projects unfiltered (no clause). The placeholders are a
-    // fixed count built from the array length, never interpolated values.
-    if (query.projects && query.projects.length > 0) {
-      const placeholders = query.projects.map(() => "?").join(", ");
-      clauses.push(`coalesce(c.project, '') IN (${placeholders})`);
-      params.push(...query.projects);
-    }
-
-    // Tag filter (AND / intersection). A real-Tag selection keeps only chats
-    // holding every selected Tag — the grouped subquery counts matched Tags per
-    // chat and requires the full set. The `Untagged` group (the '' marker) keeps
-    // only chats with zero Tags. Both reference the `ATTACH`ed `meta.chat_tags`,
-    // so with no Metadata store there are no tags: a real-Tag filter matches
-    // nothing, and `Untagged` matches everything (no clause). Selecting both a
-    // real Tag and '' at once ANDs to nothing, as intended.
-    if (query.tags && query.tags.length > 0) {
-      const realTagIds = query.tags.filter((t) => t !== "");
-      const wantUntagged = query.tags.includes("");
-      if (realTagIds.length > 0) {
-        if (!hasMetadata) {
-          // No tags exist, so no chat can hold the selected Tag.
-          clauses.push("0");
-        } else {
-          const placeholders = realTagIds.map(() => "?").join(", ");
-          clauses.push(
-            `c.id IN (SELECT chat_id FROM meta.chat_tags
-                      WHERE tag_id IN (${placeholders})
-                      GROUP BY chat_id HAVING count(*) = ?)`
-          );
-          params.push(...realTagIds, realTagIds.length);
-        }
-      }
-      if (wantUntagged && hasMetadata) {
-        clauses.push("c.id NOT IN (SELECT chat_id FROM meta.chat_tags)");
-      }
-    }
+    // The Project/Tag filter is the same predicate the filtered List count
+    // applies (#131); it lives in `buildFilterClauses` so the two read paths
+    // share it. Filtering and the page `LIMIT` compose at scale (ADR-0017).
+    const filter = buildFilterClauses({
+      projects: query.projects,
+      tags: query.tags,
+      hasMetadata,
+    });
+    clauses.push(...filter.clauses);
+    params.push(...filter.params);
 
     // The direction flips both the keyset comparison and the ORDER BY in lock
     // step, so the cursor stays strictly past the previous page's last row and

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1679,6 +1679,28 @@ describe("Project filter", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows the server's filtered List count in the header when a filter is active", async () => {
+    // The header total must come from the server's filtered-total endpoint, not
+    // the loaded window — at scale the paginated window is smaller than the
+    // filtered set (#131 Phase B). Override the endpoint to a sentinel the window
+    // could never produce, proving the header reads it.
+    server.use(
+      http.get("/api/chats/list-total", () => HttpResponse.json({ total: 42 }))
+    );
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByText("Build a login page");
+    // Unfiltered: the header shows the server facet total (4 active chats).
+    expect(screen.getByTestId("chat-list-count")).toHaveTextContent("4");
+
+    await user.click(screen.getByTestId("project-row-backend-api"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-list-count")).toHaveTextContent("42");
+    });
+  });
+
   it("unions chats across several selected Projects (OR)", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import { useSortPreference } from "@/chat/sort/useSortPreference";
 import { CHAT_SORT_CONFIG } from "@/chat/sort/sortConfig";
 import { facetsFromCounts } from "@/chat/projects/projectFacets";
 import { useChatCounts } from "@/chat/useChatCounts";
+import { useFilteredTotal } from "@/chat/useFilteredTotal";
 import { filterChatsByProjects } from "@/chat/projects/filterChatsByProjects";
 import { filterChatsByTags } from "@/tags/filterChatsByTags";
 import { toggleTagSelection } from "@/tags/toggleTagSelection";
@@ -172,11 +173,23 @@ function App() {
   const countForTag = counts.tagCount;
   const untaggedCount = counts.counts.untagged;
 
-  // The "Chats N" header total: server-derived when unfiltered (#131 Phase A);
-  // the accurate filtered total is Phase B (#130), so a filtered list falls
-  // back to the loaded window count.
+  // The "Chats N" header total: server-derived in both cases. Unfiltered, it is
+  // the view's facet total (#131 Phase A); filtered, it is the server's
+  // post-filter count (#131 Phase B) — accurate even when the paginated window
+  // holds only a page of the filtered set.
   const filterActive = selectedProjects.size + selectedTags.size > 0;
-  const listTotal = filterActive ? undefined : counts.counts.total;
+  const filteredTotal = useFilteredTotal(
+    mode,
+    [...selectedProjects],
+    [...selectedTags]
+  );
+  // While the first filtered total is still loading (filteredTotal undefined),
+  // hold the view's facet total rather than letting the header fall back to the
+  // paginated window count (the page size) — that would flash a wrong number
+  // for a frame before the real filtered total lands (#131).
+  const listTotal = filterActive
+    ? (filteredTotal ?? counts.counts.total)
+    : counts.counts.total;
   // Create a Tag and immediately assign it to the chat the popover is on.
   const createTagForChat = useCallback(
     async (

--- a/web/src/chat/ChatList.tsx
+++ b/web/src/chat/ChatList.tsx
@@ -234,7 +234,10 @@ export function ChatList({
               <span className="font-semibold text-accent-foreground">
                 Chats
               </span>
-              <span className="rounded-full bg-card px-2 text-xs font-semibold tabular-nums text-muted-foreground">
+              <span
+                data-testid="chat-list-count"
+                className="rounded-full bg-card px-2 text-xs font-semibold tabular-nums text-muted-foreground"
+              >
                 {total ?? chats.length}
               </span>
             </span>

--- a/web/src/chat/useFilteredTotal.test.tsx
+++ b/web/src/chat/useFilteredTotal.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse, delay } from "msw";
+import { describe, it, expect } from "vitest";
+import { useFilteredTotal } from "@/chat/useFilteredTotal";
+import { server } from "@/test/server";
+
+// Active fake chats: chat-1 + chat-3 (my-web-app), chat-2 (backend-api),
+// chat-missing (some-project). Trashed: chat-deleted-1 + chat-deleted-2
+// (both my-web-app).
+describe("useFilteredTotal", () => {
+  it("reads the server's post-filter total for an active Project filter", async () => {
+    const { result } = renderHook(() =>
+      useFilteredTotal("main", ["my-web-app"], [])
+    );
+
+    await waitFor(() => expect(result.current).toBe(2));
+  });
+
+  it("is undefined when no filter is active (header falls back to facet total)", async () => {
+    const { result } = renderHook(() => useFilteredTotal("main", [], []));
+
+    // Give any stray fetch a tick to resolve; the value must stay undefined.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current).toBeUndefined();
+  });
+
+  it("keeps the previous total while the next filter's total is in flight", async () => {
+    const { result, rerender } = renderHook(
+      ({ projects }) => useFilteredTotal("main", projects, []),
+      { initialProps: { projects: ["my-web-app"] } }
+    );
+    await waitFor(() => expect(result.current).toBe(2));
+
+    // Delay the next filter's response so we can observe the in-flight window.
+    server.use(
+      http.get("/api/chats/list-total", async () => {
+        await delay(50);
+        return HttpResponse.json({ total: 1 });
+      })
+    );
+    rerender({ projects: ["backend-api"] });
+
+    // Stale-while-revalidate: the header holds the last total (2) rather than
+    // dropping to undefined — which would flash the paginated window count.
+    expect(result.current).toBe(2);
+    await waitFor(() => expect(result.current).toBe(1));
+  });
+});

--- a/web/src/chat/useFilteredTotal.ts
+++ b/web/src/chat/useFilteredTotal.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+
+// The filtered List count ("Chats N" when a filter is active; #131 Phase B).
+// Kept separate from the static facet counts (useChatCounts) so toggling a
+// filter does not refetch the per-view facets — only this lean total refetches.
+// Returns undefined when no filter is active, so the header falls back to the
+// server's unfiltered facet total.
+
+const BACKGROUND_REFRESH_MS = 4000;
+
+function listTotalUrl(
+  mode: "main" | "trash",
+  projects: string[],
+  tags: string[]
+): string {
+  const params = new URLSearchParams();
+  if (mode === "trash") params.set("includeTrashed", "true");
+  // Repeated `?project=` unions (OR); a single comma-separated `?tags=` ANDs —
+  // the same wire shape the paginated list query uses (#130).
+  for (const p of projects) params.append("project", p);
+  if (tags.length > 0) params.set("tags", tags.join(","));
+  return `/api/chats/list-total?${params.toString()}`;
+}
+
+/** A fetched total tagged with the URL that produced it. */
+interface FetchedTotal {
+  url: string;
+  total: number;
+}
+
+/**
+ * Read the server's post-filter List count for the active Project/Tag filter.
+ * Refetches when the view or the filter changes and on a background interval to
+ * track file-watcher ingestion. Returns undefined when nothing is filtered.
+ *
+ * Stale-while-revalidate: while the next filter's total is in flight it keeps
+ * returning the last fetched total rather than dropping to undefined — that
+ * would let the header momentarily fall back to the paginated window count (the
+ * page size), flashing a wrong number before the real total lands (#131).
+ */
+export function useFilteredTotal(
+  mode: "main" | "trash",
+  projects: string[],
+  tags: string[]
+): number | undefined {
+  const [fetched, setFetched] = useState<FetchedTotal | null>(null);
+  // The URL fully encodes view + filter, so depending on it re-runs the fetch
+  // exactly when the selection changes — no array-identity churn across renders.
+  const active = projects.length > 0 || tags.length > 0;
+  const url = active ? listTotalUrl(mode, projects, tags) : null;
+
+  useEffect(() => {
+    if (url === null) return;
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const res = await fetch(url);
+        if (!res.ok) return;
+        const data = (await res.json()) as { total?: number };
+        if (!cancelled) setFetched({ url, total: data.total ?? 0 });
+      } catch {
+        // Ignore transient failures; the next interval tick retries.
+      }
+    };
+    void refresh();
+    const id = setInterval(() => void refresh(), BACKGROUND_REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [url]);
+
+  // Nothing to show when no filter is active; otherwise surface the last fetched
+  // total (the current filter's once it lands, the previous one's meanwhile).
+  if (url === null) return undefined;
+  return fetched?.total;
+}

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -340,6 +340,36 @@ export const handlers = [
       untagged,
     });
   }),
+  // Filtered List count (#131 Phase B): the post-filter total for the active
+  // Project (OR) / Tag (AND) / Untagged filter, scoped to the view. Mirrors the
+  // paginated query's filter parsing so the header total matches the listed set.
+  http.get("/api/chats/list-total", ({ request }) => {
+    const url = new URL(request.url);
+    const includeTrashed = url.searchParams.get("includeTrashed") === "true";
+    const inView = includeTrashed
+      ? fakeChats.filter((c) => c.isDeleted)
+      : fakeChats.filter((c) => !c.isDeleted);
+
+    const projectSel = url.searchParams.getAll("project");
+    const tagsParam = url.searchParams.get("tags");
+    const tagSel = tagsParam === null ? null : tagsParam.split(",");
+    const total = inView.filter((c) => {
+      if (projectSel.length > 0 && !projectSel.includes(c.project)) {
+        return false;
+      }
+      if (tagSel) {
+        const ids = new Set(fakeChatTags[c.id] ?? []);
+        const wantUntagged = tagSel.includes("");
+        if (wantUntagged && ids.size > 0) return false;
+        if (!tagSel.filter((t) => t !== "").every((t) => ids.has(t))) {
+          return false;
+        }
+      }
+      return true;
+    }).length;
+
+    return HttpResponse.json({ total });
+  }),
   http.patch("/api/chats/:id/title", async ({ params, request }) => {
     const id = params.id as string;
     const chat = fakeChats.find((c) => c.id === id);


### PR DESCRIPTION
## Background (Why)

In paginated mode the frontend no longer holds the full Chat list, so it can no longer tally the "Chats N" header from the loaded window. Phase A restored the static facet counts and the unfiltered List count via a server aggregation, but left the filtered case open: when a Project/Tag filter is active, the header needs the post-filter result count, and computing that accurately at scale means the server has to apply the filter. This is issue #131 Phase B, riding on the
server-side filter from #130.

## Approach (How)

The filtered total is a count, not a page, but it must match the keyset page's filter exactly. So the Project (OR) / Tag (AND) / Untagged predicate is pulled out of the page query into a shared `buildFilterClauses` and reused by a new
`queryFilteredTotal` that wraps it in `count(*)`. Facet counts stay static per view and are fetched on view change; the filtered total is dynamic per filter click and read by its own lean hook, so toggling a filter never refetches the
whole facet aggregation.

On the client the header prefers the server filtered total when a filter is active and the facet total otherwise. To stop the number flashing during the brief in-flight window, the hook is stale-while-revalidate and the first filtered total falls back to the facet total — otherwise the header momentarily showed the paginated window count (the page size).

## Changes (What)

- [x] `refactor(api)`: extract the shared Project/Tag filter predicate into `buildFilterClauses` (`list-filter.ts`); the keyset page query now uses it
- [x] `feat(api)`: `ChatCountsQuery.queryFilteredTotal` + `ChatReader.listFilteredTotal`; `GET /api/chats/counts` takes the filter params and returns `filteredTotal`
- [x] `feat(web)`: `useFilteredTotal` reads the server filtered total; the header uses it when a filter is active, with no flash on filter change

### Test Verification

- [x] Filtered total: single/multiple Projects (OR), `(No project)` group, multi-Tag AND, `Untagged` group, Project+Tag across-type AND
- [x] Filtered total respects the view (main vs Trash) and degrades to 0 for Trash with no Metadata store
- [x] Route returns `filteredTotal` for the wire filter params (`app.test.ts`)
- [x] Hook holds the previous total while the next is in flight (stale-while-revalidate)
- [x] Hook returns undefined when no filter is active (header falls back to facet total)
- [x] Full suites green: api 260, web 175

## Additional Notes

Ships onto the `integration/server-side-list-pipeline` branch, not `main`, per the list-pipeline integration plan (#126–#132, #143–#146). Completes #131 Phase B; Phase A already landed.

## Related Links

- Closes #131 (Phase B; Phase A already shipped)
- Builds on #130 (server-side Project/Tag filter), ADR-0017