### PR TITLE
chore(api): remove orphaned listChatIdsWithAllTags tag reader

### DIFF
--- a/api/src/metadata/tags.test.ts
+++ b/api/src/metadata/tags.test.ts
@@ -137,39 +137,4 @@ describe("TagRepository", () => {
     expect(second.listTags()).toEqual([tag]);
     expect(second.listTagsForChat("chat-1")).toEqual([tag]);
   });
-
-  it("lists chats holding ALL of the given tags (AND intersection)", () => {
-    const repo = createTagRepository({ dataDir });
-    const bug = repo.createTag("bug", "red");
-    const idea = repo.createTag("idea", "violet");
-    repo.assignTag("chat-both", bug.id);
-    repo.assignTag("chat-both", idea.id);
-    repo.assignTag("chat-bug-only", bug.id);
-    repo.assignTag("chat-idea-only", idea.id);
-
-    const chatIds = repo.listChatIdsWithAllTags([bug.id, idea.id]);
-
-    expect(chatIds).toEqual(["chat-both"]);
-  });
-
-  it("lists every chat carrying a single given tag", () => {
-    const repo = createTagRepository({ dataDir });
-    const bug = repo.createTag("bug", "red");
-    repo.assignTag("chat-1", bug.id);
-    repo.assignTag("chat-2", bug.id);
-
-    const chatIds = repo.listChatIdsWithAllTags([bug.id]);
-
-    expect(chatIds.sort()).toEqual(["chat-1", "chat-2"]);
-  });
-
-  it("de-duplicates repeated tag ids so they don't inflate the AND count", () => {
-    const repo = createTagRepository({ dataDir });
-    const bug = repo.createTag("bug", "red");
-    repo.assignTag("chat-1", bug.id);
-
-    const chatIds = repo.listChatIdsWithAllTags([bug.id, bug.id]);
-
-    expect(chatIds).toEqual(["chat-1"]);
-  });
 });

--- a/api/src/metadata/tags.ts
+++ b/api/src/metadata/tags.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { openStore } from "../storage/openStore.js";
 import * as schema from "./schema.js";
 import { chatTags, tags } from "./schema.js";
@@ -30,14 +30,6 @@ export interface TagRepository {
   /** Tags grouped by Chat id in one query — never one query per Chat
    * (ADR-0016). Pass `chatIds` to scope to a subset; omit for every Chat. */
   listTagsByChat(chatIds?: string[]): Map<string, Tag[]>;
-  /**
-   * Chat ids holding ALL of the given Tags — the AND-intersection that backs
-   * the multi-Tag filter (#11 / ADR-0016). `tag_id IN (...) GROUP BY chat_id
-   * HAVING COUNT = N`; the `(chat_id, tag_id)` PK guarantees no duplicate rows
-   * so the count is exact. Duplicate ids in the input are de-duplicated first
-   * so a repeated id can't inflate N past what any Chat can match. An empty
-   * input returns no ids (an AND over nothing has no candidate set here). */
-  listChatIdsWithAllTags(tagIds: string[]): string[];
 }
 
 interface TagRepositoryOptions {
@@ -173,19 +165,6 @@ export function createTagRepository({
         byChat.set(row.chatId, list);
       }
       return byChat;
-    },
-
-    listChatIdsWithAllTags(tagIds) {
-      const distinct = [...new Set(tagIds)];
-      if (distinct.length === 0) return [];
-      return db
-        .select({ chatId: chatTags.chatId })
-        .from(chatTags)
-        .where(inArray(chatTags.tagId, distinct))
-        .groupBy(chatTags.chatId)
-        .having(sql`count(${chatTags.tagId}) = ${distinct.length}`)
-        .all()
-        .map((r) => r.chatId);
     },
   };
 }


### PR DESCRIPTION
## What

Deletes the `listChatIdsWithAllTags` reader method from `api/src/metadata/tags.ts` (interface declaration + implementation, plus its now-unused `sql` import) and the three unit tests that covered it.

## Why

PR #172 (chore/remove-legacy-full-list-path) removed the server-side legacy full-list path, which held the **last live caller** of `listChatIdsWithAllTags`. After that merged, the function was referenced only by its own unit test — orphaned dead code.

This was intentionally left out of #169 to keep that change minimal. It's the final follow-up in the list-pipeline dead-code cleanup family (#167 / #168 / #169), and only became safe to land now that #172 orphaned the function.

## Verification

- `rg "listChatIdsWithAllTags"` (excluding node_modules) returns no remaining references.
- `pnpm --filter api typecheck` — green.
- api test suite — 296 passed. Full pre-commit typecheck + test across both workspaces also green.