### PR TITLE
chore(api): remove orphaned server-side legacy full-list path

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -491,8 +491,9 @@ describe("Chat id is the public API handle", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const list = await app.request("/api/chats");
+    const list = await app.request("/api/chats?limit=200");
     const body = (await list.json()) as { chats: ChatResponse[] };
     const chat = body.chats.find((s) => s.sourceId === "session-1");
     expect(chat?.id).toBe(wireId);
@@ -519,6 +520,7 @@ describe("Chat id is the public API handle", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     const res = await app.request("/api/chats/session-1");
     expect(res.status).toBe(404);
@@ -545,6 +547,7 @@ describe("Chat id is the public API handle", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     const res = await app.request(`/api/chats/${wireId}`);
     expect(res.status).toBe(200);
@@ -567,10 +570,11 @@ describe("Soft delete and restore (archive-backed)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
 
-    const res = await app.request("/api/chats?includeDeleted=true");
+    const res = await app.request("/api/chats?includeDeleted=true&limit=200");
     const body = (await res.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((s) => s.sourceId)).not.toContain("session-1");
   });
@@ -588,13 +592,14 @@ describe("Soft delete and restore (archive-backed)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     const del = await app.request(`/api/chats/${wireId}`, {
       method: "DELETE",
     });
     expect(del.status).toBe(204);
 
-    const list = await app.request("/api/chats");
+    const list = await app.request("/api/chats?limit=200");
     const body = (await list.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((s) => s.sourceId)).not.toContain("session-1");
   });
@@ -612,6 +617,7 @@ describe("Soft delete and restore (archive-backed)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
     const restore = await app.request(`/api/chats/${wireId}/restore`, {
@@ -619,7 +625,7 @@ describe("Soft delete and restore (archive-backed)", () => {
     });
     expect(restore.status).toBe(204);
 
-    const list = await app.request("/api/chats");
+    const list = await app.request("/api/chats?limit=200");
     const body = (await list.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((s) => s.sourceId)).toContain("session-1");
   });
@@ -637,6 +643,7 @@ describe("Soft delete and restore (archive-backed)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
 
@@ -667,6 +674,7 @@ describe("GET /api/chats/:id visibility", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
 
@@ -695,6 +703,7 @@ describe("GET /api/chats/:id visibility", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
 
@@ -717,6 +726,7 @@ describe("GET /api/chats/:id visibility", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     await app.request(`/api/chats/${wireId}`, { method: "DELETE" });
     const restore = await app.request(`/api/chats/${wireId}/restore`, {
@@ -734,6 +744,7 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
 
     const res = await app.request("/api/chats/nonexistent", {
@@ -749,6 +760,7 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
 
     const res = await app.request("/api/chats/nonexistent/restore", {
@@ -769,6 +781,7 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
 
     const first = await app.request(`/api/chats/${wireId}`, {
@@ -793,6 +806,7 @@ describe("DELETE / restore idempotency (archive-backed)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
 
     const res = await app.request(`/api/chats/${wireId}/restore`, {
@@ -824,6 +838,7 @@ describe("PATCH /api/chats/:id/title", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     const patch = await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
@@ -832,7 +847,7 @@ describe("PATCH /api/chats/:id/title", () => {
     });
     expect(patch.status).toBe(204);
 
-    const list = await app.request("/api/chats");
+    const list = await app.request("/api/chats?limit=200");
     const body = (await list.json()) as { chats: ChatResponse[] };
     const session = body.chats.find((s) => s.sourceId === "session-1");
     expect(session?.title).toBe("My favourite chat");
@@ -860,6 +875,7 @@ describe("PATCH /api/chats/:id/title", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     const patch = await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
@@ -868,7 +884,7 @@ describe("PATCH /api/chats/:id/title", () => {
     });
     expect(patch.status).toBe(204);
 
-    const list = await app.request("/api/chats");
+    const list = await app.request("/api/chats?limit=200");
     const body = (await list.json()) as { chats: ChatResponse[] };
     const session = body.chats.find((s) => s.sourceId === "session-1");
     expect(session?.title).toBe("Build a login page");
@@ -888,6 +904,7 @@ describe("PATCH /api/chats/:id/title", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     const patch = await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
@@ -896,7 +913,7 @@ describe("PATCH /api/chats/:id/title", () => {
     });
     expect(patch.status).toBe(204);
 
-    const list = await app.request("/api/chats");
+    const list = await app.request("/api/chats?limit=200");
     const body = (await list.json()) as { chats: ChatResponse[] };
     const session = body.chats.find((s) => s.sourceId === "session-1");
     expect(session?.title).toBe("Untitled");
@@ -915,6 +932,7 @@ describe("PATCH /api/chats/:id/title", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     await app.request(`/api/chats/${wireId}/title`, {
       method: "PATCH",
@@ -922,7 +940,7 @@ describe("PATCH /api/chats/:id/title", () => {
       body: JSON.stringify({ title: "  Padded title  " }),
     });
 
-    const list = await app.request("/api/chats");
+    const list = await app.request("/api/chats?limit=200");
     const body = (await list.json()) as { chats: ChatResponse[] };
     const session = body.chats.find((s) => s.sourceId === "session-1");
     expect(session?.title).toBe("Padded title");
@@ -935,6 +953,7 @@ describe("PATCH /api/chats/:id/title", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
 
     const res = await app.request("/api/chats/nonexistent/title", {
@@ -957,6 +976,7 @@ describe("PATCH /api/chats/:id/title", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
 
     const wrongType = await app.request(`/api/chats/${wireId}/title`, {
@@ -979,6 +999,7 @@ describe("PATCH /api/chats/:id/title", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
 
     const tooLong = "x".repeat(201);
@@ -1010,8 +1031,9 @@ describe("GET /api/chats?project= (server-side Project filter)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const res = await app.request("/api/chats?project=project-a");
+    const res = await app.request("/api/chats?project=project-a&limit=200");
     const body = (await res.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((c) => c.sourceId)).toEqual(["session-a"]);
   });
@@ -1039,9 +1061,10 @@ describe("GET /api/chats?project= (server-side Project filter)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     const res = await app.request(
-      "/api/chats?project=project-a&project=project-c"
+      "/api/chats?project=project-a&project=project-c&limit=200"
     );
     const body = (await res.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((c) => c.sourceId).sort()).toEqual([
@@ -1068,8 +1091,9 @@ describe("GET /api/chats?project= (server-side Project filter)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const res = await app.request("/api/chats?project=");
+    const res = await app.request("/api/chats?project=&limit=200");
     const body = (await res.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((c) => c.sourceId)).toEqual(["session-none"]);
   });
@@ -1092,8 +1116,9 @@ describe("GET /api/chats?project= (server-side Project filter)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const res = await app.request("/api/chats");
+    const res = await app.request("/api/chats?limit=200");
     const body = (await res.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((c) => c.sourceId).sort()).toEqual([
       "session-a",
@@ -1120,13 +1145,14 @@ describe("GET /api/chats?project= (server-side Project filter)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const main = await app.request("/api/chats?project=project-a");
+    const main = await app.request("/api/chats?project=project-a&limit=200");
     const mainBody = (await main.json()) as { chats: ChatResponse[] };
     expect(mainBody.chats.map((c) => c.sourceId)).toEqual(["session-active"]);
 
     const trash = await app.request(
-      "/api/chats?project=project-a&includeTrashed=true"
+      "/api/chats?project=project-a&includeTrashed=true&limit=200"
     );
     const trashBody = (await trash.json()) as { chats: ChatResponse[] };
     expect(trashBody.chats.map((c) => c.sourceId).sort()).toEqual([
@@ -1155,8 +1181,15 @@ describe("GET /api/chats?tags= (server-side Tag filter)", () => {
     tags.assignTag(both, idea.id);
     tags.assignTag(bugOnly, bug.id);
 
-    const app = createApp({ archive, metadata, tags });
-    const res = await app.request(`/api/chats?tags=${bug.id},${idea.id}`);
+    const app = createApp({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const res = await app.request(
+      `/api/chats?tags=${bug.id},${idea.id}&limit=200`
+    );
     const body = (await res.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((c) => c.sourceId)).toEqual(["session-both"]);
   });
@@ -1179,9 +1212,14 @@ describe("GET /api/chats?tags= (server-side Tag filter)", () => {
     tags.assignTag(inA, bug.id);
     tags.assignTag(inB, bug.id);
 
-    const app = createApp({ archive, metadata, tags });
+    const app = createApp({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
     const res = await app.request(
-      `/api/chats?tags=${bug.id}&project=project-a`
+      `/api/chats?tags=${bug.id}&project=project-a&limit=200`
     );
     const body = (await res.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((c) => c.sourceId)).toEqual(["session-a-tagged"]);
@@ -1202,8 +1240,13 @@ describe("GET /api/chats?tags= (server-side Tag filter)", () => {
     const bug = tags.createTag("bug", "red");
     tags.assignTag(tagged, bug.id);
 
-    const app = createApp({ archive, metadata, tags });
-    const res = await app.request("/api/chats?tags=");
+    const app = createApp({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const res = await app.request("/api/chats?tags=&limit=200");
     const body = (await res.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((c) => c.sourceId)).toEqual(["session-bare"]);
   });
@@ -1223,8 +1266,13 @@ describe("GET /api/chats?tags= (server-side Tag filter)", () => {
     const bug = tags.createTag("bug", "red");
     tags.assignTag(a, bug.id);
 
-    const app = createApp({ archive, metadata, tags });
-    const res = await app.request("/api/chats");
+    const app = createApp({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const res = await app.request("/api/chats?limit=200");
     const body = (await res.json()) as { chats: ChatResponse[] };
     expect(body.chats.map((c) => c.sourceId).sort()).toEqual([
       "session-a",
@@ -1242,6 +1290,7 @@ describe("GET /api/chats/:id (route status mapping)", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     const res = await app.request("/api/chats/does-not-exist");
     expect(res.status).toBe(404);
@@ -1253,7 +1302,12 @@ describe("Tag API", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
     const tags = createTagRepository({ dataDir });
-    const app = createApp({ archive, metadata, tags });
+    const app = createApp({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
     return { archive, metadata, tags, app };
   }
 
@@ -1410,7 +1464,7 @@ describe("Tag API", () => {
     tags.assignTag(row.id, bug.id);
     tags.assignTag(row.id, idea.id);
 
-    const res = await app.request("/api/chats");
+    const res = await app.request("/api/chats?limit=200");
     const body = (await res.json()) as {
       chats: Array<{ sourceId: string; tags: Tag[] }>;
     };
@@ -1425,7 +1479,7 @@ describe("Tag API", () => {
       firstSeenAt: new Date(1700000000000),
     });
 
-    const res = await app.request("/api/chats");
+    const res = await app.request("/api/chats?limit=200");
     const body = (await res.json()) as {
       chats: Array<{ sourceId: string; tags: Tag[] }>;
     };

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -64,77 +64,62 @@ export function createApp({
   app.get("/api/chats", (c) => {
     const includeTrashed = c.req.query("includeTrashed") === "true";
 
-    // Paginated mode: `?limit=` opts into one server-sorted keyset page. The
-    // legacy full-list path below stays for callers that omit `limit` (Trash and
-    // the title sort, until they migrate).
+    // The List reads one server-sorted keyset page per request (ADR-0017): the
+    // sort + window run inside the cross-store SQL pass, so `?limit=` is
+    // required and the endpoint never loads the full list.
     const limitParam = c.req.query("limit");
-    if (limitParam !== undefined) {
-      if (!pageQuery) {
-        return c.json({ error: "Pagination is not available" }, 501);
-      }
-      const limit = Number.parseInt(limitParam, 10);
-      if (!Number.isInteger(limit) || limit <= 0 || limit > MAX_PAGE_LIMIT) {
-        return c.json({ error: "Invalid limit" }, 400);
-      }
-      const sort = c.req.query("sort") ?? "updatedAt";
-      // `deletedAt` is the Trash view's deleted-time axis (#145); it sorts
-      // through the ATTACHed Metadata store and is trash-only by nature.
-      // `title` sorts through the ATTACHed `chat_sort_keys` collation index
-      // (#146 / ADR-0019), in both the main view and Trash.
-      if (
-        sort !== "createdAt" &&
-        sort !== "updatedAt" &&
-        sort !== "deletedAt" &&
-        sort !== "title"
-      ) {
-        return c.json({ error: "Invalid sort" }, 400);
-      }
-      // Direction defaults to "desc" (newest-first) so existing callers that
-      // omit it are unchanged; the covering index scans either way (#143).
-      const direction = c.req.query("direction") ?? "desc";
-      if (direction !== "asc" && direction !== "desc") {
-        return c.json({ error: "Invalid direction" }, 400);
-      }
-      // The Trash view scopes the page to soft-deleted chats only (#145),
-      // distinct from `includeTrashed` (active + trashed). The frontend sends it
-      // for every Trash page; the `deletedAt` axis is trash-only regardless.
-      const trashedOnly = c.req.query("trashedOnly") === "true";
-      // The active filter pages server-side alongside the keyset window (#130),
-      // parsed the same way as the legacy full-list branch: repeated `?project=`
-      // unions (OR), a single comma-separated `?tags=` ANDs. An empty value
-      // selects the `(No project)` / `Untagged` group; an absent param is
-      // undefined => unfiltered.
-      const projects = c.req.queries("project");
-      const tagsParam = c.req.query("tags");
-      const tagSelection =
-        tagsParam === undefined ? undefined : tagsParam.split(",");
-      const { chats, nextCursor } = reader.listChatsPage({
-        sort,
-        direction,
-        limit,
-        cursor: c.req.query("cursor"),
-        includeTrashed,
-        trashedOnly,
-        projects,
-        tags: tagSelection,
-      });
-      return c.json({ chats, nextCursor });
+    if (limitParam === undefined) {
+      return c.json({ error: "Missing limit" }, 400);
     }
-
-    // Repeated `?project=` params union (OR); an empty value selects the
-    // `(No project)` group. Absent param => undefined => unfiltered.
+    if (!pageQuery) {
+      return c.json({ error: "Pagination is not available" }, 501);
+    }
+    const limit = Number.parseInt(limitParam, 10);
+    if (!Number.isInteger(limit) || limit <= 0 || limit > MAX_PAGE_LIMIT) {
+      return c.json({ error: "Invalid limit" }, 400);
+    }
+    const sort = c.req.query("sort") ?? "updatedAt";
+    // `deletedAt` is the Trash view's deleted-time axis (#145); it sorts
+    // through the ATTACHed Metadata store and is trash-only by nature.
+    // `title` sorts through the ATTACHed `chat_sort_keys` collation index
+    // (#146 / ADR-0019), in both the main view and Trash.
+    if (
+      sort !== "createdAt" &&
+      sort !== "updatedAt" &&
+      sort !== "deletedAt" &&
+      sort !== "title"
+    ) {
+      return c.json({ error: "Invalid sort" }, 400);
+    }
+    // Direction defaults to "desc" (newest-first) so existing callers that
+    // omit it are unchanged; the covering index scans either way (#143).
+    const direction = c.req.query("direction") ?? "desc";
+    if (direction !== "asc" && direction !== "desc") {
+      return c.json({ error: "Invalid direction" }, 400);
+    }
+    // The Trash view scopes the page to soft-deleted chats only (#145),
+    // distinct from `includeTrashed` (active + trashed). The frontend sends it
+    // for every Trash page; the `deletedAt` axis is trash-only regardless.
+    const trashedOnly = c.req.query("trashedOnly") === "true";
+    // The active filter pages server-side alongside the keyset window (#130):
+    // repeated `?project=` unions (OR), a single comma-separated `?tags=` ANDs.
+    // An empty value selects the `(No project)` / `Untagged` group; an absent
+    // param is undefined => unfiltered.
     const projects = c.req.queries("project");
-    // A single comma-separated `?tags=` param, AND within. `tags=` (empty)
-    // splits to `[""]` — the `Untagged` group — mirroring `project=`'s empty
-    // `(No project)` convention. Absent param => undefined => unfiltered.
     const tagsParam = c.req.query("tags");
-    const tags = tagsParam === undefined ? undefined : tagsParam.split(",");
-    const chats = reader.listChats({
+    const tagSelection =
+      tagsParam === undefined ? undefined : tagsParam.split(",");
+    const { chats, nextCursor } = reader.listChatsPage({
+      sort,
+      direction,
+      limit,
+      cursor: c.req.query("cursor"),
       includeTrashed,
+      trashedOnly,
       projects,
-      tags,
+      tags: tagSelection,
     });
-    return c.json({ chats });
+    return c.json({ chats, nextCursor });
   });
 
   // The live-update channel (issue #132): a Server-Sent Events stream that

--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -2,12 +2,30 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, it, expect } from "vitest";
-import { createChatReader } from "./chat-reader.js";
+import { createChatReader, type ChatReader } from "./chat-reader.js";
+import { createChatPageQuery } from "./list-pagination.js";
 import { createArchiveRepository } from "./archive/repository.js";
 import { createMetadataRepository } from "./metadata/repository.js";
 import { createTagRepository } from "./metadata/tags.js";
 import { CROCKFORD_ALPHABET, formatChatId } from "./archive/chat-id.js";
 import type { ArchiveReadSeam } from "./archive/read-seam.js";
+
+// The public List read is the keyset page path (ADR-0017). These tests seed a
+// handful of chats and assert hydration/filter/visibility, not pagination, so
+// they read the whole seeded set through one large page. Sorting by updatedAt
+// keeps assertions that check membership (not order) stable.
+function listAll(
+  reader: ChatReader,
+  opts: { includeTrashed: boolean; projects?: string[]; tags?: string[] }
+): ReturnType<ChatReader["listChatsPage"]>["chats"] {
+  return reader.listChatsPage({
+    sort: "updatedAt",
+    limit: 1000,
+    includeTrashed: opts.includeTrashed,
+    projects: opts.projects,
+    tags: opts.tags,
+  }).chats;
+}
 
 const DEFAULT_AGENT = "claude-code";
 
@@ -116,7 +134,7 @@ afterEach(() => {
   fs.rmSync(dataDir, { recursive: true, force: true });
 });
 
-describe("ChatReader.listChats", () => {
+describe("ChatReader.listChatsPage hydration", () => {
   it("returns chats from the archive even when source JSONL is absent", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
@@ -130,8 +148,9 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chats = reader.listChats({ includeTrashed: false });
+    const chats = listAll(reader, { includeTrashed: false });
     expect(chats.map((c) => c.sourceId)).toContain("session-1");
   });
 
@@ -149,10 +168,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.project).toBe("project-a");
   });
 
@@ -185,10 +205,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.title).toBe("Build a login page");
   });
 
@@ -214,10 +235,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.title).toBe("My favourite chat");
   });
 
@@ -234,10 +256,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.title).toBe("Untitled");
   });
 
@@ -270,10 +293,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.createdAt).toBe(1700000100000);
     expect(chat?.updatedAt).toBe(1700000500000);
   });
@@ -291,10 +315,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.createdAt).toBe(1700000000000);
     expect(chat?.updatedAt).toBe(1700000000000);
   });
@@ -313,10 +338,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     // id is the public wire-form chat id (clog_ + 6 Crockford chars).
     expect(chat?.id).toBe(`clog_${code}`);
     expect(code).toHaveLength(6);
@@ -339,10 +365,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat).toBeDefined();
     expect("chatId" in chat!).toBe(false);
   });
@@ -372,10 +399,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.sourceFilePath).toBe("/new/path.jsonl");
   });
 
@@ -392,10 +420,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.sourceFilePath).toBeNull();
   });
 
@@ -412,10 +441,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.agent).toBe("claude-code");
   });
 
@@ -434,10 +464,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.projectPath).toBe("/Users/evaaaaawu/Documents/chat-logbook");
   });
 
@@ -454,10 +485,11 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.projectPath).toBeNull();
   });
 
@@ -475,15 +507,16 @@ describe("ChatReader.listChats", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.project).toBe("");
   });
 });
 
-describe("ChatReader.listChats project filter", () => {
+describe("ChatReader.listChatsPage project filter", () => {
   it("returns only chats in the given project", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
@@ -503,8 +536,9 @@ describe("ChatReader.listChats project filter", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chats = reader.listChats({
+    const chats = listAll(reader, {
       includeTrashed: false,
       projects: ["project-a"],
     });
@@ -535,8 +569,9 @@ describe("ChatReader.listChats project filter", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chats = reader.listChats({
+    const chats = listAll(reader, {
       includeTrashed: false,
       projects: ["project-a", "project-c"],
     });
@@ -565,8 +600,9 @@ describe("ChatReader.listChats project filter", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chats = reader.listChats({
+    const chats = listAll(reader, {
       includeTrashed: false,
       projects: [""],
     });
@@ -593,14 +629,15 @@ describe("ChatReader.listChats project filter", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const active = reader.listChats({
+    const active = listAll(reader, {
       includeTrashed: false,
       projects: ["project-a"],
     });
     expect(active.map((c) => c.sourceId)).toEqual(["session-active"]);
 
-    const trash = reader.listChats({
+    const trash = listAll(reader, {
       includeTrashed: true,
       projects: ["project-a"],
     });
@@ -611,7 +648,7 @@ describe("ChatReader.listChats project filter", () => {
   });
 });
 
-describe("ChatReader.listChats tag filter", () => {
+describe("ChatReader.listChatsPage tag filter", () => {
   it("returns only chats holding ALL selected tags (AND)", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
@@ -631,8 +668,13 @@ describe("ChatReader.listChats tag filter", () => {
     tags.assignTag(both, idea.id);
     tags.assignTag(bugOnly, bug.id);
 
-    const reader = createChatReader({ archive, metadata, tags });
-    const chats = reader.listChats({
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const chats = listAll(reader, {
       includeTrashed: false,
       tags: [bug.id, idea.id],
     });
@@ -655,8 +697,13 @@ describe("ChatReader.listChats tag filter", () => {
     const bug = tags.createTag("bug", "red");
     tags.assignTag(tagged, bug.id);
 
-    const reader = createChatReader({ archive, metadata, tags });
-    const chats = reader.listChats({ includeTrashed: false, tags: [""] });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const chats = listAll(reader, { includeTrashed: false, tags: [""] });
     expect(chats.map((c) => c.sourceId)).toEqual(["session-bare"]);
   });
 
@@ -676,8 +723,13 @@ describe("ChatReader.listChats tag filter", () => {
     const bug = tags.createTag("bug", "red");
     tags.assignTag(tagged, bug.id);
 
-    const reader = createChatReader({ archive, metadata, tags });
-    const chats = reader.listChats({
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const chats = listAll(reader, {
       includeTrashed: false,
       tags: ["", bug.id],
     });
@@ -703,8 +755,13 @@ describe("ChatReader.listChats tag filter", () => {
     tags.assignTag(inA, bug.id);
     tags.assignTag(inB, bug.id);
 
-    const reader = createChatReader({ archive, metadata, tags });
-    const chats = reader.listChats({
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const chats = listAll(reader, {
       includeTrashed: false,
       projects: ["project-a"],
       tags: [bug.id],
@@ -730,15 +787,19 @@ describe("ChatReader.listChats tag filter", () => {
     tags.assignTag(trashed, bug.id);
     metadata.softDelete(trashed);
 
-    const reader = createChatReader({ archive, metadata, tags });
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
     expect(
-      reader
-        .listChats({ includeTrashed: false, tags: [bug.id] })
-        .map((c) => c.sourceId)
+      listAll(reader, { includeTrashed: false, tags: [bug.id] }).map(
+        (c) => c.sourceId
+      )
     ).toEqual(["session-active"]);
     expect(
-      reader
-        .listChats({ includeTrashed: true, tags: [bug.id] })
+      listAll(reader, { includeTrashed: true, tags: [bug.id] })
         .map((c) => c.sourceId)
         .sort()
     ).toEqual(["session-active", "session-trashed"]);
@@ -759,8 +820,9 @@ describe("ChatReader visibility", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chats = reader.listChats({ includeTrashed: false });
+    const chats = listAll(reader, { includeTrashed: false });
     expect(chats.map((c) => c.sourceId)).not.toContain("session-1");
   });
 
@@ -777,10 +839,11 @@ describe("ChatReader visibility", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: true })
-      .find((c) => c.sourceId === "session-1");
+    const chat = listAll(reader, { includeTrashed: true }).find(
+      (c) => c.sourceId === "session-1"
+    );
     expect(chat?.isDeleted).toBe(true);
   });
 
@@ -802,8 +865,9 @@ describe("ChatReader visibility", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chats = reader.listChats({ includeTrashed: true });
+    const chats = listAll(reader, { includeTrashed: true });
     const active = chats.find((c) => c.sourceId === "session-active");
     const trashed = chats.find((c) => c.sourceId === "session-trashed");
     expect(active?.deletedAt).toBeNull();
@@ -842,6 +906,7 @@ describe("ChatReader.getMessages", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
       includeTrashed: false,
@@ -877,6 +942,7 @@ describe("ChatReader.getMessages", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     expect(reader.getMessages(wireId, { includeTrashed: false })).toBeNull();
   });
@@ -889,6 +955,7 @@ describe("ChatReader.getMessages", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     expect(
       reader.getMessages("does-not-exist", { includeTrashed: false })
@@ -915,6 +982,7 @@ describe("ChatReader.getMessages", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     // Source id is no longer a public lookup key — only the wire-form chat id is.
     expect(
@@ -943,6 +1011,7 @@ describe("ChatReader.getMessages", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     // Strict: only the clog_ wire form resolves; the bare code does not.
     expect(reader.getMessages(bareCode, { includeTrashed: false })).toBeNull();
@@ -969,6 +1038,7 @@ describe("ChatReader.getMessages", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
       includeTrashed: false,
@@ -1003,10 +1073,11 @@ describe("ChatReader is agent-agnostic", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chat = reader
-      .listChats({ includeTrashed: false })
-      .find((c) => c.sourceId === "session-codex");
+    const chat = listAll(reader, { includeTrashed: false }).find(
+      (c) => c.sourceId === "session-codex"
+    );
     expect(chat?.agent).toBe("codex");
     expect(chat?.title).toBe("Hello from Codex");
 
@@ -1022,7 +1093,7 @@ describe("ChatReader is agent-agnostic", () => {
 
 /**
  * Count how many archive read-seam methods are invoked while `fn` runs.
- * The #106 invariant is "listChats issues a constant number of archive reads
+ * The #106 invariant is "the hydration pass issues a constant number of archive reads
  * regardless of chat count" — each seam method maps to one underlying SQL
  * statement, so a constant call count is the public-surface proxy for the
  * constant SQL-statement count the original raw-handle counter measured.
@@ -1102,7 +1173,7 @@ function seedFullChat(
   }
 }
 
-describe("ChatReader.listChats query batching", () => {
+describe("ChatReader.listChatsPage query batching", () => {
   it("runs a constant number of archive queries regardless of chat count", () => {
     const archiveSmall = createArchiveRepository({ dataDir });
     const metadataSmall = createMetadataRepository({ dataDir });
@@ -1111,9 +1182,10 @@ describe("ChatReader.listChats query batching", () => {
       archive: archiveSmall,
       metadata: metadataSmall,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
     const smallCount = countArchiveQueries(archiveSmall, () => {
-      readerSmall.listChats({ includeTrashed: false });
+      listAll(readerSmall, { includeTrashed: false });
     });
 
     const bigDir = fs.mkdtempSync(
@@ -1129,9 +1201,10 @@ describe("ChatReader.listChats query batching", () => {
         archive: archiveBig,
         metadata: metadataBig,
         tags: createTagRepository({ dataDir: bigDir }),
+        pageQuery: createChatPageQuery({ dataDir: bigDir }),
       });
       const bigCount = countArchiveQueries(archiveBig, () => {
-        readerBig.listChats({ includeTrashed: false });
+        listAll(readerBig, { includeTrashed: false });
       });
 
       expect(bigCount).toBe(smallCount);
@@ -1211,8 +1284,9 @@ describe("ChatReader.listChats query batching", () => {
       archive,
       metadata,
       tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
     });
-    const chats = reader.listChats({ includeTrashed: false });
+    const chats = listAll(reader, { includeTrashed: false });
 
     // Ordering mirrors the chat-row insertion order.
     expect(chats.map((c) => c.sourceId)).toEqual([

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -72,22 +72,6 @@ function toApiBlock(block: StoredBlock): ApiContentBlock {
 
 export interface ChatReader {
   /**
-   * List visible chats. `projects`, when given, filters server-side to chats in
-   * any of those Projects (OR / union); an empty-string entry selects the
-   * `(No project)` group. Omitting it returns every visible chat.
-   */
-  listChats(opts: {
-    includeTrashed: boolean;
-    projects?: string[];
-    /**
-     * Tag filter, AND within: a Chat must hold every selected Tag to pass. An
-     * empty-string entry selects the `Untagged` group (zero Tags) — mixing it
-     * with a real Tag id naturally yields nothing. Combined with `projects` (OR
-     * within) the two AND across types. Omitting it leaves Tags unfiltered.
-     */
-    tags?: string[];
-  }): ChatResponse[];
-  /**
    * One keyset-paginated, server-sorted page of visible chats (ADR-0017). The
    * sort + windowing run inside the cross-store SQL pass, so the caller never
    * loads the full list. `cursor` is the opaque token returned as a prior page's
@@ -163,8 +147,8 @@ interface ChatReaderDeps {
   tags: TagRepository;
   /**
    * The keyset page query that runs the cross-store sorted + paginated listing
-   * (ADR-0017). Optional so the full-list read paths (and their tests) compose
-   * without it; `listChatsPage` requires it.
+   * (ADR-0017). Optional so the read paths that don't page (and their tests)
+   * compose without it; `listChatsPage` requires it.
    */
   pageQuery?: ChatPageQuery;
   /**
@@ -205,61 +189,11 @@ export function createChatReader({
     return [agent, sourceId].join("\u0000");
   }
 
-  function listChats({
-    includeTrashed,
-    projects,
-    tags: tagSelection,
-  }: {
-    includeTrashed: boolean;
-    projects?: string[];
-    tags?: string[];
-  }): ChatResponse[] {
-    const visibility = loadChatVisibility(metadata, { includeTrashed });
-    const rows = archive.read.listChatRows(projects ? { projects } : undefined);
-
-    // Tag filter (AND within) is resolved as a per-Chat predicate intersected
-    // in app code with the Project-filtered Archive rows — the cross-store
-    // intersection ADR-0016 mandates instead of a single cross-database JOIN.
-    // A real-id set comes from the AND-intersection query; the `Untagged`
-    // group is "holds no Tag at all", so it excludes any Chat that appears in
-    // the grouped tags map. Selecting both at once leaves nothing, as intended.
-    let passesTagFilter: ((chatInternalId: string) => boolean) | null = null;
-    if (tagSelection) {
-      const realTagIds = tagSelection.filter((t) => t !== "");
-      const wantUntagged = tagSelection.includes("");
-      const allowedByTags =
-        realTagIds.length > 0
-          ? new Set(tags.listChatIdsWithAllTags(realTagIds))
-          : null;
-      const taggedChatIds = wantUntagged
-        ? new Set(tags.listTagsByChat().keys())
-        : null;
-      passesTagFilter = (chatInternalId) => {
-        if (allowedByTags && !allowedByTags.has(chatInternalId)) return false;
-        if (taggedChatIds && taggedChatIds.has(chatInternalId)) return false;
-        return true;
-      };
-    }
-
-    const toResponse = loadHydration();
-
-    const chats: ChatResponse[] = [];
-    for (const row of rows) {
-      if (!visibility.isVisible(row.id)) continue;
-      if (passesTagFilter && !passesTagFilter(row.id)) continue;
-      chats.push(toResponse(row, visibility));
-    }
-
-    return chats;
-  }
-
   // Loads the grouped/windowed derivation maps once (one query per derived
   // field, never ~3 per row — issue #106) and returns an assembler that turns a
-  // single Archive chat row + visibility into the public Chat shape. Shared by
-  // the full-list (`listChats`) and paginated (`listChatsPage`) read paths.
+  // single Archive chat row + visibility into the public Chat shape.
   // `scope.sourceIds` bounds the message/raw aggregations to a page's chats so
-  // the paginated path stays O(page); the full-list path calls this with no
-  // scope and aggregates every chat as before (issue #158).
+  // the paginated read path stays O(page) (issue #158).
   function loadHydration(scope?: {
     sourceIds?: string[];
   }): (
@@ -422,7 +356,6 @@ export function createChatReader({
   }
 
   return {
-    listChats,
     listChatsPage,
     listCounts,
     listFilteredTotal,

--- a/api/src/seed/seed.test.ts
+++ b/api/src/seed/seed.test.ts
@@ -5,8 +5,25 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createArchiveRepository } from "../archive/repository.js";
 import { createMetadataRepository } from "../metadata/repository.js";
 import { createTagRepository } from "../metadata/tags.js";
-import { createChatReader } from "../chat-reader.js";
+import { createChatReader, type ChatReader } from "../chat-reader.js";
+import { createChatPageQuery } from "../list-pagination.js";
 import { seedArchive } from "./seed.js";
+
+// The List read is the keyset page path (ADR-0017); these seeder assertions
+// check membership/filtering, not order, so they read the whole seeded set
+// through one large page.
+function listAll(
+  reader: ChatReader,
+  opts: { includeTrashed: boolean; projects?: string[]; tags?: string[] }
+): ReturnType<ChatReader["listChatsPage"]>["chats"] {
+  return reader.listChatsPage({
+    sort: "updatedAt",
+    limit: 100000,
+    includeTrashed: opts.includeTrashed,
+    projects: opts.projects,
+    tags: opts.tags,
+  }).chats;
+}
 
 let dataDir: string;
 
@@ -26,7 +43,12 @@ function openReader() {
     archive,
     metadata,
     tags,
-    reader: createChatReader({ archive, metadata, tags }),
+    reader: createChatReader({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    }),
   };
 }
 
@@ -40,7 +62,7 @@ describe("seedArchive", () => {
     expect(summary.chats).toBe(25);
 
     const { reader } = openReader();
-    const listed = reader.listChats({ includeTrashed: false });
+    const listed = listAll(reader, { includeTrashed: false });
     expect(listed).toHaveLength(25);
   });
 
@@ -55,14 +77,14 @@ describe("seedArchive", () => {
     expect(summary.namedProjects).toBeGreaterThan(1);
 
     const { reader } = openReader();
-    const noProject = reader.listChats({
+    const noProject = listAll(reader, {
       includeTrashed: false,
       projects: [""],
     });
     expect(noProject.length).toBeGreaterThan(0);
     expect(noProject.every((c) => c.project === "")).toBe(true);
 
-    const all = reader.listChats({ includeTrashed: false });
+    const all = listAll(reader, { includeTrashed: false });
     expect(all.some((c) => c.project !== "")).toBe(true);
     // Generous margin: these seed through the repos one autocommit at a time,
     // which is slower on shared CI runners than locally.
@@ -85,6 +107,7 @@ describe("seedArchive", () => {
         archive: archive2,
         metadata: metadata2,
         tags: tags2,
+        pageQuery: createChatPageQuery({ dataDir: dir }),
       });
       return { reader, tags: tags2 };
     }
@@ -93,7 +116,7 @@ describe("seedArchive", () => {
 
     // A tag filter returns a non-empty subset, every member holding that tag.
     const someTag = first.tags.listTags()[0];
-    const filtered = first.reader.listChats({
+    const filtered = listAll(first.reader, {
       includeTrashed: false,
       tags: [someTag.id],
     });
@@ -105,7 +128,7 @@ describe("seedArchive", () => {
     // Same seed in a fresh directory yields the same sourceId -> tag-names map.
     const tagFingerprint = (r: ReturnType<typeof seedInto>["reader"]) =>
       new Map(
-        r.listChats({ includeTrashed: false }).map((c) => [
+        listAll(r, { includeTrashed: false }).map((c) => [
           c.sourceId,
           c.tags
             .map((t) => t.name)


### PR DESCRIPTION
## What

`GET /api/chats` still carried a legacy full-list branch for callers that omitted `?limit=`, backed by the reader's `listChats` method. That branch was orphaned: the web client always sends `limit`, and the two views it was kept for — Trash (#145) and Title sort (#146) — already page through the server-side keyset path (ADR-0017). The in-code "until they migrate" comment was stale.

This is a code-path removal only: no schema, ingestion, FTS, or archive-row changes.

## Changes

- **Require `limit` on `GET /api/chats`.** A missing `limit` now returns `400 { "error": "Missing limit" }`, matching the handler's existing validation style. The endpoint always uses the keyset page path.
- **Remove the `listChats` reader method** from `chat-reader.ts` (interface entry, implementation, and return-object entry), plus the stale "until they migrate" comment and the "full-list" references in the surrounding doc comments.
- **Migrate the tests** that used `listChats` as a helper — `chat-reader.test.ts`, `app.test.ts`, `seed/seed.test.ts` — onto the keyset page path via `listChatsPage`, preserving their hydration / filter / visibility / seeder coverage. No keyset-path tests were deleted.

## Keyset coverage confirmed

The keyset path already covers every axis the removed branch served: `createdAt`, `updatedAt`, `deletedAt`, and `title` sorts, across both the main view and Trash (`trashedOnly`), plus Project (OR) / Tag (AND) / Untagged filtering. `list-pagination.test.ts` and `list-pagination-title.test.ts` exercise these directly.

No client code depended on the removed branch — `web/src/chat/usePaginatedChats.ts` always includes `limit` in the request.

## Verification

- `pnpm --filter api typecheck` — green
- Full monorepo suite via pre-commit hook: **api 299 passed, web 185 passed**

Closes #169