### PR TITLE
feat: bound the loaded list window with page eviction

### DIFF
--- a/web/e2e/chat-list-pagination.spec.ts
+++ b/web/e2e/chat-list-pagination.spec.ts
@@ -1,10 +1,12 @@
 import { test, expect, type Page } from "@playwright/test";
 
-// More chats than the keyset cap (200) so the loaded window can grow past it —
-// the condition that crashed the background refresh. Descending updatedAt order,
-// so "Chat 0" is newest and sorts first. The cursor here just encodes the next
-// offset — opaque to the frontend, which only echoes nextCursor back.
-const TOTAL = 220;
+// More chats than the bounded window holds (default 8 pages × 30 = 240 rows) so
+// deep scroll evicts pages above and scroll-back re-fetches them (#132), and
+// more than the keyset cap (200) so a window-sized request would be rejected —
+// the crash condition #147 guarded. Descending updatedAt order, so "Chat 0" is
+// newest and sorts first. The cursor just encodes the next offset — opaque to
+// the frontend, which only echoes nextCursor back.
+const TOTAL = 400;
 const MAX_PAGE_LIMIT = 200;
 
 function allChats() {
@@ -123,21 +125,57 @@ test.describe("Chat list pagination", () => {
     await page.goto("/");
     await expect(page.getByText("Chat 0", { exact: true })).toBeVisible();
 
-    // Walk every page so the loaded window exceeds the 200 cap, confirming deep
-    // continuous scroll never blanks the list (#147). The window-sized refresh's
-    // own limit-clamping is covered by usePaginatedChats' unit tests; live
-    // updates are a server push now (#132), so no periodic window-sized refetch
-    // fires here.
+    // Walk every page to the very bottom, confirming deep continuous scroll —
+    // which now also evicts pages above the bounded window (#132) — never blanks
+    // the list (#147). The window-sized refresh's own limit-clamping is covered
+    // by usePaginatedChats' unit tests; live updates are a server push now
+    // (#132), so no periodic window-sized refetch fires here.
     const scroller = page.getByTestId("chat-scroll");
-    for (let i = 0; i < 60; i++) {
+    for (let i = 0; i < 80; i++) {
       await scroller.evaluate((el) => {
         el.scrollTop = el.scrollHeight;
       });
-      await page.waitForTimeout(150);
+      await page.waitForTimeout(120);
     }
 
     await expect(page.getByTestId("chat-row").first()).toBeVisible();
-    await expect(page.getByText("Chat 219", { exact: true })).toBeVisible();
+    await expect(page.getByText("Chat 399", { exact: true })).toBeVisible();
+    expect(errors, errors.join("\n")).toEqual([]);
+  });
+
+  test("re-fetches evicted pages on scroll-back to the top", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (e) => errors.push(String(e)));
+    page.on("console", (m) => {
+      if (m.type() === "error") errors.push(m.text());
+    });
+
+    await mockChatPages(page);
+    await page.goto("/");
+    await expect(page.getByText("Chat 0", { exact: true })).toBeVisible();
+
+    // Scroll deep enough to evict the head pages, then back to the very top. The
+    // head rows were dropped from the window, so seeing "Chat 0" again proves the
+    // evicted page was re-fetched on scroll-back (#132), not merely retained.
+    const scroller = page.getByTestId("chat-scroll");
+    for (let i = 0; i < 80; i++) {
+      await scroller.evaluate((el) => {
+        el.scrollTop = el.scrollHeight;
+      });
+      await page.waitForTimeout(120);
+    }
+    await expect(page.getByText("Chat 399", { exact: true })).toBeVisible();
+
+    for (let i = 0; i < 80; i++) {
+      await scroller.evaluate((el) => {
+        el.scrollTop = 0;
+      });
+      await page.waitForTimeout(120);
+    }
+
+    await expect(page.getByText("Chat 0", { exact: true })).toBeVisible();
     expect(errors, errors.join("\n")).toEqual([]);
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -352,6 +352,8 @@ function App() {
             sortControl={<SortControl {...order.sortControlProps} />}
             hasMore={source.hasMore}
             onLoadMore={source.loadMore}
+            hasPrevious={source.hasPrevious}
+            onLoadPrevious={source.loadPrevious}
           />
         </ResizablePanel>
         <ResizableHandle />

--- a/web/src/chat/ChatList.tsx
+++ b/web/src/chat/ChatList.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ArrowLeft, Pencil, RotateCcw, Trash2 } from "lucide-react";
 import type { Chat } from "@/types";
@@ -31,12 +37,20 @@ interface ChatListProps {
   hasMore?: boolean;
   /** Called when the user scrolls within a few rows of the loaded window's end. */
   onLoadMore?: () => void;
+  /**
+   * True while a page evicted above the bounded window can be re-fetched; gates
+   * near-top loading (#132). False at the list head and on the full path.
+   */
+  hasPrevious?: boolean;
+  /** Called when the user scrolls within a few rows of the loaded window's start. */
+  onLoadPrevious?: () => void;
 }
 
 // Trigger the next page once the rendered window reaches within this many rows
-// of the end, so the fetch overlaps the remaining scroll rather than stalling
-// at the very bottom.
+// of the end (or, for the previous page, the start), so the fetch overlaps the
+// remaining scroll rather than stalling at the edge.
 const LOAD_MORE_THRESHOLD = 5;
+const LOAD_PREVIOUS_THRESHOLD = 5;
 
 function getProjectName(projectPath: string): string {
   const segments = projectPath.split("/").filter(Boolean);
@@ -128,6 +142,8 @@ export function ChatList({
   sortSignature,
   hasMore = false,
   onLoadMore,
+  hasPrevious = false,
+  onLoadPrevious,
 }: ChatListProps) {
   const [internalEditingId, setInternalEditingId] = useState<string | null>(
     null
@@ -155,6 +171,11 @@ export function ChatList({
     estimateSize: () => 84,
     overscan: 8,
     initialRect: { width: 320, height: 600 },
+    // Key rows by their stable chat id so the virtualizer's measurement cache
+    // survives a window mutation. When the bounded window evicts a page above or
+    // re-fetches one on scroll-back (#132), the surviving rows keep their
+    // measured offsets, anchoring scroll to the content under the viewport.
+    getItemKey: (index) => chats[index]?.id ?? index,
   });
 
   // Keep the selected chat visible after a sort change; otherwise scroll to top.
@@ -190,6 +211,61 @@ export function ChatList({
       onLoadMore();
     }
   }, [hasMore, onLoadMore, lastVisibleIndex, chats.length]);
+
+  // Symmetric near-top detector: re-fetch the page evicted above the bounded
+  // window as the user scrolls back within a few rows of the start (#132). The
+  // first virtual item's index tracks the scroll-back distance; onLoadPrevious
+  // guards against overlapping fetches itself.
+  const firstVisibleIndex = virtualItems[0]?.index ?? -1;
+  useEffect(() => {
+    if (!hasPrevious || !onLoadPrevious) return;
+    if (
+      firstVisibleIndex >= 0 &&
+      firstVisibleIndex <= LOAD_PREVIOUS_THRESHOLD
+    ) {
+      onLoadPrevious();
+    }
+  }, [hasPrevious, onLoadPrevious, firstVisibleIndex]);
+
+  // Anchor the viewport to a stable row across bounded-window mutations (#132).
+  // On scroll, remember the row at the viewport top plus the pixel offset into
+  // it; after the window evicts a page above or re-fetches one on scroll-back,
+  // restore the scroll so that same row stays put. Without this, removing or
+  // prepending rows above the viewport jumps the content and the near-edge
+  // detectors mis-fire (or stall), since the loaded window's length is constant.
+  const anchorRef = useRef<{ id: string; index: number; delta: number } | null>(
+    null
+  );
+  const handleScroll = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const offset = el.scrollTop;
+    const item = virtualizer.getVirtualItemForOffset(offset);
+    const id = item ? chats[item.index]?.id : undefined;
+    if (item && id) {
+      anchorRef.current = { id, index: item.index, delta: offset - item.start };
+    }
+  }, [virtualizer, chats]);
+
+  useLayoutEffect(() => {
+    // A sort/filter re-anchor owns the scroll (it resets to top or the
+    // selection); drop the stale anchor and leave the scroll to that effect.
+    if (prevSortSignature.current !== sortSignature) {
+      anchorRef.current = null;
+      return;
+    }
+    const el = scrollContainerRef.current;
+    const anchor = anchorRef.current;
+    if (!el || !anchor) return;
+    const newIndex = chats.findIndex((c) => c.id === anchor.id);
+    // Only adjust when rows actually shifted above the anchor; a pure field
+    // update leaves its index unchanged.
+    if (newIndex < 0 || newIndex === anchor.index) return;
+    const start = virtualizer.getOffsetForIndex(newIndex, "start")?.[0];
+    if (start === undefined) return;
+    el.scrollTop = start + anchor.delta;
+    anchorRef.current = { ...anchor, index: newIndex };
+  }, [chats, virtualizer, sortSignature]);
 
   useEffect(() => {
     if (!contextMenu) return;
@@ -249,6 +325,7 @@ export function ChatList({
         ref={scrollContainerRef}
         data-testid="chat-scroll"
         className="flex-1 overflow-y-auto"
+        onScroll={handleScroll}
       >
         {chats.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center px-6 text-center text-sm text-muted-foreground">

--- a/web/src/chat/useChatMutations.ts
+++ b/web/src/chat/useChatMutations.ts
@@ -20,6 +20,12 @@ export interface ChatListSource extends ChatMutations {
   hasMore: boolean;
   // Fetch the next page (a no-op on the full path).
   loadMore: () => void;
+  // True while a page evicted above the bounded window can be re-fetched on
+  // scroll-back (#132). Always false on the full path and at the list head.
+  hasPrevious: boolean;
+  // Re-fetch the page just above the window and prepend it, evicting the
+  // far-below page to stay bounded (a no-op on the full path / at the head).
+  loadPrevious: () => void;
   // Re-read and re-sort the loaded chats (used after a tag assignment changes
   // the chips a chat shows).
   reload: () => Promise<void>;

--- a/web/src/chat/usePaginatedChats.test.tsx
+++ b/web/src/chat/usePaginatedChats.test.tsx
@@ -17,6 +17,27 @@ function fakeStreamConnector() {
   return { connect, emitChanged: () => handlers?.onChanged() };
 }
 
+// Replace the fake active list with `n` synthetic chats whose ids sort by
+// updatedAt desc as b0, b1, …, so keyset pages are deterministic: page size 2
+// yields [b0,b1], [b2,b3], …. resetFakeChats (afterEach) restores the originals.
+function seedManyActiveChats(n: number): void {
+  fakeChats.length = 0;
+  for (let i = 0; i < n; i++) {
+    fakeChats.push({
+      id: `b${i}`,
+      sourceId: `B${i}`,
+      agent: "claude-code",
+      defaultTitle: `Chat ${i}`,
+      customTitle: null,
+      project: "my-web-app",
+      projectPath: "/Users/test/my-web-app",
+      sourceFilePath: null,
+      createdAt: 2_000_000_000_000 - i,
+      updatedAt: 2_000_000_000_000 - i * 1000,
+    });
+  }
+}
+
 // Active fake chats by updatedAt desc: chat-2 (300), chat-1 (200), chat-3 (150),
 // chat-missing (1699999900000). Deleted chats are excluded from the active list.
 describe("usePaginatedChats", () => {
@@ -249,5 +270,144 @@ describe("usePaginatedChats", () => {
 
     // Refresh is a no-op on failure; the window stays intact, nothing throws.
     expect(result.current.chats.map((c) => c.id)).toEqual(before);
+  });
+});
+
+// Bounded loaded window / page eviction (#132). The loaded window is capped at
+// `maxWindowPages`; scrolling further evicts far-offscreen pages and re-fetches
+// them on scroll-back, so memory and per-render re-sort stay bounded at scale.
+describe("usePaginatedChats — bounded window (#132)", () => {
+  it("evicts the oldest page when loadMore grows the window past the cap", async () => {
+    seedManyActiveChats(10); // b0 (newest) … b9 (oldest)
+    const { result } = renderHook(() =>
+      usePaginatedChats("updatedAt", "desc", { pageSize: 2, maxWindowPages: 2 })
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // Page 1.
+    expect(result.current.chats.map((c) => c.id)).toEqual(["b0", "b1"]);
+
+    // Page 2 fills the window to the 2-page cap.
+    act(() => result.current.loadMore());
+    await waitFor(() =>
+      expect(result.current.chats.map((c) => c.id)).toEqual([
+        "b0",
+        "b1",
+        "b2",
+        "b3",
+      ])
+    );
+
+    // Page 3 exceeds the cap: the oldest page (b0,b1) is evicted, so the window
+    // holds the last two pages and stays bounded at four rows.
+    act(() => result.current.loadMore());
+    await waitFor(() =>
+      expect(result.current.chats.map((c) => c.id)).toEqual([
+        "b2",
+        "b3",
+        "b4",
+        "b5",
+      ])
+    );
+  });
+
+  it("re-fetches an evicted page on loadPrevious (scroll-back)", async () => {
+    seedManyActiveChats(10);
+    const { result } = renderHook(() =>
+      usePaginatedChats("updatedAt", "desc", { pageSize: 2, maxWindowPages: 2 })
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Scroll down two pages so the head page (b0,b1) is evicted above.
+    act(() => result.current.loadMore());
+    await waitFor(() =>
+      expect(result.current.chats.map((c) => c.id)).toEqual([
+        "b0",
+        "b1",
+        "b2",
+        "b3",
+      ])
+    );
+    act(() => result.current.loadMore());
+    await waitFor(() =>
+      expect(result.current.chats.map((c) => c.id)).toEqual([
+        "b2",
+        "b3",
+        "b4",
+        "b5",
+      ])
+    );
+    // There is now content above the window.
+    expect(result.current.hasPrevious).toBe(true);
+
+    // Scroll back: the evicted page above is re-fetched and prepended, and the
+    // far-below page is evicted to keep the window bounded.
+    act(() => result.current.loadPrevious());
+    await waitFor(() =>
+      expect(result.current.chats.map((c) => c.id)).toEqual([
+        "b0",
+        "b1",
+        "b2",
+        "b3",
+      ])
+    );
+    // Back at the head: nothing above to re-fetch.
+    expect(result.current.hasPrevious).toBe(false);
+  });
+
+  it("skips the head reconcile when scrolled deep enough to evict the head", async () => {
+    seedManyActiveChats(10);
+    const stream = fakeStreamConnector();
+    const { result } = renderHook(() =>
+      usePaginatedChats("updatedAt", "desc", {
+        pageSize: 2,
+        maxWindowPages: 2,
+        connect: stream.connect,
+      })
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.loadMore());
+    await waitFor(() =>
+      expect(result.current.chats.map((c) => c.id)).toEqual([
+        "b0",
+        "b1",
+        "b2",
+        "b3",
+      ])
+    );
+    act(() => result.current.loadMore());
+    await waitFor(() =>
+      expect(result.current.chats.map((c) => c.id)).toEqual([
+        "b2",
+        "b3",
+        "b4",
+        "b5",
+      ])
+    );
+
+    // A brand-new chat ranks at the very top, then the server pushes. Because the
+    // head page is evicted, the head reconcile is skipped: the deep-scrolled
+    // window is left exactly where it is, undisturbed by a change at the head.
+    fakeChats.unshift({
+      id: "b-new",
+      sourceId: "BNEW",
+      agent: "claude-code",
+      defaultTitle: "Brand new",
+      customTitle: null,
+      project: "my-web-app",
+      projectPath: "/Users/test/my-web-app",
+      sourceFilePath: null,
+      createdAt: 3_000_000_000_000,
+      updatedAt: 3_000_000_000_000,
+    });
+    await act(async () => {
+      stream.emitChanged();
+    });
+
+    expect(result.current.chats.map((c) => c.id)).toEqual([
+      "b2",
+      "b3",
+      "b4",
+      "b5",
+    ]);
   });
 });

--- a/web/src/chat/usePaginatedChats.ts
+++ b/web/src/chat/usePaginatedChats.ts
@@ -17,6 +17,24 @@ export type ListDirection = "asc" | "desc";
 
 const DEFAULT_PAGE_SIZE = 30;
 
+// Cap on how many pages the loaded window holds. Past this, scrolling further
+// evicts the far-offscreen page at the opposite end; scrolling back re-fetches
+// it via its cursor. This bounds memory and the frozen-sort layer's per-render
+// re-sort cost at scale (~50,000 Chats), where an unbounded window grew both
+// without limit (#132 / ADR-0018, ADR-0020). 8 pages comfortably exceeds a
+// viewport-plus-overscan worth of rows at the default page size.
+const DEFAULT_MAX_WINDOW_PAGES = 8;
+
+// One fetched page held in the loaded window, tagged with the cursors that
+// bound it: `fromCursor` is the keyset cursor that fetched this page (null for
+// the list head), so an evicted page can be re-fetched on scroll-back;
+// `nextCursor` fetches the page below it (null at the list tail).
+interface LoadedPage {
+  fromCursor: string | null;
+  nextCursor: string | null;
+  chats: Chat[];
+}
+
 // The keyset endpoint rejects a `limit` over MAX_PAGE_LIMIT (the shared cap in
 // `@contract`). The window can grow past it via loadMore, so any window-sized
 // request must clamp to it — otherwise the server returns 400 and the response
@@ -28,21 +46,16 @@ const DEFAULT_PAGE_SIZE = 30;
 // window can never stay stale indefinitely even if a push is lost.
 const RECONCILE_FLOOR_MS = 30000;
 
-// Merge a freshly-fetched window into the loaded one: refresh fields for chats
-// the server still returns, keep loaded chats the refetch no longer covers (the
-// window only grows under a background refresh — rows never vanish), and append
-// brand-new chats. Ordering is left to the frozen-sort layer.
-function mergeWindow(loaded: Chat[], incoming: Chat[]): Chat[] {
-  const incomingById = new Map(incoming.map((c) => [c.id, c]));
-  const loadedIds = new Set(loaded.map((c) => c.id));
-  const merged = loaded.map((c) => incomingById.get(c.id) ?? c);
-  const added = incoming.filter((c) => !loadedIds.has(c.id));
-  return [...merged, ...added];
-}
-
 interface UsePaginatedChatsOptions {
   /** Page size for the keyset `limit`. */
   pageSize?: number;
+  /**
+   * Cap on the loaded window's page count (#132). Past this, `loadMore` evicts
+   * the oldest page and `loadPrevious` evicts the newest, keeping the window
+   * bounded. Injectable so tests can drive eviction with a small window;
+   * defaults to {@link DEFAULT_MAX_WINDOW_PAGES}.
+   */
+  maxWindowPages?: number;
   // Active only when the main view sorts by a descending time axis. When off,
   // the hook holds an empty window and issues no requests (the full-load path
   // is serving instead).
@@ -136,6 +149,7 @@ export function usePaginatedChats(
   direction: ListDirection,
   {
     pageSize = DEFAULT_PAGE_SIZE,
+    maxWindowPages = DEFAULT_MAX_WINDOW_PAGES,
     enabled = true,
     projects = [],
     tags = [],
@@ -158,42 +172,47 @@ export function usePaginatedChats(
     [projectsKey, tagsKey]
   );
 
-  const [chats, setChats] = useState<Chat[]>([]);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  // The loaded window is a list of fetched pages, each carrying the cursors that
+  // bound it (#132). The outward `chats` is their concatenation; holding pages
+  // (not a flat array) lets the window evict and re-fetch by page at its edges.
+  const [pages, setPages] = useState<LoadedPage[]>([]);
   const [loading, setLoading] = useState(true);
   const [sortEpoch, setSortEpoch] = useState(0);
   const bumpEpoch = useCallback(() => setSortEpoch((e) => e + 1), []);
 
-  // The cursor is read inside loadMore, which is called from event handlers that
-  // close over a stale render. A ref keeps the live cursor without re-creating
-  // the callback. `fetching` guards against overlapping page fetches (e.g. a
-  // near-bottom detector firing twice before the next page resolves).
-  const cursorRef = useRef<string | null>(null);
+  const chats = useMemo(() => pages.flatMap((p) => p.chats), [pages]);
+
+  // `fetching` guards against overlapping page fetches (e.g. a near-bottom
+  // detector firing twice before the next page resolves). `pagesRef` keeps the
+  // live window for callbacks (loadMore / loadPrevious / refresh) that run from
+  // event handlers or intervals closing over a stale render.
   const fetchingRef = useRef(false);
-  // The live window, read by refresh (called from an interval / event handler
-  // that closes over a stale render) to size the refetch and merge into. Synced
-  // after commit — refresh only ever runs post-render, so it sees the latest.
-  const chatsRef = useRef<Chat[]>(chats);
+  const pagesRef = useRef<LoadedPage[]>(pages);
   useEffect(() => {
-    chatsRef.current = chats;
-  }, [chats]);
+    pagesRef.current = pages;
+  }, [pages]);
+  // `fromCursor`s of pages evicted above the window, oldest-first. loadPrevious
+  // pops the last (the page just above the current top) to re-fetch it on
+  // scroll-back. Reset whenever the window re-anchors (#132).
+  const evictedAboveRef = useRef<(string | null)[]>([]);
 
   // (Re)load the first page whenever the sort axis, the active filter, or the
   // enabled flag changes — resetting the window so the new axis or filter
-  // re-anchors from its top (#130).
+  // re-anchors from its top (#130). The fresh window is a single head page
+  // (`fromCursor: null`), from which loadMore grows downward.
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
-    cursorRef.current = null;
     fetchingRef.current = true;
     void fetchPage(
       pageUrl(sort, direction, pageSize, filter, trashedOnly)
     ).then((data) => {
       if (cancelled) return;
       if (data) {
-        setChats(data.chats);
-        setNextCursor(data.nextCursor);
-        cursorRef.current = data.nextCursor;
+        evictedAboveRef.current = [];
+        setPages([
+          { fromCursor: null, nextCursor: data.nextCursor, chats: data.chats },
+        ]);
       }
       fetchingRef.current = false;
       setLoading(false);
@@ -204,35 +223,111 @@ export function usePaginatedChats(
   }, [sort, direction, pageSize, enabled, filter, trashedOnly]);
 
   const loadMore = useCallback(() => {
-    if (fetchingRef.current || cursorRef.current === null) return;
-    const cursor = cursorRef.current;
+    if (fetchingRef.current) return;
+    const prev = pagesRef.current;
+    const tail = prev[prev.length - 1];
+    if (!tail || tail.nextCursor === null) return;
+    const cursor = tail.nextCursor;
     fetchingRef.current = true;
     void fetchPage(
       pageUrl(sort, direction, pageSize, filter, trashedOnly, cursor)
     ).then((data) => {
       if (data) {
-        setChats((prev) => [...prev, ...data.chats]);
-        setNextCursor(data.nextCursor);
-        cursorRef.current = data.nextCursor;
+        const grown = [
+          ...pagesRef.current,
+          {
+            fromCursor: cursor,
+            nextCursor: data.nextCursor,
+            chats: data.chats,
+          },
+        ];
+        // Evict the oldest page(s) once the window passes the cap; they sit far
+        // above the viewport. Stash their cursors so scroll-back can re-fetch.
+        if (grown.length > maxWindowPages) {
+          const evictCount = grown.length - maxWindowPages;
+          evictedAboveRef.current = [
+            ...evictedAboveRef.current,
+            ...grown.slice(0, evictCount).map((p) => p.fromCursor),
+          ];
+          setPages(grown.slice(evictCount));
+        } else {
+          setPages(grown);
+        }
       }
       fetchingRef.current = false;
     });
-  }, [sort, direction, pageSize, filter, trashedOnly]);
+  }, [sort, direction, pageSize, filter, trashedOnly, maxWindowPages]);
 
-  // Re-read the top of the loaded window. Sized to the current window so a
-  // brand-new chat ranking into it is surfaced, but clamped to the page-limit
-  // cap so a large window never asks for more than the endpoint allows. Merged
-  // so existing rows keep their place; the downward cursor is left untouched —
-  // refresh reconciles the window's head, loadMore continues from its tail.
+  // Re-fetch the page just above the window and prepend it (scroll-back, #132),
+  // evicting the far-below page to stay bounded. The cursor comes off the
+  // evicted-above stack; loadMore can re-fetch the evicted-below page from the
+  // new tail's cursor, so only the top end needs a stash.
+  const loadPrevious = useCallback(() => {
+    if (fetchingRef.current) return;
+    const stack = evictedAboveRef.current;
+    if (stack.length === 0) return;
+    const cursor = stack[stack.length - 1];
+    fetchingRef.current = true;
+    void fetchPage(
+      pageUrl(
+        sort,
+        direction,
+        pageSize,
+        filter,
+        trashedOnly,
+        cursor ?? undefined
+      )
+    ).then((data) => {
+      if (data) {
+        evictedAboveRef.current = evictedAboveRef.current.slice(0, -1);
+        const grown = [
+          {
+            fromCursor: cursor,
+            nextCursor: data.nextCursor,
+            chats: data.chats,
+          },
+          ...pagesRef.current,
+        ];
+        setPages(
+          grown.length > maxWindowPages ? grown.slice(0, maxWindowPages) : grown
+        );
+      }
+      fetchingRef.current = false;
+    });
+  }, [sort, direction, pageSize, filter, trashedOnly, maxWindowPages]);
+
+  // Re-read the head of the loaded window and reconcile it in place (live-update
+  // path, #132). Only acts when the head page is still loaded: new Chats appear
+  // at the list head (newest-first), so a window scrolled far past the head has
+  // nothing at the top to reconcile, and re-reading the head there would fight
+  // eviction. Sized to the loaded window but clamped to the page-limit cap so a
+  // large window never asks for more than the endpoint allows (#147).
   const refresh = useCallback(async () => {
-    const limit = Math.min(
-      Math.max(chatsRef.current.length, pageSize),
-      MAX_PAGE_LIMIT
-    );
+    const current = pagesRef.current;
+    if (current.length === 0 || current[0].fromCursor !== null) return;
+    const windowLen = current.reduce((n, p) => n + p.chats.length, 0);
+    const limit = Math.min(Math.max(windowLen, pageSize), MAX_PAGE_LIMIT);
     const data = await fetchPage(
       pageUrl(sort, direction, limit, filter, trashedOnly)
     );
-    if (data) setChats((prev) => mergeWindow(prev, data.chats));
+    if (!data) return;
+    setPages((prev) => {
+      if (prev.length === 0) return prev;
+      const incomingById = new Map(data.chats.map((c) => [c.id, c]));
+      const loadedIds = new Set(prev.flatMap((p) => p.chats).map((c) => c.id));
+      // Refresh fields in place for chats the server still returns; keep loaded
+      // rows the refetch no longer covers (the window only grows here).
+      const updated = prev.map((p) => ({
+        ...p,
+        chats: p.chats.map((c) => incomingById.get(c.id) ?? c),
+      }));
+      // Brand-new chats now ranking into the window slot onto the head page, in
+      // server order; the frozen-sort layer places them among the held rows.
+      const added = data.chats.filter((c) => !loadedIds.has(c.id));
+      if (added.length === 0) return updated;
+      const [head, ...rest] = updated;
+      return [{ ...head, chats: [...added, ...head.chats] }, ...rest];
+    });
   }, [sort, direction, pageSize, filter, trashedOnly]);
 
   // Primary trigger: reconcile the window head on each server-pushed change, so
@@ -261,18 +356,42 @@ export function usePaginatedChats(
     bumpEpoch();
   }, [refresh, bumpEpoch]);
 
+  // Bridge the mutations' flat-list optimistic updates onto the page model.
+  // Mutations only update fields or drop a row by id, so re-distributing the
+  // transformed rows back into their pages by id keeps page boundaries — and
+  // their cursors — intact.
+  const setChats = useCallback((updater: (prev: Chat[]) => Chat[]) => {
+    setPages((prev) => {
+      const next = updater(prev.flatMap((p) => p.chats));
+      const byId = new Map(next.map((c) => [c.id, c]));
+      return prev.map((p) => ({
+        ...p,
+        chats: p.chats
+          .filter((c) => byId.has(c.id))
+          .map((c) => byId.get(c.id) as Chat),
+      }));
+    });
+  }, []);
+
   const { softDelete, restore, setTitle } = useChatMutations(
     setChats,
     bumpEpoch,
     reload
   );
 
+  const tail = pages[pages.length - 1];
+  const head = pages[0];
+
   return {
     chats,
     loading: enabled ? loading : false,
     sortEpoch,
-    hasMore: nextCursor !== null,
+    hasMore: tail ? tail.nextCursor !== null : false,
     loadMore,
+    // Content sits above the window only once its head page was evicted, which
+    // leaves the top page tagged with the cursor that fetched it (#132).
+    hasPrevious: head ? head.fromCursor !== null : false,
+    loadPrevious,
     reload,
     refresh,
     softDelete,


### PR DESCRIPTION
## Background (Why)

The loaded chat-list window only ever grew. Every `loadMore` appended a page and kept it; the frozen-sort layer then re-sorted the entire loaded window on every render. At ~50,000 Chats with deep continuous scroll, both memory and per-render cost grow without limit. This is the bounded-window half of #132 — the follow-up that ADR-0018 and ADR-0020 anticipated once the 4s poll was gone.

## Approach (How)

`usePaginatedChats` now holds the window as a list of pages, each tagged with the keyset cursors that bound it (`fromCursor` fetched it, `nextCursor` fetches the one below). `loadMore` evicts the oldest page once the window passes the cap and stashes its cursor; a new `loadPrevious` re-fetches the page just above on scroll-back and evicts the far-below one. The window stays bounded in both directions, and an evicted page is always re-fetchable via its cursor.

The head reconcile (live update / floor) is skipped once the head page is evicted: a change at the list head cannot affect a view scrolled deep into the tail, so there is no point disturbing it.

`ChatList` wires a near-top detector to `loadPrevious`, mirroring the near-bottom `loadMore`, and anchors the viewport to a stable row across window mutations. On scroll it records the row at the viewport top; after an eviction or re-fetch shifts rows above it, a layout effect restores the scroll so that row stays put. This anchor is not optional polish — because the bounded window's length is now constant, without it the near-edge detectors stall and the content jumps (a diagnostic caught the scroll stalling mid-list before the anchor was added).

## Changes (What)

- [x] `usePaginatedChats`: page-list window model; `loadMore` evicts + stashes; new `loadPrevious` re-fetches on scroll-back; head-reconcile skipped when the head is evicted. `maxWindowPages` is injectable (default 8).
- [x] `ChatListSource`: adds `hasPrevious` + `loadPrevious`.
- [x] `ChatList`: near-top detector, `getItemKey` by chat id, and scroll anchoring; `App` wires the new props.
- [x] e2e: deep scroll to the tail without blanking, then scroll-back re-fetching the evicted head.

## Additional Notes

Stacked on #154 (server-push live updates), now merged into the integration branch, so this diff is just the bounded-window change. Both touch `usePaginatedChats`, which is why they were sequenced rather than parallel.

Scroll-position smoothness under eviction is inherently layout-dependent and verified in a real browser (Playwright), not jsdom; the unit tests cover the hook's windowing logic.

### Test Verification

- [x] web unit: 185 passed (incl. eviction bounds the window, `loadPrevious` re-fetches an evicted page, head reconcile skipped when scrolled deep)
- [x] Playwright e2e: 3 passed — deep scroll reaches the tail with no blank/console errors; scroll-back re-fetches "Chat 0"
- [x] api unit: 295 passed; typecheck clean

## Related Links

- Issue #132 (incremental live list updates + bounded window)
- ADR-0018 (single keyset read path — anticipated the bounded window)
- ADR-0020 (push-based live updates — removed the poll this completes)