### PR TITLE
chore(api): add reset command and idempotent seed --reset

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "tsx scripts/dev.ts",
     "seed": "tsx scripts/seed.ts",
+    "reset": "tsx scripts/reset.ts",
     "build": "tsup",
     "test": "vitest run",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",

--- a/api/scripts/reset.ts
+++ b/api/scripts/reset.ts
@@ -1,0 +1,21 @@
+import os from "node:os";
+import { resolveDataDir } from "../src/config/data-dir.js";
+import { assertSeedDataDirSafe } from "../src/seed/guard.js";
+import { resetDataDir } from "../src/seed/reset.js";
+
+// Developer-only reset. Wipes every store file in the directory resolved from
+// CHAT_LOGBOOK_DATA_DIR so a seeded dataset can be thrown away and rebuilt from
+// scratch. The same guard the seed script uses refuses to touch the real,
+// backup-worthy ~/.chat-logbook.
+//
+//   CHAT_LOGBOOK_DATA_DIR=~/.chat-logbook-seed pnpm --filter @chat-logbook/api reset
+
+const dataDir = resolveDataDir(process.env, os.homedir());
+assertSeedDataDirSafe(dataDir, os.homedir());
+
+const { removed } = resetDataDir(dataDir);
+if (removed.length === 0) {
+  console.log(`Nothing to reset in ${dataDir} (no store files found).`);
+} else {
+  console.log(`Reset ${dataDir}: removed ${removed.join(", ")}.`);
+}

--- a/api/scripts/seed.ts
+++ b/api/scripts/seed.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import { resolveDataDir } from "../src/config/data-dir.js";
 import { assertSeedDataDirSafe } from "../src/seed/guard.js";
+import { resetDataDir } from "../src/seed/reset.js";
 import { createArchiveRepository } from "../src/archive/repository.js";
 import { createTagRepository } from "../src/metadata/tags.js";
 import { seedArchive } from "../src/seed/seed.js";
@@ -13,17 +14,34 @@ import { DEFAULT_SEED_CONFIG, type SeedConfig } from "../src/seed/generator.js";
 //
 //   CHAT_LOGBOOK_DATA_DIR=~/.chat-logbook-dev pnpm --filter @chat-logbook/api seed
 //   ... seed --count 50000 --seed 1 --projects 50 --tag-ratio 0.3 --tag-pool 10
+//
+// Seeding appends, so re-running doubles the row count. Pass --reset to wipe the
+// target's store files first, making the seed idempotent (exactly --count rows).
 
-function parseArgs(argv: string[]): Partial<SeedConfig> {
+// Flags that take no value; every other flag consumes the following token.
+const BOOLEAN_FLAGS = new Set(["reset"]);
+
+interface ParsedArgs {
+  config: Partial<SeedConfig>;
+  reset: boolean;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
   const flags: Record<string, string> = {};
+  let reset = false;
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (!arg.startsWith("--")) continue;
     const eq = arg.indexOf("=");
+    const key = eq !== -1 ? arg.slice(2, eq) : arg.slice(2);
+    if (BOOLEAN_FLAGS.has(key)) {
+      reset = eq === -1 || arg.slice(eq + 1) !== "false";
+      continue;
+    }
     if (eq !== -1) {
-      flags[arg.slice(2, eq)] = arg.slice(eq + 1);
+      flags[key] = arg.slice(eq + 1);
     } else {
-      flags[arg.slice(2)] = argv[++i] ?? "";
+      flags[key] = argv[++i] ?? "";
     }
   }
   const num = (key: string): number | undefined =>
@@ -40,12 +58,21 @@ function parseArgs(argv: string[]): Partial<SeedConfig> {
   if (projects !== undefined) config.projects = projects;
   if (tagRatio !== undefined) config.tagRatio = tagRatio;
   if (tagPool !== undefined) config.tagPool = tagPool;
-  return config;
+  return { config, reset };
 }
 
-const config = parseArgs(process.argv.slice(2));
+const { config, reset } = parseArgs(process.argv.slice(2));
 const dataDir = resolveDataDir(process.env, os.homedir());
 assertSeedDataDirSafe(dataDir, os.homedir());
+
+if (reset) {
+  const { removed } = resetDataDir(dataDir);
+  console.log(
+    removed.length === 0
+      ? `Reset: no store files to remove in ${dataDir}.`
+      : `Reset: removed ${removed.join(", ")} from ${dataDir}.`
+  );
+}
 
 const resolved = { ...DEFAULT_SEED_CONFIG, ...config };
 console.log(

--- a/api/src/seed/reset.test.ts
+++ b/api/src/seed/reset.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resetDataDir } from "./reset.js";
+
+describe("resetDataDir", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "reset-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const touch = (name: string): void => {
+    fs.writeFileSync(path.join(dir, name), "");
+  };
+  const exists = (name: string): boolean => fs.existsSync(path.join(dir, name));
+
+  it("removes every store file and its WAL sidecars", () => {
+    for (const name of [
+      "archive.db",
+      "archive.db-wal",
+      "archive.db-shm",
+      "metadata.db",
+      "checkpoint.db",
+      "index.db",
+      "data.db",
+    ]) {
+      touch(name);
+    }
+
+    const { removed } = resetDataDir(dir);
+
+    expect(removed).toContain("archive.db");
+    expect(removed).toContain("archive.db-wal");
+    expect(removed).toContain("archive.db-shm");
+    expect(removed).toContain("data.db");
+    for (const name of removed) expect(exists(name)).toBe(false);
+  });
+
+  it("leaves non-store files untouched", () => {
+    touch("archive.db");
+    touch("notes.txt");
+
+    const { removed } = resetDataDir(dir);
+
+    expect(removed).toEqual(["archive.db"]);
+    expect(exists("notes.txt")).toBe(true);
+  });
+
+  it("is a no-op on an empty directory", () => {
+    expect(resetDataDir(dir).removed).toEqual([]);
+  });
+});

--- a/api/src/seed/reset.ts
+++ b/api/src/seed/reset.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Every chat-logbook store file that lives under a data directory. `index.db` is
+ * planned (see ARCHITECTURE.md); `data.db` is the pre-v0.8 metadata filename.
+ * Listing them explicitly — rather than globbing `*.db` — keeps the wipe
+ * intentional and self-documenting, and leaves any unrelated file untouched.
+ */
+const STORE_FILES = [
+  "archive.db",
+  "metadata.db",
+  "checkpoint.db",
+  "index.db",
+  "data.db",
+] as const;
+
+// SQLite can leave these sidecars next to a db (WAL mode); remove them too so a
+// reset never leaves a half-deleted store behind.
+const SIDECAR_SUFFIXES = ["", "-wal", "-shm"] as const;
+
+export interface ResetSummary {
+  /** Basenames of the files actually removed (existing ones only). */
+  removed: string[];
+}
+
+/**
+ * Deletes every chat-logbook store file under `dataDir`, returning the ones that
+ * existed. Callers MUST guard the directory (see {@link ./guard.js}) first so
+ * this can never wipe the real, backup-worthy archive. Non-store files are left
+ * untouched, so pointing it at a shared directory only clears the stores.
+ */
+export function resetDataDir(dataDir: string): ResetSummary {
+  const removed: string[] = [];
+  for (const store of STORE_FILES) {
+    for (const suffix of SIDECAR_SUFFIXES) {
+      const name = `${store}${suffix}`;
+      const target = path.join(dataDir, name);
+      if (fs.existsSync(target)) {
+        fs.rmSync(target);
+        removed.push(name);
+      }
+    }
+  }
+  return { removed };
+}


### PR DESCRIPTION
## Background (Why)

Validating the #126–#146 list-pipeline refactor at the ~50,000-chat scale it targets means seeding a throwaway dev archive. The existing `seed` script appends, so re-running it doubled the row count, and there was no supported way to undo a seed short of hand-deleting `*.db` files. This adds a first-class way to clear a seeded dataset and makes re-seeding idempotent.

## Approach (How)

A small pure `resetDataDir(dataDir)` does the deletion; both the standalone `reset` CLI and the `seed --reset` flag reuse it, and both go through the same `assertSeedDataDirSafe` guard that already protects the real `~/.chat-logbook`. The guard only defends the one irreplaceable archive — a re-ingestible dev dir is fair game — keeping the responsibility boundary the seed script already set. Store files are listed explicitly rather than globbing `*.db`, so the wipe stays intentional and never touches an unrelated file.

## Changes (What)

- [x] `api/src/seed/reset.ts`: `resetDataDir()` removes `archive`/`metadata`/`checkpoint`/`index`/legacy `data` db files plus their `-wal`/`-shm` sidecars; leaves non-store files untouched.
- [x] `api/scripts/reset.ts` + `reset` package script: guarded CLI that clears the `CHAT_LOGBOOK_DATA_DIR` stores.
- [x] `seed --reset`: wipe-then-seed so a re-seed yields exactly `--count` rows; also fixes the arg parser swallowing the token after a boolean flag.

### Test Verification

- [x] `reset.test.ts`: removes every store file and its WAL sidecars.
- [x] `reset.test.ts`: leaves non-store files (e.g. `notes.txt`) untouched.
- [x] `reset.test.ts`: no-op on an empty directory.
- [x] Manual end-to-end: `seed --count 200 --reset` run twice stays at 200 rows (idempotent); `reset` empties the dir; guard blocks `CHAT_LOGBOOK_DATA_DIR=~/.chat-logbook`.
- [x] Full suite green (api 298, web 185) via the pre-push hook.

## Additional Notes

The reset guard intentionally protects only the real `~/.chat-logbook`, not `~/.chat-logbook-dev` — the latter is rebuildable by re-ingesting the read-only source dirs. Recommended workflow is a dedicated `~/.chat-logbook-seed` dir for the 50k synthetic dataset, keeping the real-data dev dir available for fidelity/dogfood testing.

## Related Links

- Part of the #126–#146 list-pipeline refactor validation.