### PR TITLE
feat: server-side keyset pagination for the Trash view

### DIFF
--- a/api/drizzle/0005_add_deleted_at_index.sql
+++ b/api/drizzle/0005_add_deleted_at_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `chats_meta_deleted_at_idx` ON `chats_meta` (`deleted_at`,`id`) WHERE `deleted_at` IS NOT NULL;

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1780000000000,
       "tag": "0004_add_tags",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1780500000000,
+      "tag": "0005_add_deleted_at_index",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -275,6 +275,70 @@ describe("GET /api/chats — keyset pagination mode", () => {
   });
 });
 
+describe("GET /api/chats — Trash view keyset page (#145)", () => {
+  it("serves a trashed-only page sorted by deleted time", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    const c1 = seedChat(archive, {
+      sourceId: "c1",
+      firstSeenAt: new Date(1_000),
+    });
+    seedChat(archive, { sourceId: "c2", firstSeenAt: new Date(2_000) });
+    const c3 = seedChat(archive, {
+      sourceId: "c3",
+      firstSeenAt: new Date(3_000),
+    });
+    metadata.softDelete(c1);
+    metadata.softDelete(c3);
+
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+
+    // sort=deletedAt is accepted (not a 400), and the page is trashed-only: the
+    // active c2 never appears, only the soft-deleted c1 and c3.
+    const res = await app.request(
+      "/api/chats?sort=deletedAt&limit=10&trashedOnly=true"
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    expect(new Set(body.chats.map((c) => c.sourceId))).toEqual(
+      new Set(["c1", "c3"])
+    );
+  });
+
+  it("serves a trashed-only page along a time axis within Trash", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, { sourceId: "active", firstSeenAt: new Date(1_000) });
+    const trashed = seedChat(archive, {
+      sourceId: "trashed",
+      firstSeenAt: new Date(2_000),
+    });
+    metadata.softDelete(trashed);
+
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+
+    // trashedOnly scopes the time-axis page to Trash: the active chat drops out.
+    const res = await app.request(
+      "/api/chats?sort=createdAt&limit=10&trashedOnly=true"
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { chats: ChatResponse[] };
+    expect(body.chats.map((c) => c.sourceId)).toEqual(["trashed"]);
+  });
+});
+
 describe("GET /api/chats/counts — server-side facet counts", () => {
   it("serves per-view counts (main excludes trashed, Trash counts only trashed)", async () => {
     const archive = createArchiveRepository({ dataDir });

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -61,7 +61,13 @@ export function createApp({
         return c.json({ error: "Invalid limit" }, 400);
       }
       const sort = c.req.query("sort") ?? "updatedAt";
-      if (sort !== "createdAt" && sort !== "updatedAt") {
+      // `deletedAt` is the Trash view's deleted-time axis (#145); it sorts
+      // through the ATTACHed Metadata store and is trash-only by nature.
+      if (
+        sort !== "createdAt" &&
+        sort !== "updatedAt" &&
+        sort !== "deletedAt"
+      ) {
         return c.json({ error: "Invalid sort" }, 400);
       }
       // Direction defaults to "desc" (newest-first) so existing callers that
@@ -70,6 +76,10 @@ export function createApp({
       if (direction !== "asc" && direction !== "desc") {
         return c.json({ error: "Invalid direction" }, 400);
       }
+      // The Trash view scopes the page to soft-deleted chats only (#145),
+      // distinct from `includeTrashed` (active + trashed). The frontend sends it
+      // for every Trash page; the `deletedAt` axis is trash-only regardless.
+      const trashedOnly = c.req.query("trashedOnly") === "true";
       // The active filter pages server-side alongside the keyset window (#130),
       // parsed the same way as the legacy full-list branch: repeated `?project=`
       // unions (OR), a single comma-separated `?tags=` ANDs. An empty value
@@ -85,6 +95,7 @@ export function createApp({
         limit,
         cursor: c.req.query("cursor"),
         includeTrashed,
+        trashedOnly,
         projects,
         tags: tagSelection,
       });

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -101,6 +101,12 @@ export interface ChatReader {
     cursor?: string;
     includeTrashed?: boolean;
     /**
+     * Trash view scope: when true the page returns only soft-deleted chats
+     * (#145), distinct from `includeTrashed` (active + trashed). Pairs with the
+     * `deletedAt` sort axis but also applies to the time axes within Trash.
+     */
+    trashedOnly?: boolean;
+    /**
      * Project filter (OR / union), applied server-side inside the keyset query
      * (#130). An empty-string entry selects the `(No project)` group; omitting
      * it leaves Projects unfiltered.
@@ -301,6 +307,7 @@ export function createChatReader({
     limit,
     cursor,
     includeTrashed = false,
+    trashedOnly = false,
     projects,
     tags: tagSelection,
   }: {
@@ -309,6 +316,7 @@ export function createChatReader({
     limit: number;
     cursor?: string;
     includeTrashed?: boolean;
+    trashedOnly?: boolean;
     projects?: string[];
     tags?: string[];
   }): { chats: ChatResponse[]; nextCursor: string | null } {
@@ -324,14 +332,18 @@ export function createChatReader({
       limit,
       cursor: decoded,
       includeTrashed,
+      trashedOnly,
       projects,
       tags: tagSelection,
     });
 
     // The keyset SQL already applied visibility + ordering; hydration is pure
     // assembly over the page's ids, in page order. Visibility is still loaded so
-    // `deletedAt`/`isDeleted` render on the (includeTrashed) Trash path.
-    const visibility = loadChatVisibility(metadata, { includeTrashed });
+    // `deletedAt`/`isDeleted` render on the trashed paths (includeTrashed or the
+    // trashed-only Trash view).
+    const visibility = loadChatVisibility(metadata, {
+      includeTrashed: includeTrashed || trashedOnly,
+    });
     const rowById = new Map(archive.read.listChatRows().map((r) => [r.id, r]));
     const toResponse = loadHydration();
 

--- a/api/src/list-pagination.test.ts
+++ b/api/src/list-pagination.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { createChatReader } from "./chat-reader.js";
 import { createChatPageQuery } from "./list-pagination.js";
@@ -58,6 +59,24 @@ function seedMessage(
       blocks: [{ type: "text", text: "hi" }],
     },
   });
+}
+
+// Soft-delete a chat and pin its deleted_at to a known instant. `softDelete`
+// stamps deleted_at with the wall clock, which collides at ms resolution across
+// rapid calls; the Trash sort tests need deterministic, distinct deleted times,
+// so we overwrite the column directly through a short-lived writable connection.
+function trashChat(
+  metadata: ReturnType<typeof createMetadataRepository>,
+  internalId: string,
+  deletedAt: Date
+): void {
+  metadata.softDelete(internalId);
+  const db = new Database(path.join(dataDir, "metadata.db"));
+  db.prepare("UPDATE chats_meta SET deleted_at = ? WHERE id = ?").run(
+    deletedAt.getTime(),
+    internalId
+  );
+  db.close();
 }
 
 let dataDir: string;
@@ -782,5 +801,339 @@ describe("ChatReader.listChatsPage — server-side filtering (#130)", () => {
     ).toEqual(["b1", "a1"]);
 
     pageQuery.close();
+  });
+});
+
+describe("ChatReader.listChatsPage — Trash view (#145)", () => {
+  it("returns only trashed chats when trashedOnly is set", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    seedChat(archive, { sourceId: "c1", firstSeenAt: new Date(1_000) });
+    const c2 = seedChat(archive, {
+      sourceId: "c2",
+      firstSeenAt: new Date(2_000),
+    });
+    seedChat(archive, { sourceId: "c3", firstSeenAt: new Date(3_000) });
+    trashChat(metadata, c2, new Date(9_000));
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+
+    // The Trash view is trashed-only: active c1/c3 never appear, only the
+    // soft-deleted c2 — unlike includeTrashed, which returns active + trashed.
+    expect(
+      reader
+        .listChatsPage({ sort: "createdAt", limit: 10, trashedOnly: true })
+        .chats.map((c) => c.sourceId)
+    ).toEqual(["c2"]);
+
+    pageQuery.close();
+  });
+
+  it("sorts the Trash view by deleted time, most-recently-deleted first", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    // Created in one order, trashed in another: the deletedAt axis follows the
+    // trash time, independent of createdAt.
+    const c1 = seedChat(archive, {
+      sourceId: "c1",
+      firstSeenAt: new Date(1_000),
+    });
+    const c2 = seedChat(archive, {
+      sourceId: "c2",
+      firstSeenAt: new Date(2_000),
+    });
+    const c3 = seedChat(archive, {
+      sourceId: "c3",
+      firstSeenAt: new Date(3_000),
+    });
+    trashChat(metadata, c1, new Date(30_000)); // deleted last
+    trashChat(metadata, c2, new Date(10_000)); // deleted first
+    trashChat(metadata, c3, new Date(20_000)); // deleted in the middle
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+
+    // Most-recently-deleted first: c1 (30k), c3 (20k), c2 (10k).
+    expect(
+      reader
+        .listChatsPage({ sort: "deletedAt", limit: 10, trashedOnly: true })
+        .chats.map((c) => c.sourceId)
+    ).toEqual(["c1", "c3", "c2"]);
+
+    pageQuery.close();
+  });
+
+  it("walks deletedAt cursors to reproduce the full trash order with no gap or overlap", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    // Five trashed chats with distinct deleted times; newest-deleted first the
+    // order is c5, c4, c3, c2, c1.
+    for (let i = 1; i <= 5; i++) {
+      const id = seedChat(archive, {
+        sourceId: `c${i}`,
+        firstSeenAt: new Date(i * 1000),
+      });
+      trashChat(metadata, id, new Date(i * 10_000));
+    }
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    let guard = 0;
+    do {
+      const page = reader.listChatsPage({
+        sort: "deletedAt",
+        limit: 2,
+        trashedOnly: true,
+        cursor,
+      });
+      seen.push(...page.chats.map((c) => c.sourceId));
+      cursor = page.nextCursor ?? undefined;
+    } while (cursor && ++guard < 10);
+
+    // Most-recently-deleted first across every page, each chat exactly once —
+    // the cursor stays strictly past the previous page's last deleted_at.
+    expect(seen).toEqual(["c5", "c4", "c3", "c2", "c1"]);
+
+    pageQuery.close();
+  });
+
+  it("paginates a run of equal deleted times by id tiebreak with no drop or duplicate", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    // Four trashed chats share one deleted_at; only the id tiebreak separates
+    // them, so the cursor must carry it to page the run cleanly.
+    for (let i = 1; i <= 4; i++) {
+      const id = seedChat(archive, {
+        sourceId: `c${i}`,
+        firstSeenAt: new Date(i * 1000),
+      });
+      trashChat(metadata, id, new Date(10_000));
+    }
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    let guard = 0;
+    do {
+      const page = reader.listChatsPage({
+        sort: "deletedAt",
+        limit: 2,
+        trashedOnly: true,
+        cursor,
+      });
+      seen.push(...page.chats.map((c) => c.sourceId));
+      cursor = page.nextCursor ?? undefined;
+    } while (cursor && ++guard < 10);
+
+    // Every chat exactly once across the tie boundary — no skip, no repeat.
+    expect(seen).toHaveLength(4);
+    expect(new Set(seen)).toEqual(new Set(["c1", "c2", "c3", "c4"]));
+
+    pageQuery.close();
+  });
+
+  it("walks deletedAt asc cursors oldest-deleted first across pages", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    for (let i = 1; i <= 5; i++) {
+      const id = seedChat(archive, {
+        sourceId: `c${i}`,
+        firstSeenAt: new Date(i * 1000),
+      });
+      trashChat(metadata, id, new Date(i * 10_000));
+    }
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    let guard = 0;
+    do {
+      const page = reader.listChatsPage({
+        sort: "deletedAt",
+        direction: "asc",
+        limit: 2,
+        trashedOnly: true,
+        cursor,
+      });
+      seen.push(...page.chats.map((c) => c.sourceId));
+      cursor = page.nextCursor ?? undefined;
+    } while (cursor && ++guard < 10);
+
+    // Oldest-deleted first across every page — the asc cursor mirrors the desc
+    // stability, flipping both the comparison and the order.
+    expect(seen).toEqual(["c1", "c2", "c3", "c4", "c5"]);
+
+    pageQuery.close();
+  });
+
+  it("orders the Trash view by a time axis independently of deleted time", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    // createdAt order is [b, a]; deleted_at order is the reverse [a, b]. Sorting
+    // the trash-only page by createdAt must follow createdAt, not the trash time.
+    const a = seedChat(archive, {
+      sourceId: "a",
+      firstSeenAt: new Date(1_000),
+    });
+    const b = seedChat(archive, {
+      sourceId: "b",
+      firstSeenAt: new Date(2_000),
+    });
+    seedChat(archive, { sourceId: "active", firstSeenAt: new Date(3_000) });
+    trashChat(metadata, a, new Date(20_000));
+    trashChat(metadata, b, new Date(10_000));
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+    const page = reader.listChatsPage({
+      sort: "createdAt",
+      limit: 10,
+      trashedOnly: true,
+    });
+
+    // Newest createdAt first within trash; the active chat is excluded.
+    expect(page.chats.map((c) => c.sourceId)).toEqual(["b", "a"]);
+
+    pageQuery.close();
+  });
+
+  it("composes a Project filter with the trashed-only scope", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const alphaTrashed = seedChat(archive, {
+      sourceId: "alphaTrashed",
+      firstSeenAt: new Date(1_000),
+      project: "alpha",
+    });
+    const betaTrashed = seedChat(archive, {
+      sourceId: "betaTrashed",
+      firstSeenAt: new Date(2_000),
+      project: "beta",
+    });
+    seedChat(archive, {
+      sourceId: "alphaActive",
+      firstSeenAt: new Date(3_000),
+      project: "alpha",
+    });
+    trashChat(metadata, alphaTrashed, new Date(10_000));
+    trashChat(metadata, betaTrashed, new Date(20_000));
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+    const page = reader.listChatsPage({
+      sort: "deletedAt",
+      limit: 10,
+      trashedOnly: true,
+      projects: ["alpha"],
+    });
+
+    // Trash + Project filter: the trashed alpha chat shows; the trashed beta
+    // chat (wrong Project) and the active alpha chat (not trashed) do not.
+    expect(page.chats.map((c) => c.sourceId)).toEqual(["alphaTrashed"]);
+
+    pageQuery.close();
+  });
+
+  it("returns an empty deletedAt page when there is no Metadata store", () => {
+    const archive = createArchiveRepository({ dataDir });
+    seedChat(archive, { sourceId: "c1", firstSeenAt: new Date(1_000) });
+
+    // No metadata repo is created, so metadata.db is absent: a deleted-time read
+    // has no trashed chats to return, rather than throwing on the missing join.
+    const pageQuery = createChatPageQuery({ dataDir });
+    const page = pageQuery.queryPage({
+      sort: "deletedAt",
+      limit: 10,
+      trashedOnly: true,
+    });
+
+    expect(page.items).toEqual([]);
+    expect(page.nextCursor).toBeNull();
+
+    pageQuery.close();
+  });
+
+  it("hydrates a deletedAt page row with its deleted time and trashed flag", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const id = seedChat(archive, {
+      sourceId: "c1",
+      firstSeenAt: new Date(1_000),
+    });
+    trashChat(metadata, id, new Date(42_000));
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+    const page = reader.listChatsPage({
+      sort: "deletedAt",
+      limit: 10,
+      trashedOnly: true,
+    });
+
+    expect(page.chats).toHaveLength(1);
+    const chat = page.chats[0];
+    expect(chat.sourceId).toBe("c1");
+    expect(chat.deletedAt).toBe(42_000);
+    expect(chat.isDeleted).toBe(true);
+
+    pageQuery.close();
+  });
+
+  it("orders the deletedAt page through the covering index, not a full scan + sort", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    for (let i = 1; i <= 50; i++) {
+      const id = seedChat(archive, {
+        sourceId: `c${i}`,
+        firstSeenAt: new Date(i * 1000),
+      });
+      trashChat(metadata, id, new Date(i * 10_000));
+    }
+    void tags;
+
+    // Inspect how SQLite plans the deleted-time page. AC #2 (ADR-0017): the
+    // ordering must be an index range scan over the deleted-time axis, never a
+    // materialize-the-whole-trash-then-sort pass.
+    const db = new Database(path.join(dataDir, "archive.db"), {
+      readonly: true,
+    });
+    db.prepare("ATTACH DATABASE ? AS meta").run(
+      path.join(dataDir, "metadata.db")
+    );
+    const plan = db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT c.id AS id, m.deleted_at AS sortKey
+         FROM chats c JOIN meta.chats_meta m ON m.id = c.id
+         WHERE m.deleted_at IS NOT NULL
+         ORDER BY m.deleted_at DESC, m.id DESC
+         LIMIT 10`
+      )
+      .all() as { detail: string }[];
+    db.close();
+
+    const detail = plan.map((p) => p.detail).join("\n");
+    // The deleted-time order is served by the keyset index...
+    expect(detail).toContain("chats_meta_deleted_at_idx");
+    // ...so there is no temp B-tree sorting the whole trash set.
+    expect(detail).not.toMatch(/USE TEMP B-TREE FOR ORDER BY/i);
   });
 });

--- a/api/src/list-pagination.ts
+++ b/api/src/list-pagination.ts
@@ -16,8 +16,14 @@ import { buildFilterClauses } from "./list-filter.js";
  * into the public Chat shape, keeping the SQL here and the derivation there.
  */
 
-/** The two time axes the keyset index supports (ADR-0017). */
-export type ListSort = "createdAt" | "updatedAt";
+/**
+ * The sort axes the keyset index supports. `createdAt`/`updatedAt` are
+ * denormalized columns on the Archive `chats` table (ADR-0017). `deletedAt` is
+ * the Trash view's own axis (#145): it lives in the Metadata store
+ * (`meta.chats_meta.deleted_at`), so it sorts through the `ATTACH`ed join and
+ * is meaningful only for trashed chats.
+ */
+export type ListSort = "createdAt" | "updatedAt" | "deletedAt";
 
 /**
  * Sort direction along the time axis. The covering `(sortKey, id)` indexes scan
@@ -56,6 +62,14 @@ export interface KeysetPageQuery {
   /** Default false: trashed chats are excluded from the page. */
   includeTrashed?: boolean;
   /**
+   * Default false. When true the page is the Trash view: only soft-deleted
+   * chats (`is_deleted = 1`) appear, the inverse of the default active list.
+   * Distinct from `includeTrashed` (active + trashed); this is trashed-only
+   * (#145). With no Metadata store there are no trashed chats, so the page is
+   * empty.
+   */
+  trashedOnly?: boolean;
+  /**
    * Project filter (OR / union): the page keeps only chats in any of these
    * `chats.project` values. An empty-string entry selects the `(No project)`
    * group (NULL or ''). Omit or pass an empty array to leave Projects
@@ -81,11 +95,15 @@ export interface ChatPageQuery {
 const ARCHIVE_DB = "archive.db";
 const METADATA_DB = "metadata.db";
 
-// The sort axis maps to a real, indexed column on `chats` — never interpolated
-// from caller input, so the column name in the SQL stays a fixed whitelist.
-const SORT_COLUMN: Record<ListSort, string> = {
-  createdAt: "created_at",
-  updatedAt: "updated_at",
+// The sort axis maps to a real, indexed column expression — never interpolated
+// from caller input, so the column in the SQL stays a fixed whitelist. The two
+// time axes are denormalized columns on the Archive `chats` (alias `c`);
+// `deletedAt` lives on the `ATTACH`ed Metadata row (alias `m`), reached through
+// the join the deletedAt path adds (#145).
+const SORT_EXPR: Record<ListSort, string> = {
+  createdAt: "c.created_at",
+  updatedAt: "c.updated_at",
+  deletedAt: "m.deleted_at",
 };
 
 /** Opaque page token for the wire — base64 JSON of the (sortKey, id) cursor. */
@@ -132,14 +150,42 @@ export function createChatPageQuery({
   }
 
   function queryPage(query: KeysetPageQuery): KeysetPage {
-    const col = SORT_COLUMN[query.sort];
+    const sortExpr = SORT_EXPR[query.sort];
+    // The deletedAt axis lives in the Metadata store, so its sort + keyset run
+    // through a join onto the `ATTACH`ed `meta.chats_meta` (alias `m`); the time
+    // axes stay on `chats` alone. With no Metadata store there is nothing to
+    // join and no trashed chats, so the page is empty.
+    const needsMetaJoin = query.sort === "deletedAt";
+    if (needsMetaJoin && !hasMetadata) return { items: [], nextCursor: null };
+    const from = needsMetaJoin
+      ? "chats c JOIN meta.chats_meta m ON m.id = c.id"
+      : "chats c";
+    // Tie-break by the joined `m.id` on the deletedAt axis so the `(deleted_at,
+    // id)` covering index serves the whole ORDER BY; otherwise by `c.id`. The
+    // two are the same value (`m.id = c.id`).
+    const idCol = needsMetaJoin ? "m.id" : "c.id";
+
     const clauses: string[] = [];
     const params: (string | number)[] = [];
 
-    // Active-list semantics: soft-deleted chats never appear in a page unless
-    // the caller asks for trashed. The flag lives in the Metadata store, so the
-    // exclusion rides the `ATTACH`ed `meta.chats_meta`.
-    if (!query.includeTrashed && hasMetadata) {
+    // Visibility scope. The Trash view (`trashedOnly`) keeps only soft-deleted
+    // chats; the default active list keeps only non-deleted ones (unless the
+    // caller opts into `includeTrashed`, which keeps both). The flag lives in
+    // the Metadata store, so the scope rides the `ATTACH`ed `meta.chats_meta` —
+    // and with no Metadata store there are no trashed chats, so Trash is empty.
+    if (needsMetaJoin) {
+      // Deleted-time ordering is trash-only by nature: a non-trashed chat has a
+      // null deleted_at and no place on this axis. The scope is phrased as
+      // `deleted_at IS NOT NULL` (equivalent to `is_deleted = 1` — restore nulls
+      // deleted_at) so it matches the partial `chats_meta_deleted_at_idx`
+      // predicate exactly, letting that covering index drive the ordered scan.
+      clauses.push("m.deleted_at IS NOT NULL");
+    } else if (query.trashedOnly) {
+      if (!hasMetadata) return { items: [], nextCursor: null };
+      clauses.push(
+        "c.id IN (SELECT id FROM meta.chats_meta WHERE is_deleted = 1)"
+      );
+    } else if (!query.includeTrashed && hasMetadata) {
       clauses.push(
         "c.id NOT IN (SELECT id FROM meta.chats_meta WHERE is_deleted = 1)"
       );
@@ -168,7 +214,9 @@ export function createChatPageQuery({
     // Keyset cursor: strictly after the last row of the previous page in the
     // (sortKey, id) order for this direction.
     if (query.cursor) {
-      clauses.push(`(c.${col} ${cmp} ? OR (c.${col} = ? AND c.id ${cmp} ?))`);
+      clauses.push(
+        `(${sortExpr} ${cmp} ? OR (${sortExpr} = ? AND ${idCol} ${cmp} ?))`
+      );
       params.push(query.cursor.sortKey, query.cursor.sortKey, query.cursor.id);
     }
 
@@ -176,9 +224,9 @@ export function createChatPageQuery({
     // Fetch one extra row to tell whether a next page exists without a count.
     const rows = archive
       .prepare(
-        `SELECT c.id AS id, c.${col} AS sortKey
-         FROM chats c ${where}
-         ORDER BY c.${col} ${order}, c.id ${order}
+        `SELECT c.id AS id, ${sortExpr} AS sortKey
+         FROM ${from} ${where}
+         ORDER BY ${sortExpr} ${order}, ${idCol} ${order}
          LIMIT ?`
       )
       .all(...params, query.limit + 1) as KeysetPageItem[];

--- a/api/src/metadata/schema.ts
+++ b/api/src/metadata/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   index,
   integer,
@@ -6,18 +7,32 @@ import {
   text,
 } from "drizzle-orm/sqlite-core";
 
-export const chatsMeta = sqliteTable("chats_meta", {
-  id: text("id").primaryKey(),
-  isDeleted: integer("is_deleted", { mode: "boolean" })
-    .notNull()
-    .default(false),
-  customTitle: text("custom_title"),
-  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
-  // Set when a chat is moved to Trash; null while active. Drives the Trash
-  // view's independent "Deleted time" sort axis.
-  deletedAt: integer("deleted_at", { mode: "timestamp_ms" }),
-});
+export const chatsMeta = sqliteTable(
+  "chats_meta",
+  {
+    id: text("id").primaryKey(),
+    isDeleted: integer("is_deleted", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    customTitle: text("custom_title"),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+    // Set when a chat is moved to Trash; null while active. Drives the Trash
+    // view's independent "Deleted time" sort axis.
+    deletedAt: integer("deleted_at", { mode: "timestamp_ms" }),
+  },
+  (table) => [
+    // Covering keyset index for the Trash view's deleted-time axis (#145,
+    // ADR-0017): `(deleted_at, id)` so the page's ORDER BY + LIMIT is an index
+    // range scan, not a full-trash sort. Partial on `deleted_at IS NOT NULL`,
+    // which holds exactly for trashed rows (restore nulls it), so the index
+    // carries only the Trash set and the page query's matching predicate lets
+    // the planner use it.
+    index("chats_meta_deleted_at_idx")
+      .on(table.deletedAt, table.id)
+      .where(sql`${table.deletedAt} is not null`),
+  ]
+);
 
 // A user-defined Tag. `color` holds a semantic palette token (e.g. "violet"),
 // never a raw hex — rendering resolves token→hex through one shared map

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1863,7 +1863,7 @@ describe("Chat list pagination", () => {
     expect(searches.every((s) => s.includes("limit="))).toBe(true);
   });
 
-  it("uses the full-load path for the Trash view", async () => {
+  it("uses the keyset paginated path for the Trash view (#145)", async () => {
     const user = userEvent.setup();
     const searches = captureChatListRequests();
     render(<App />);
@@ -1871,9 +1871,20 @@ describe("Chat list pagination", () => {
 
     await user.click(screen.getByTestId("trash-link"));
 
-    // Trash stays on the client-side full-load path; its deleted chats load.
+    // Trash no longer pulls the full list (ADR-0018): it pages server-side,
+    // trashed-only, defaulting to the deleted-time axis (#145). Its deleted
+    // chats load through the keyset endpoint.
     const list = screen.getByTestId("chat-list");
     expect(await within(list).findByText("Old prototype")).toBeInTheDocument();
-    expect(searches.some((s) => !s.includes("limit="))).toBe(true);
+    await waitFor(() =>
+      expect(
+        searches.some(
+          (s) =>
+            s.includes("limit=") &&
+            s.includes("trashedOnly=true") &&
+            s.includes("sort=deletedAt")
+        )
+      ).toBe(true)
+    );
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,7 +10,7 @@ import { useMessages } from "@/conversation/useMessages";
 import { useToast } from "@/shared/useToast";
 import { useChatOrder } from "@/chat/sort/useChatOrder";
 import { useSortPreference } from "@/chat/sort/useSortPreference";
-import { CHAT_SORT_CONFIG } from "@/chat/sort/sortConfig";
+import { CHAT_SORT_CONFIG, TRASH_SORT_CONFIG } from "@/chat/sort/sortConfig";
 import { facetsFromCounts } from "@/chat/projects/projectFacets";
 import { useChatCounts } from "@/chat/useChatCounts";
 import { useFilteredTotal } from "@/chat/useFilteredTotal";
@@ -33,21 +33,33 @@ function App() {
   const [mode, setMode] = useState<"main" | "trash">("main");
   const [editingTitleId, setEditingTitleId] = useState<string | null>(null);
 
-  // The main view's sort preference is owned here, not inside useChatOrder, so
-  // the data path and the SortControl agree on one instance: the same field and
+  // The sort preferences are owned here, not inside useChatOrder, so the data
+  // path and each view's SortControl agree on one instance: the same field and
   // direction decide whether to paginate.
   const mainPref = useSortPreference(CHAT_SORT_CONFIG);
+  const trashPref = useSortPreference(TRASH_SORT_CONFIG);
 
-  // The main view's time sorts page server-side in both directions: the keyset
-  // index covers createdAt/updatedAt either way (ADR-0017, #143). Title sort and
-  // the Trash view stay on the full-load client path. The two read hooks always
-  // run (hooks rule); `enabled` decides which one fetches.
-  const paginate =
+  // Both views page server-side on a time axis: the keyset index covers
+  // createdAt/updatedAt either way (ADR-0017, #143), and the Trash view adds the
+  // deleted-time axis through the ATTACHed Metadata store (#145). Only the Title
+  // sort stays on the full-load client path, until it migrates (#146). The read
+  // hooks always run (hooks rule); `enabled` decides which one fetches.
+  const mainPaginate =
     mode === "main" &&
     (mainPref.field === "createdAt" || mainPref.field === "updatedAt");
+  const trashPaginate = mode === "trash" && trashPref.field !== "title";
+  const paginate = mainPaginate || trashPaginate;
   const pageSort: ListSort =
     mainPref.field === "createdAt" ? "createdAt" : "updatedAt";
   const pageDirection: ListDirection = mainPref.direction;
+  // The Trash axis maps straight to a keyset sort; Title never reaches here
+  // (trashPaginate is false for it), so the fallback is the default deletedAt.
+  const trashPageSort: ListSort =
+    trashPref.field === "createdAt"
+      ? "createdAt"
+      : trashPref.field === "updatedAt"
+        ? "updatedAt"
+        : "deletedAt";
 
   // The active filter is owned here so the paginated read path can push it into
   // the keyset query (#130): an empty selection means "all". Declared above the
@@ -62,14 +74,30 @@ function App() {
 
   const full = useChats({ enabled: !paginate });
   // The paginated path filters server-side: the selection rides the keyset query
-  // and re-anchors the window on change (#130). The full-load path (Title sort,
-  // Trash) keeps filtering its loaded window client-side below.
+  // and re-anchors the window on change (#130). The full-load path (Title sort)
+  // keeps filtering its loaded window client-side below.
   const paginated = usePaginatedChats(pageSort, pageDirection, {
-    enabled: paginate,
+    enabled: mainPaginate,
     projects: [...selectedProjects],
     tags: [...selectedTags],
   });
-  const source = paginate ? paginated : full;
+  // The Trash view reuses the same paginated read path, scoped to trashed-only
+  // (#145). It re-anchors on the active filter and the deleted-time axis the
+  // same way the main view does on its time axes.
+  const trashPaginated = usePaginatedChats(trashPageSort, trashPref.direction, {
+    enabled: trashPaginate,
+    trashedOnly: true,
+    projects: [...selectedProjects],
+    tags: [...selectedTags],
+  });
+  const source =
+    mode === "trash"
+      ? trashPaginate
+        ? trashPaginated
+        : full
+      : mainPaginate
+        ? paginated
+        : full;
   const { chats, sortEpoch, softDelete, restore, setTitle, reload } = source;
 
   // Filter-panel facet counts and the unfiltered List count come from a server
@@ -113,7 +141,7 @@ function App() {
   // frozen order; sort field/direction changes flush it inside the hook.
   const resortKey = `${sortEpoch}:${viewGen}`;
   const mainOrder = useChatOrder("main", chats, resortKey, mainPref);
-  const trashOrder = useChatOrder("trash", chats, resortKey);
+  const trashOrder = useChatOrder("trash", chats, resortKey, trashPref);
   const order = mode === "trash" ? trashOrder : mainOrder;
   const mainChats = mainOrder.orderedChats;
   const deletedChats = trashOrder.orderedChats;

--- a/web/src/chat/usePaginatedChats.test.tsx
+++ b/web/src/chat/usePaginatedChats.test.tsx
@@ -157,6 +157,25 @@ describe("usePaginatedChats", () => {
     );
   });
 
+  it("loads a trashed-only page sorted by deleted time (#145)", async () => {
+    // The Trash view pages server-side: trashed-only, most-recently-deleted
+    // first. chat-deleted-1 (deletedAt 1700000200000) precedes chat-deleted-2
+    // (1700000100000); every active chat is excluded.
+    const { result } = renderHook(() =>
+      usePaginatedChats("deletedAt", "desc", {
+        pageSize: 10,
+        trashedOnly: true,
+      })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.chats.map((c) => c.id)).toEqual([
+      "chat-deleted-1",
+      "chat-deleted-2",
+    ]);
+  });
+
   it("ignores a failed background refresh instead of crashing", async () => {
     const { result } = renderHook(() =>
       usePaginatedChats("updatedAt", "desc", { pageSize: 2 })

--- a/web/src/chat/usePaginatedChats.ts
+++ b/web/src/chat/usePaginatedChats.ts
@@ -3,9 +3,11 @@ import { MAX_PAGE_LIMIT } from "@contract";
 import type { Chat } from "@/types";
 import { useChatMutations, type ChatListSource } from "@/chat/useChatMutations";
 
-// The two time axes the keyset page endpoint supports (#129 / ADR-0017). Title
-// stays on the full-load client path, so it never reaches here.
-export type ListSort = "createdAt" | "updatedAt";
+// The sort axes the keyset page endpoint supports. createdAt/updatedAt are the
+// main view's time axes (#129 / ADR-0017); deletedAt is the Trash view's
+// deleted-time axis (#145), valid only alongside `trashedOnly`. Title stays on
+// the full-load client path, so it never reaches here.
+export type ListSort = "createdAt" | "updatedAt" | "deletedAt";
 
 // Both directions of each time axis page server-side (#143): the covering keyset
 // index scans either way, so "Oldest first" no longer falls back to full-load.
@@ -53,6 +55,13 @@ interface UsePaginatedChatsOptions {
    * Untagged group. An empty array leaves Tags unfiltered. Re-anchors on change.
    */
   tags?: readonly string[];
+  /**
+   * Trash view scope (#145): when true the page is trashed-only, the inverse of
+   * the default active list. Pairs with the `deletedAt` sort axis but also
+   * scopes the time axes within Trash. Sent to the keyset query as
+   * `trashedOnly=true`.
+   */
+  trashedOnly?: boolean;
 }
 
 /** The active list filter sent to the keyset query alongside sort + cursor. */
@@ -77,9 +86,12 @@ function pageUrl(
   direction: ListDirection,
   limit: number,
   filter: ActiveFilter,
+  trashedOnly: boolean,
   cursor?: string
 ): string {
   let base = `/api/chats?sort=${sort}&direction=${direction}&limit=${limit}`;
+  // The Trash view scopes the page to soft-deleted chats only (#145).
+  if (trashedOnly) base += `&trashedOnly=true`;
   // Repeated `?project=` unions (OR); a single comma-separated `?tags=` ANDs.
   // An empty-string entry rides through as `?project=` / `?tags=`, selecting the
   // (No project) / Untagged group — the same wire form the server parses (#130).
@@ -119,6 +131,7 @@ export function usePaginatedChats(
     enabled = true,
     projects = [],
     tags = [],
+    trashedOnly = false,
   }: UsePaginatedChatsOptions = {}
 ): UsePaginatedChatsResult {
   // The selection arrays change identity every render (App spreads a Set), so a
@@ -164,7 +177,9 @@ export function usePaginatedChats(
     let cancelled = false;
     cursorRef.current = null;
     fetchingRef.current = true;
-    void fetchPage(pageUrl(sort, direction, pageSize, filter)).then((data) => {
+    void fetchPage(
+      pageUrl(sort, direction, pageSize, filter, trashedOnly)
+    ).then((data) => {
       if (cancelled) return;
       if (data) {
         setChats(data.chats);
@@ -177,23 +192,23 @@ export function usePaginatedChats(
     return () => {
       cancelled = true;
     };
-  }, [sort, direction, pageSize, enabled, filter]);
+  }, [sort, direction, pageSize, enabled, filter, trashedOnly]);
 
   const loadMore = useCallback(() => {
     if (fetchingRef.current || cursorRef.current === null) return;
     const cursor = cursorRef.current;
     fetchingRef.current = true;
-    void fetchPage(pageUrl(sort, direction, pageSize, filter, cursor)).then(
-      (data) => {
-        if (data) {
-          setChats((prev) => [...prev, ...data.chats]);
-          setNextCursor(data.nextCursor);
-          cursorRef.current = data.nextCursor;
-        }
-        fetchingRef.current = false;
+    void fetchPage(
+      pageUrl(sort, direction, pageSize, filter, trashedOnly, cursor)
+    ).then((data) => {
+      if (data) {
+        setChats((prev) => [...prev, ...data.chats]);
+        setNextCursor(data.nextCursor);
+        cursorRef.current = data.nextCursor;
       }
-    );
-  }, [sort, direction, pageSize, filter]);
+      fetchingRef.current = false;
+    });
+  }, [sort, direction, pageSize, filter, trashedOnly]);
 
   // Re-read the top of the loaded window. Sized to the current window so a
   // brand-new chat ranking into it is surfaced, but clamped to the page-limit
@@ -205,9 +220,11 @@ export function usePaginatedChats(
       Math.max(chatsRef.current.length, pageSize),
       MAX_PAGE_LIMIT
     );
-    const data = await fetchPage(pageUrl(sort, direction, limit, filter));
+    const data = await fetchPage(
+      pageUrl(sort, direction, limit, filter, trashedOnly)
+    );
     if (data) setChats((prev) => mergeWindow(prev, data.chats));
-  }, [sort, direction, pageSize, filter]);
+  }, [sort, direction, pageSize, filter, trashedOnly]);
 
   useEffect(() => {
     if (!enabled) return;

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -217,9 +217,14 @@ export const handlers = [
   http.get("/api/chats", ({ request }) => {
     const url = new URL(request.url);
     const includeTrashed = url.searchParams.get("includeTrashed") === "true";
-    const visible = includeTrashed
-      ? fakeChats
-      : fakeChats.filter((c) => !c.isDeleted);
+    // The Trash view scopes the page to soft-deleted chats only (#145), distinct
+    // from includeTrashed (active + trashed).
+    const trashedOnly = url.searchParams.get("trashedOnly") === "true";
+    const visible = trashedOnly
+      ? fakeChats.filter((c) => c.isDeleted)
+      : includeTrashed
+        ? fakeChats
+        : fakeChats.filter((c) => !c.isDeleted);
 
     // Paginated mode mirrors the merged backend (#142, #143): `?limit=` opts into
     // one server-sorted keyset page, with an opaque cursor and `nextCursor` (null
@@ -235,15 +240,24 @@ export const handlers = [
       if (!Number.isInteger(limit) || limit <= 0 || limit > MAX_PAGE_LIMIT) {
         return HttpResponse.json({ error: "Invalid limit" }, { status: 400 });
       }
+      const sortParam = url.searchParams.get("sort");
       const sort =
-        url.searchParams.get("sort") === "createdAt"
+        sortParam === "createdAt"
           ? "createdAt"
-          : "updatedAt";
+          : sortParam === "deletedAt"
+            ? "deletedAt"
+            : "updatedAt";
       const direction =
         url.searchParams.get("direction") === "asc" ? "asc" : "desc";
       const dir = direction === "asc" ? -1 : 1;
+      // deletedAt is the Trash deleted-time axis (#145); a null deletedAt (an
+      // active chat that slipped through) sorts as the oldest possible time.
       const sortKeyOf = (c: FakeChat) =>
-        sort === "createdAt" ? c.createdAt : c.updatedAt;
+        sort === "createdAt"
+          ? c.createdAt
+          : sort === "deletedAt"
+            ? (c.deletedAt ?? 0)
+            : c.updatedAt;
       // Project (OR) + Tag (AND) filtering inside the paginated query, mirroring
       // the server (#130). Repeated `?project=` unions; `?tags=` is one
       // comma-separated AND set. An empty value selects the (No project) /


### PR DESCRIPTION
## Background (Why)

Opening Trash pulled the full list of trashed chats into the browser and sorted them client-side — the same cost the list pipeline epic exists to remove. Issue #145 moves Trash onto the keyset-paginated path the main view already uses, so it loads a first page fast and fetches more on scroll, and so every list concern (sort, filter, counts) lives in one server-side path rather than two (ADR-0018).

## Approach (How)

The Trash view is trashed-only and sorts by deleted time, which lives in the Metadata store (`meta.chats_meta.deleted_at`), not on the Archive `chats` table. So:

- The keyset query gains a `deletedAt` sort axis that runs through the ATTACHed Metadata join (ADR-0017), tie-broken by `id` so a covering keyset index serves the whole ORDER BY, and a `trashedOnly` scope distinct from `includeTrashed` (active + trashed).
- The deleted-time axis is trash-only by nature; it filters `deleted_at IS NOT NULL` (equivalent to `is_deleted = 1` since restore nulls `deleted_at`) so it matches a **partial** covering index `chats_meta_deleted_at_idx (deleted_at, id) WHERE deleted_at IS NOT NULL`. The page is then an index range scan, not a materialize-then-sort — verified by `EXPLAIN QUERY PLAN` (no temp B-tree).
- The frontend reuses `usePaginatedChats` (extended with the axis + scope) and the shared `useChatOrder`/`useFrozenSort` window-freeze, so Trash gets first-page + fetch-on-scroll and the same freeze/re-sort behavior as the main view. Title-in-Trash stays full-load until #146.

## Changes (What)

- [x] `deletedAt` sort axis + `trashedOnly` scope in the keyset query (`list-pagination.ts`), threaded through `chat-reader` and `GET /api/chats`.
- [x] Partial covering index `chats_meta_deleted_at_idx` (schema + migration `0005`).
- [x] `usePaginatedChats` gains `deletedAt` + `trashedOnly`; `App` drives the Trash view through it with its own (deleted-time default) sort preference.
- [x] Updated the obsolete "Trash uses full-load" test to assert the paginated path.

### Test Verification

- [x] Trashed-only filtering; deleted-time ordering (desc default + asc); cursor stability across distinct and equal deleted times.
- [x] createdAt/updatedAt time axes within Trash; Project/Tag filter composed with trashed-only; empty page when no Metadata store.
- [x] `EXPLAIN QUERY PLAN` confirms the deleted-time page uses the covering index with no temp B-tree sort.
- [x] Endpoint serves `sort=deletedAt&trashedOnly=true`; web hook sends the wire params; App switches Trash to the paginated endpoint.
- [x] Full suites green: api 272/272, web 176/176, typecheck clean both sides.

## Additional Notes

Window-freeze in Trash (AC#4) rides the shared `useChatOrder`/`useFrozenSort` layer already covered by the main view's freeze tests — the Trash view now runs the identical ordering path. Title-in-Trash remains full-load and migrates with #146.

This PR targets the `integration/server-side-list-pipeline` integration branch, not `main`.

## Related Links

- Closes #145
- ADR-0017 (cross-store pagination uses ATTACH), ADR-0018 (single keyset read path)