### PR TITLE
perf(api): hydrate list pages by id, not the whole archive

### DIFF
--- a/api/src/archive/read-seam.ts
+++ b/api/src/archive/read-seam.ts
@@ -44,6 +44,12 @@ export interface ArchiveReadSeam {
    * nothing; omitting `projects` returns every row.
    */
   listChatRows(opts?: { projects?: string[] }): ChatRow[];
+  /**
+   * Chat rows for a specific set of internal ids, in no guaranteed order (the
+   * caller re-orders). Bounded by the id set, so hydrating one keyset page stays
+   * O(page) instead of loading the whole table (issue #158).
+   */
+  listChatRowsByIds(ids: string[]): ChatRow[];
   /** Resolve a chat by its source id; null when absent. */
   findChatBySourceId(sourceId: string): ChatRow | null;
   /** Resolve a chat by its bare chat_id code (the public handle); null when absent. */
@@ -53,18 +59,24 @@ export interface ArchiveReadSeam {
   /**
    * One grouped row per `(agent, source_id)` with the min/max message ts.
    * A single grouped query — constant query count regardless of chat count.
+   * With `sourceIds`, scopes the scan to those chats so page hydration does not
+   * aggregate the whole messages table (issue #158).
    */
-  listChatTsRanges(): ChatTsRange[];
+  listChatTsRanges(opts?: { sourceIds?: string[] }): ChatTsRange[];
   /**
    * The latest-ingested raw source path per `(agent, source_id)`, resolved
    * with a windowed query so listing N chats stays a constant query count.
+   * `sourceIds` scopes the scan to a page's chats (issue #158).
    */
-  listLatestRawSourcePaths(): LatestRawSourcePath[];
+  listLatestRawSourcePaths(opts?: {
+    sourceIds?: string[];
+  }): LatestRawSourcePath[];
   /**
    * The earliest user message text per `(agent, source_id)`, resolved with a
-   * windowed query so listing N chats stays a constant query count.
+   * windowed query so listing N chats stays a constant query count. `sourceIds`
+   * scopes the scan to a page's chats (issue #158).
    */
-  listFirstUserTexts(): FirstUserText[];
+  listFirstUserTexts(opts?: { sourceIds?: string[] }): FirstUserText[];
   /** Every ingestion-event audit row, in insertion order. */
   listIngestionEvents(): IngestionEventRow[];
 }
@@ -83,6 +95,10 @@ export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
           .all();
       }
       return db.select().from(chats).all();
+    },
+    listChatRowsByIds(ids) {
+      if (ids.length === 0) return [];
+      return db.select().from(chats).where(inArray(chats.id, ids)).all();
     },
     findChatBySourceId(sourceId) {
       return (
@@ -103,7 +119,11 @@ export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
         .orderBy(asc(messages.ts))
         .all();
     },
-    listChatTsRanges() {
+    listChatTsRanges(opts) {
+      const scope =
+        opts?.sourceIds !== undefined
+          ? inArray(messages.sourceId, opts.sourceIds)
+          : sql`1 = 1`;
       return db
         .select({
           agent: messages.agent,
@@ -112,10 +132,15 @@ export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
           maxTs: sql<number | null>`max(${messages.ts})`,
         })
         .from(messages)
+        .where(scope)
         .groupBy(messages.agent, messages.sourceId)
         .all();
     },
-    listLatestRawSourcePaths() {
+    listLatestRawSourcePaths(opts) {
+      const scope =
+        opts?.sourceIds !== undefined
+          ? inArray(rawMessages.sourceId, opts.sourceIds)
+          : sql`1 = 1`;
       const ranked = db
         .select({
           agent: rawMessages.agent,
@@ -126,6 +151,7 @@ export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
           ),
         })
         .from(rawMessages)
+        .where(scope)
         .as("ranked_raw");
       return db
         .select({
@@ -137,7 +163,14 @@ export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
         .where(eq(ranked.rn, 1))
         .all();
     },
-    listFirstUserTexts() {
+    listFirstUserTexts(opts) {
+      const scope =
+        opts?.sourceIds !== undefined
+          ? and(
+              eq(messages.role, "user"),
+              inArray(messages.sourceId, opts.sourceIds)
+            )
+          : eq(messages.role, "user");
       const ranked = db
         .select({
           agent: messages.agent,
@@ -148,7 +181,7 @@ export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
           ),
         })
         .from(messages)
-        .where(eq(messages.role, "user"))
+        .where(scope)
         .as("ranked_user");
       return db
         .select({

--- a/api/src/archive/repository-write.test.ts
+++ b/api/src/archive/repository-write.test.ts
@@ -199,6 +199,58 @@ describe("ArchiveRepository write seam", () => {
     repo.close();
   });
 
+  it("bounded reads scope listChatRowsByIds and the aggregations to a page (issue #158)", () => {
+    const repo = createArchiveRepository({ dataDir });
+    const mkChat = (sourceId: string, text: string, ts: string) => {
+      const id = repo.ensureChat("claude-code", sourceId, new Date());
+      const raw = repo.insertRawMessage({
+        agent: "claude-code",
+        sourceId,
+        sourcePath: `/src/${sourceId}.jsonl`,
+        sourceLocator: "line:1",
+        payload: { role: "user", content: text },
+        ingestedAt: new Date(),
+      });
+      repo.upsertNormalizedMessage({
+        agent: "claude-code",
+        sourceId,
+        rawId: raw.id,
+        message: {
+          messageId: "m1",
+          role: "user",
+          ts,
+          text,
+          blocks: [{ type: "text", text }],
+        },
+      });
+      return id;
+    };
+    const id1 = mkChat("session-1", "first", "2024-01-01T00:00:00Z");
+    mkChat("session-2", "second", "2024-02-02T00:00:00Z");
+
+    // listChatRowsByIds returns only the requested rows, never the whole table.
+    const only1 = repo.read.listChatRowsByIds([id1]);
+    expect(only1).toHaveLength(1);
+    expect(only1[0].id).toBe(id1);
+    expect(repo.read.listChatRowsByIds([])).toHaveLength(0);
+    expect(repo.read.listChatRows()).toHaveLength(2);
+
+    // The message/raw aggregations scope to the given source ids; unscoped they
+    // still cover every chat (the full-list path).
+    const scopedTs = repo.read.listChatTsRanges({ sourceIds: ["session-1"] });
+    expect(scopedTs.map((r) => r.sourceId)).toEqual(["session-1"]);
+    expect(repo.read.listChatTsRanges()).toHaveLength(2);
+
+    const scopedText = repo.read.listFirstUserTexts({
+      sourceIds: ["session-2"],
+    });
+    expect(scopedText).toHaveLength(1);
+    expect(scopedText[0].text).toBe("second");
+    expect(repo.read.listFirstUserTexts()).toHaveLength(2);
+
+    repo.close();
+  });
+
   it("recordIngestionEvent writes an audit row and never deletes archive rows", () => {
     const repo = createArchiveRepository({ dataDir });
 

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -257,21 +257,28 @@ export function createChatReader({
   // field, never ~3 per row — issue #106) and returns an assembler that turns a
   // single Archive chat row + visibility into the public Chat shape. Shared by
   // the full-list (`listChats`) and paginated (`listChatsPage`) read paths.
-  function loadHydration(): (
+  // `scope.sourceIds` bounds the message/raw aggregations to a page's chats so
+  // the paginated path stays O(page); the full-list path calls this with no
+  // scope and aggregates every chat as before (issue #158).
+  function loadHydration(scope?: {
+    sourceIds?: string[];
+  }): (
     row: ChatRow,
     visibility: ReturnType<typeof loadChatVisibility>
   ) => ChatResponse {
     const tsRangeByKey = new Map(
-      archive.read.listChatTsRanges().map((r) => [key(r.agent, r.sourceId), r])
+      archive.read
+        .listChatTsRanges(scope)
+        .map((r) => [key(r.agent, r.sourceId), r])
     );
     const sourcePathByKey = new Map(
       archive.read
-        .listLatestRawSourcePaths()
+        .listLatestRawSourcePaths(scope)
         .map((r) => [key(r.agent, r.sourceId), r.sourcePath])
     );
     const firstUserTextByKey = new Map(
       archive.read
-        .listFirstUserTexts()
+        .listFirstUserTexts(scope)
         .map((r) => [key(r.agent, r.sourceId), r.text])
     );
     const customTitleById = metadata.listCustomTitles();
@@ -347,8 +354,15 @@ export function createChatReader({
     const visibility = loadChatVisibility(metadata, {
       includeTrashed: includeTrashed || trashedOnly,
     });
-    const rowById = new Map(archive.read.listChatRows().map((r) => [r.id, r]));
-    const toResponse = loadHydration();
+    // Hydrate only this page's chats: fetch their rows by id and scope the
+    // message/raw aggregations to their source ids, so a page read stays
+    // O(page) instead of loading and aggregating the whole archive (issue #158).
+    const pageIds = page.items.map((item) => item.id);
+    const rows = archive.read.listChatRowsByIds(pageIds);
+    const rowById = new Map(rows.map((r) => [r.id, r]));
+    const toResponse = loadHydration({
+      sourceIds: rows.map((r) => r.sourceId),
+    });
 
     const chats: ChatResponse[] = [];
     for (const item of page.items) {


### PR DESCRIPTION
## Background (Why)

The list-pipeline benchmark (`docs/benchmarks/2026-07-list-pipeline.md`) found that `GET /api/chats?limit=50` was **O(N)**: ~4ms at 0.5k chats rising to ~950ms at 100k, tracking the pre-pipeline full-load it was meant to replace. The keyset SQL itself is O(page) — `EXPLAIN QUERY PLAN` uses the covering `(updated_at, id)` index and runs in 0.6ms at 100k — but `listChatsPage` hydrated every page by loading and aggregating the **whole** archive, silently negating the server-side scaling goal of the refactor (ADR-0017 / ADR-0018).

## Approach (How)

Scope hydration to the page's rows. `listChatsPage` now fetches only the page's chat rows by id and passes their source ids to `loadHydration`, which bounds the message/raw aggregations to those chats. The full-list path (`listChats`) is unchanged: it calls `loadHydration` with no scope and aggregates every chat exactly as before (a `1 = 1` no-op filter when unscoped).

## Changes (What)

- [x] Add `listChatRowsByIds(ids)` to the archive read seam (bounded row fetch; `[]` for empty).
- [x] Add optional `{ sourceIds }` scope to `listChatTsRanges` / `listLatestRawSourcePaths` / `listFirstUserTexts`.
- [x] `listChatsPage` hydrates only the page's ids/source ids instead of `listChatRows()` (whole table) + full-table aggregations.
- [x] Regression test pinning the bounded-read contract.

### Test Verification

- [x] api suite: **299 passed** (298 + new bounded-reads test); `typecheck` clean.
- [x] New test: `listChatRowsByIds` returns only requested ids (and `[]` for empty); scoped aggregations cover only the named source ids; unscoped still cover every chat.
- [x] End-to-end at 100k (empty-HOME seed): `page:updatedAt:desc` p50 **953ms → 146ms**; scoped `listChatTsRanges` **773ms → 33ms**.
- [x] Existing end-to-end page tests (title axis, keyset pagination) still pass.

## Additional Notes

- The `after` numbers in the benchmark report include this fix. Merge it into `integration` **before** `integration → main`, or the server-side "scales" claim does not hold.
- Follow-up: a `messages(source_id)` index would flatten the residual per-page aggregation further (100k page latency is 146ms, not sub-ms).
- Metadata-side maps (custom titles, tags) are small (O(renamed)/O(tagged)) and left unscoped; only the dominant messages/raw scans are bounded here.