### PR TITLE
feat: Tag filter Any (OR) mode alongside default All (AND)

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -264,6 +264,57 @@ describe("GET /api/chats — keyset pagination mode", () => {
     expect(byTagBody.chats.map((c) => c.sourceId)).toEqual(["alpha1"]);
   });
 
+  it("unions the selected Tags when ?tagMode=any", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const c1 = seedChat(archive, { sourceId: "c1", firstSeenAt: new Date(1) });
+    const c2 = seedChat(archive, { sourceId: "c2", firstSeenAt: new Date(2) });
+    seedChat(archive, { sourceId: "c3", firstSeenAt: new Date(3) });
+
+    const work = tags.createTag("work", "blue");
+    const fun = tags.createTag("fun", "violet");
+    tags.assignTag(c1, work.id);
+    tags.assignTag(c2, fun.id);
+
+    const app = createApp({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+
+    // `all` (default) intersects → nothing holds both.
+    const allRes = await app.request(
+      `/api/chats?sort=createdAt&limit=10&tags=${work.id},${fun.id}`
+    );
+    const allBody = (await allRes.json()) as { chats: ChatResponse[] };
+    expect(allBody.chats).toEqual([]);
+
+    // `any` unions → c2 (fun, newer) then c1 (work); c3 excluded.
+    const anyRes = await app.request(
+      `/api/chats?sort=createdAt&limit=10&tags=${work.id},${fun.id}&tagMode=any`
+    );
+    const anyBody = (await anyRes.json()) as { chats: ChatResponse[] };
+    expect(anyBody.chats.map((c) => c.sourceId)).toEqual(["c2", "c1"]);
+  });
+
+  it("rejects an invalid tagMode with 400", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const app = createApp({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const res = await app.request(
+      "/api/chats?sort=createdAt&limit=10&tagMode=bogus"
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("rejects an invalid sort with 400", async () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });
@@ -474,6 +525,41 @@ describe("GET /api/chats/list-total — filtered List count (Phase B)", () => {
       `/api/chats/list-total?project=alpha&tags=${work.id}`
     );
     expect(((await byBoth.json()) as { total: number }).total).toBe(1);
+  });
+
+  it("unions the selected Tags when ?tagMode=any", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const c1 = seedChat(archive, { sourceId: "c1", firstSeenAt: new Date(1) });
+    const c2 = seedChat(archive, { sourceId: "c2", firstSeenAt: new Date(2) });
+    seedChat(archive, { sourceId: "c3", firstSeenAt: new Date(3) });
+
+    const work = tags.createTag("work", "blue");
+    const fun = tags.createTag("fun", "violet");
+    tags.assignTag(c1, work.id);
+    tags.assignTag(c2, fun.id);
+
+    const app = createApp({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+      countsQuery: createChatCountsQuery({ dataDir }),
+    });
+
+    // `all` (default) intersects → nothing holds both.
+    const all = await app.request(
+      `/api/chats/list-total?tags=${work.id},${fun.id}`
+    );
+    expect(((await all.json()) as { total: number }).total).toBe(0);
+
+    // `any` unions → c1 and c2 each hold one.
+    const any = await app.request(
+      `/api/chats/list-total?tags=${work.id},${fun.id}&tagMode=any`
+    );
+    expect(((await any.json()) as { total: number }).total).toBe(2);
   });
 });
 

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -109,6 +109,14 @@ export function createApp({
     const tagsParam = c.req.query("tags");
     const tagSelection =
       tagsParam === undefined ? undefined : tagsParam.split(",");
+    // `tagMode` chooses how the selected real Tags combine: `all` (default, AND)
+    // or `any` (OR, with `Untagged` joining the union) — ADR-0016 update.
+    // Validated to the fixed pair like `direction`, so an unknown value is a 400
+    // rather than a silent fallback.
+    const tagMode = c.req.query("tagMode") ?? "all";
+    if (tagMode !== "all" && tagMode !== "any") {
+      return c.json({ error: "Invalid tagMode" }, 400);
+    }
     const { chats, nextCursor } = reader.listChatsPage({
       sort,
       direction,
@@ -118,6 +126,7 @@ export function createApp({
       trashedOnly,
       projects,
       tags: tagSelection,
+      tagMode,
     });
     return c.json({ chats, nextCursor });
   });
@@ -178,7 +187,18 @@ export function createApp({
     const projects = c.req.queries("project");
     const tagsParam = c.req.query("tags");
     const tags = tagsParam === undefined ? undefined : tagsParam.split(",");
-    const total = reader.listFilteredTotal({ includeTrashed, projects, tags });
+    // `tagMode` chooses how the selected real Tags combine (ADR-0016 update);
+    // validated to the fixed pair like the paginated list route.
+    const tagMode = c.req.query("tagMode") ?? "all";
+    if (tagMode !== "all" && tagMode !== "any") {
+      return c.json({ error: "Invalid tagMode" }, 400);
+    }
+    const total = reader.listFilteredTotal({
+      includeTrashed,
+      projects,
+      tags,
+      tagMode,
+    });
     return c.json({ total });
   });
 

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -13,6 +13,7 @@ import {
   type ListSort,
 } from "./list-pagination.js";
 import type { ChatCountsQuery, ListCounts } from "./list-counts.js";
+import type { TagMode } from "./list-filter.js";
 
 /**
  * The Chat read face. At read time it composes Archive + Metadata into the
@@ -103,6 +104,11 @@ export interface ChatReader {
      * it leaves Tags unfiltered.
      */
     tags?: string[];
+    /**
+     * How the selected real Tags combine (ADR-0016 update): `all` (default) ANDs
+     * them, `any` ORs them and lets `Untagged` join that union.
+     */
+    tagMode?: TagMode;
   }): { chats: ChatResponse[]; nextCursor: string | null };
   /**
    * The filter-panel facet counts and the unfiltered List count for a view
@@ -123,6 +129,8 @@ export interface ChatReader {
     includeTrashed?: boolean;
     projects?: string[];
     tags?: string[];
+    /** How the selected real Tags combine (ADR-0016 update); `all` by default. */
+    tagMode?: TagMode;
   }): number;
   /**
    * Messages for a Chat resolved by its public wire-form chat id (`clog_…`).
@@ -254,6 +262,7 @@ export function createChatReader({
     trashedOnly = false,
     projects,
     tags: tagSelection,
+    tagMode,
   }: {
     sort: ListSort;
     direction?: ListDirection;
@@ -263,6 +272,7 @@ export function createChatReader({
     trashedOnly?: boolean;
     projects?: string[];
     tags?: string[];
+    tagMode?: TagMode;
   }): { chats: ChatResponse[]; nextCursor: string | null } {
     if (!pageQuery) {
       throw new Error("listChatsPage requires a pageQuery dependency");
@@ -279,6 +289,7 @@ export function createChatReader({
       trashedOnly,
       projects,
       tags: tagSelection,
+      tagMode,
     });
 
     // The keyset SQL already applied visibility + ordering; hydration is pure
@@ -325,15 +336,22 @@ export function createChatReader({
     includeTrashed = false,
     projects,
     tags,
+    tagMode,
   }: {
     includeTrashed?: boolean;
     projects?: string[];
     tags?: string[];
+    tagMode?: TagMode;
   }): number {
     if (!countsQuery) {
       throw new Error("listFilteredTotal requires a countsQuery dependency");
     }
-    return countsQuery.queryFilteredTotal({ includeTrashed, projects, tags });
+    return countsQuery.queryFilteredTotal({
+      includeTrashed,
+      projects,
+      tags,
+      tagMode,
+    });
   }
 
   function getMessages(

--- a/api/src/list-counts.test.ts
+++ b/api/src/list-counts.test.ts
@@ -413,6 +413,87 @@ describe("ChatCountsQuery.queryFilteredTotal — Tag filter", () => {
   });
 });
 
+describe("ChatCountsQuery.queryFilteredTotal — Tag filter Any (OR) mode", () => {
+  it("ORs the Untagged group into the union in 'any' mode", () => {
+    const archive = createArchiveRepository({ dataDir });
+    createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const c1 = seedChat(archive, { sourceId: "c1", firstSeenAt: new Date(1) });
+    const c2 = seedChat(archive, { sourceId: "c2", firstSeenAt: new Date(2) });
+    seedChat(archive, { sourceId: "c3", firstSeenAt: new Date(3) });
+
+    const work = tags.createTag("work", "blue");
+    const fun = tags.createTag("fun", "violet");
+    // c1 holds work, c2 holds fun, c3 holds nothing (untagged).
+    tags.assignTag(c1, work.id);
+    tags.assignTag(c2, fun.id);
+
+    const countsQuery = createChatCountsQuery({ dataDir });
+    // Any + Untagged: "holds work OR holds no tags" — c1 and c3, not c2.
+    const total = countsQuery.queryFilteredTotal({
+      tags: [work.id, ""],
+      tagMode: "any",
+    });
+
+    expect(total).toBe(2);
+
+    countsQuery.close();
+  });
+
+  it("treats Untagged alone the same in 'any' mode as in 'all'", () => {
+    const archive = createArchiveRepository({ dataDir });
+    createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const c1 = seedChat(archive, { sourceId: "c1", firstSeenAt: new Date(1) });
+    seedChat(archive, { sourceId: "c2", firstSeenAt: new Date(2) });
+    seedChat(archive, { sourceId: "c3", firstSeenAt: new Date(3) });
+
+    const work = tags.createTag("work", "blue");
+    tags.assignTag(c1, work.id);
+
+    const countsQuery = createChatCountsQuery({ dataDir });
+    // With no real Tag selected the mode is irrelevant — c2, c3 are untagged.
+    const total = countsQuery.queryFilteredTotal({
+      tags: [""],
+      tagMode: "any",
+    });
+
+    expect(total).toBe(2);
+
+    countsQuery.close();
+  });
+
+  it("unions multiple selected tags when tagMode is 'any'", () => {
+    const archive = createArchiveRepository({ dataDir });
+    createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const c1 = seedChat(archive, { sourceId: "c1", firstSeenAt: new Date(1) });
+    const c2 = seedChat(archive, { sourceId: "c2", firstSeenAt: new Date(2) });
+    seedChat(archive, { sourceId: "c3", firstSeenAt: new Date(3) });
+
+    const work = tags.createTag("work", "blue");
+    const fun = tags.createTag("fun", "violet");
+    // c1 holds both, c2 holds only work, c3 holds neither.
+    tags.assignTag(c1, work.id);
+    tags.assignTag(c1, fun.id);
+    tags.assignTag(c2, work.id);
+
+    const countsQuery = createChatCountsQuery({ dataDir });
+    // Any: a chat holding AT LEAST ONE of work/fun — c1 and c2, not c3.
+    const total = countsQuery.queryFilteredTotal({
+      tags: [work.id, fun.id],
+      tagMode: "any",
+    });
+
+    expect(total).toBe(2);
+
+    countsQuery.close();
+  });
+});
+
 describe("ChatCountsQuery.queryFilteredTotal — cross-type and view", () => {
   it("ANDs a Project and a Tag filter across types", () => {
     const archive = createArchiveRepository({ dataDir });

--- a/api/src/list-counts.ts
+++ b/api/src/list-counts.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import Database from "better-sqlite3";
-import { buildFilterClauses } from "./list-filter.js";
+import { buildFilterClauses, type TagMode } from "./list-filter.js";
 
 /**
  * The facet-count aggregation (issue #131 Phase A, ADR-0017). Owns one Archive
@@ -55,6 +55,12 @@ export interface ChatCountsQuery {
     includeTrashed?: boolean;
     projects?: string[];
     tags?: string[];
+    /**
+     * How the selected real Tags combine (ADR-0016 update): `all` (default) ANDs
+     * them (hold every Tag), `any` ORs them (hold at least one) and lets
+     * `Untagged` join that union. Only the List total follows the mode.
+     */
+    tagMode?: TagMode;
   }): number;
   close(): void;
 }
@@ -148,10 +154,12 @@ export function createChatCountsQuery({
     includeTrashed = false,
     projects,
     tags,
+    tagMode = "all",
   }: {
     includeTrashed?: boolean;
     projects?: string[];
     tags?: string[];
+    tagMode?: TagMode;
   }): number {
     const clauses: string[] = [];
     const params: (string | number)[] = [];
@@ -170,7 +178,7 @@ export function createChatCountsQuery({
 
     // The Project/Tag filter is the same predicate the keyset page applies
     // (#130); it lives in `buildFilterClauses` so the two read paths share it.
-    const filter = buildFilterClauses({ projects, tags, hasMetadata });
+    const filter = buildFilterClauses({ projects, tags, tagMode, hasMetadata });
     clauses.push(...filter.clauses);
     params.push(...filter.params);
 

--- a/api/src/list-filter.ts
+++ b/api/src/list-filter.ts
@@ -19,6 +19,15 @@ export interface FilterClauses {
 }
 
 /**
+ * How the selected real Tags combine (ADR-0016 update). `all` (default) keeps
+ * the AND intersection — a Chat must hold every selected Tag. `any` keeps a Chat
+ * holding at least one, and lets the `Untagged` marker OR into that union
+ * instead of ANDing to nothing. Governs Tag-to-Tag combination only; the Project
+ * axis stays an OR/union and the cross-axis relation is unchanged.
+ */
+export type TagMode = "all" | "any";
+
+/**
  * Build the Project (OR / union) and Tag (AND / intersection) filter clauses.
  *
  * An empty-string Project entry selects the `(No project)` group (NULL or '');
@@ -31,10 +40,12 @@ export interface FilterClauses {
 export function buildFilterClauses({
   projects,
   tags,
+  tagMode = "all",
   hasMetadata,
 }: {
   projects?: string[];
   tags?: string[];
+  tagMode?: TagMode;
   hasMetadata: boolean;
 }): FilterClauses {
   const clauses: string[] = [];
@@ -48,30 +59,54 @@ export function buildFilterClauses({
     params.push(...projects);
   }
 
-  // Tag filter (AND / intersection). A real-Tag selection keeps only chats
-  // holding every selected Tag — the grouped subquery counts matched Tags per
-  // chat and requires the full set. The `Untagged` group (the '' marker) keeps
-  // only chats with zero Tags. Selecting both a real Tag and '' at once ANDs to
-  // nothing, as intended.
+  // Tag filter. `all` (default) intersects the selected real Tags — a chat must
+  // hold every one — and the `Untagged` group ('' marker) keeps chats with zero
+  // Tags; selecting both a real Tag and '' ANDs to nothing, as intended. `any`
+  // unions the selected real Tags — a chat holding at least one — and lets
+  // `Untagged` OR into that union ("holds no Tags OR holds a selected Tag"),
+  // which is why the two fragments compose with OR here and AND in `all` mode
+  // (ADR-0016 update). The real-Tag membership subquery is bound, never
+  // interpolated, and stays an index range scan on `chat_tags` either way.
   if (tags && tags.length > 0) {
     const realTagIds = tags.filter((t) => t !== "");
     const wantUntagged = tags.includes("");
+
+    // The real-Tag fragment, or null when nothing real is selected / no tags
+    // can exist. In the no-Metadata case a real-Tag selection matches nothing
+    // ("0"); the `Untagged` fragment is dropped there since every chat is
+    // untagged (matching everything needs no clause).
+    let realFragment: string | null = null;
     if (realTagIds.length > 0) {
       if (!hasMetadata) {
-        // No tags exist, so no chat can hold the selected Tag.
-        clauses.push("0");
+        realFragment = "0";
       } else {
         const placeholders = realTagIds.map(() => "?").join(", ");
-        clauses.push(
-          `c.id IN (SELECT chat_id FROM meta.chat_tags
+        if (tagMode === "any") {
+          realFragment = `c.id IN (SELECT DISTINCT chat_id FROM meta.chat_tags
+                    WHERE tag_id IN (${placeholders}))`;
+          params.push(...realTagIds);
+        } else {
+          realFragment = `c.id IN (SELECT chat_id FROM meta.chat_tags
                     WHERE tag_id IN (${placeholders})
-                    GROUP BY chat_id HAVING count(*) = ?)`
-        );
-        params.push(...realTagIds, realTagIds.length);
+                    GROUP BY chat_id HAVING count(*) = ?)`;
+          params.push(...realTagIds, realTagIds.length);
+        }
       }
     }
-    if (wantUntagged && hasMetadata) {
-      clauses.push("c.id NOT IN (SELECT chat_id FROM meta.chat_tags)");
+
+    const untaggedFragment =
+      wantUntagged && hasMetadata
+        ? "c.id NOT IN (SELECT chat_id FROM meta.chat_tags)"
+        : null;
+
+    // In `any` mode a real-Tag union and `Untagged` compose with OR into one
+    // clause; in `all` mode they are independent predicates that each AND onto
+    // the WHERE.
+    if (tagMode === "any" && realFragment && untaggedFragment) {
+      clauses.push(`(${realFragment} OR ${untaggedFragment})`);
+    } else {
+      if (realFragment) clauses.push(realFragment);
+      if (untaggedFragment) clauses.push(untaggedFragment);
     }
   }
 

--- a/api/src/list-pagination.test.ts
+++ b/api/src/list-pagination.test.ts
@@ -608,6 +608,76 @@ describe("ChatReader.listChatsPage — server-side filtering (#130)", () => {
     pageQuery.close();
   });
 
+  it("unions the selected Tags when tagMode is 'any'", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const both = seedChat(archive, {
+      sourceId: "both",
+      firstSeenAt: new Date(1_000),
+    });
+    const onlyX = seedChat(archive, {
+      sourceId: "onlyX",
+      firstSeenAt: new Date(2_000),
+    });
+    seedChat(archive, { sourceId: "none", firstSeenAt: new Date(3_000) });
+
+    const x = tags.createTag("x", "violet");
+    const y = tags.createTag("y", "blue");
+    tags.assignTag(both, x.id);
+    tags.assignTag(both, y.id);
+    tags.assignTag(onlyX, x.id);
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+    const page = reader.listChatsPage({
+      sort: "createdAt",
+      limit: 10,
+      tags: [x.id, y.id],
+      tagMode: "any",
+    });
+
+    // Any: every chat holding at least one of x/y — "onlyX" and "both"
+    // (newest-first by createdAt), not the untagged "none".
+    expect(page.chats.map((c) => c.sourceId)).toEqual(["onlyX", "both"]);
+
+    pageQuery.close();
+  });
+
+  it("ORs the Untagged group into the union in 'any' mode", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const tagged = seedChat(archive, {
+      sourceId: "tagged",
+      firstSeenAt: new Date(1_000),
+    });
+    seedChat(archive, { sourceId: "other", firstSeenAt: new Date(2_000) });
+    seedChat(archive, { sourceId: "bare", firstSeenAt: new Date(3_000) });
+
+    const x = tags.createTag("x", "violet");
+    const other = tags.createTag("other", "blue");
+    tags.assignTag(tagged, x.id);
+    // "other" (sourceId) holds a different Tag; "bare" holds none.
+    const otherId = archive.ensureChat("claude-code", "other", new Date(2_000));
+    tags.assignTag(otherId, other.id);
+
+    const { reader, pageQuery } = makeReader(archive, metadata, tags);
+    const page = reader.listChatsPage({
+      sort: "createdAt",
+      limit: 10,
+      tags: [x.id, ""],
+      tagMode: "any",
+    });
+
+    // Any + Untagged: "holds x OR holds no Tags" — bare (3000) then tagged
+    // (1000), newest-first; the differently-tagged "other" is excluded.
+    expect(page.chats.map((c) => c.sourceId)).toEqual(["bare", "tagged"]);
+
+    pageQuery.close();
+  });
+
   it("ANDs the Project and Tag filters across types", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });

--- a/api/src/list-pagination.ts
+++ b/api/src/list-pagination.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import Database from "better-sqlite3";
-import { buildFilterClauses } from "./list-filter.js";
+import { buildFilterClauses, type TagMode } from "./list-filter.js";
 
 /**
  * The keyset page query (issue #129, ADR-0017). Owns one Archive connection with
@@ -90,6 +90,13 @@ export interface KeysetPageQuery {
    * `ATTACH`ed `meta.chat_tags` (ADR-0017); ANDs across types with `projects`.
    */
   tags?: string[];
+  /**
+   * How the selected real Tags combine (ADR-0016 update): `all` (default)
+   * intersects them (hold every Tag), `any` unions them (hold at least one) and
+   * lets the `Untagged` marker OR into that union. Governs Tag-to-Tag
+   * combination only; `projects` stays an OR/union ANDed across types.
+   */
+  tagMode?: TagMode;
 }
 
 export interface ChatPageQuery {
@@ -218,6 +225,7 @@ export function createChatPageQuery({
     const filter = buildFilterClauses({
       projects: query.projects,
       tags: query.tags,
+      tagMode: query.tagMode,
       hasMetadata,
     });
     clauses.push(...filter.clauses);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import {
   type ListSort,
 } from "@/chat/usePaginatedChats";
 import { useTags } from "@/tags/useTags";
+import { useTagMode } from "@/tags/useTagMode";
 import { useMessages } from "@/conversation/useMessages";
 import { useToast } from "@/shared/useToast";
 import { useChatOrder } from "@/chat/sort/useChatOrder";
@@ -70,6 +71,12 @@ function App() {
   const [selectedTags, setSelectedTags] = useState<ReadonlySet<string>>(
     () => new Set()
   );
+  // The Tag filter's Match mode (all/any), persisted per view like the sort
+  // preference (ADR-0016 update). Main and Trash keep independent modes; the
+  // active one rides the read hooks and the TagsSection control.
+  const mainTagMode = useTagMode("main");
+  const trashTagMode = useTagMode("trash");
+  const tagMode = mode === "trash" ? trashTagMode : mainTagMode;
 
   // The paginated path filters server-side: the selection rides the keyset query
   // and re-anchors the window on change (#130). Both views read through it now;
@@ -78,6 +85,7 @@ function App() {
     enabled: mainPaginate,
     projects: [...selectedProjects],
     tags: [...selectedTags],
+    tagMode: mainTagMode.mode,
   });
   // The Trash view reuses the same paginated read path, scoped to trashed-only
   // (#145). It re-anchors on the active filter and its axis the same way the main
@@ -87,6 +95,7 @@ function App() {
     trashedOnly: true,
     projects: [...selectedProjects],
     tags: [...selectedTags],
+    tagMode: trashTagMode.mode,
   });
   const source = mode === "trash" ? trashPaginated : paginated;
   const { chats, sortEpoch, softDelete, restore, setTitle, reload } = source;
@@ -99,10 +108,14 @@ function App() {
   // Trash counts independently of the active view's counts.
   const trashCounts = useChatCounts("trash");
 
+  // Destructure the (stable) counts reloader into a local so the callback deps
+  // are plain identifiers — a `counts.reload` member dep can't be tracked by the
+  // React Compiler's manual-memoization check.
+  const { reload: reloadCounts } = counts;
   const onAssignmentChange = useCallback(() => {
     void reload();
-    void counts.reload();
-  }, [reload, counts.reload]);
+    void reloadCounts();
+  }, [reload, reloadCounts]);
   const {
     tags: tagCatalog,
     createTag,
@@ -194,7 +207,8 @@ function App() {
   const filteredTotal = useFilteredTotal(
     mode,
     [...selectedProjects],
-    [...selectedTags]
+    [...selectedTags],
+    tagMode.mode
   );
   // While the first filtered total is still loading (filteredTotal undefined),
   // hold the view's facet total rather than letting the header fall back to the
@@ -327,6 +341,8 @@ function App() {
             countForTag={countForTag}
             untaggedCount={untaggedCount}
             selectedTags={selectedTags}
+            tagMode={tagMode.mode}
+            onTagModeChange={tagMode.setMode}
             onToggleTag={toggleTag}
             onRenameTag={(id, name) => void renameTag(id, name)}
             onRecolorTag={(id, color) => void recolorTag(id, color)}

--- a/web/src/chat/FilterPanel.tsx
+++ b/web/src/chat/FilterPanel.tsx
@@ -5,6 +5,7 @@ import type { ProjectFacet } from "@/chat/projects/projectFacets";
 import { TagsSection } from "@/tags/TagsSection";
 import type { Tag } from "@/types";
 import type { ColorToken } from "@/tags/palette";
+import type { TagMode } from "@/tags/tagModePreference";
 
 interface FilterPanelProps {
   /** How many chats are in Trash — the server-derived trashed total (#131). */
@@ -18,6 +19,8 @@ interface FilterPanelProps {
   countForTag: (tagId: string) => number;
   untaggedCount: number;
   selectedTags: ReadonlySet<string>;
+  tagMode: TagMode;
+  onTagModeChange: (mode: TagMode) => void;
   onToggleTag: (tagId: string) => void;
   onRenameTag: (id: string, name: string) => void;
   onRecolorTag: (id: string, color: ColorToken) => void;
@@ -35,6 +38,8 @@ export function FilterPanel({
   countForTag,
   untaggedCount,
   selectedTags,
+  tagMode,
+  onTagModeChange,
   onToggleTag,
   onRenameTag,
   onRecolorTag,
@@ -61,6 +66,8 @@ export function FilterPanel({
           countForTag={countForTag}
           untaggedCount={untaggedCount}
           selected={selectedTags}
+          tagMode={tagMode}
+          onTagModeChange={onTagModeChange}
           onToggle={onToggleTag}
           onRename={onRenameTag}
           onRecolor={onRecolorTag}

--- a/web/src/chat/useChatCounts.ts
+++ b/web/src/chat/useChatCounts.ts
@@ -74,6 +74,10 @@ export function useChatCounts(mode: "main" | "trash"): UseChatCountsResult {
   }, [mode]);
 
   useEffect(() => {
+    // `refresh` only setStates after `await fetch`, so this is not the
+    // synchronous cascading render the rule guards against — it's a standard
+    // fetch-on-mount / on-view-change.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void refresh();
   }, [refresh]);
 

--- a/web/src/chat/useFilteredTotal.test.tsx
+++ b/web/src/chat/useFilteredTotal.test.tsx
@@ -24,6 +24,27 @@ describe("useFilteredTotal", () => {
     expect(result.current).toBeUndefined();
   });
 
+  it("sends ?tagMode=any when the Any mode is active, and omits it for All", async () => {
+    const urls: string[] = [];
+    server.use(
+      http.get("/api/chats/list-total", ({ request }) => {
+        urls.push(request.url);
+        return HttpResponse.json({ total: 0 });
+      })
+    );
+
+    const { rerender } = renderHook(
+      ({ mode }: { mode: "all" | "any" }) =>
+        useFilteredTotal("main", [], ["bug"], mode),
+      { initialProps: { mode: "all" as "all" | "any" } }
+    );
+    await waitFor(() => expect(urls.length).toBeGreaterThan(0));
+    expect(urls.at(-1)).not.toContain("tagMode");
+
+    rerender({ mode: "any" });
+    await waitFor(() => expect(urls.at(-1)).toContain("tagMode=any"));
+  });
+
   it("keeps the previous total while the next filter's total is in flight", async () => {
     const { result, rerender } = renderHook(
       ({ projects }) => useFilteredTotal("main", projects, []),

--- a/web/src/chat/useFilteredTotal.ts
+++ b/web/src/chat/useFilteredTotal.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import type { TagMode } from "@/tags/tagModePreference";
 
 // The filtered List count ("Chats N" when a filter is active; #131 Phase B).
 // Kept separate from the static facet counts (useChatCounts) so toggling a
@@ -11,7 +12,8 @@ const BACKGROUND_REFRESH_MS = 4000;
 function listTotalUrl(
   mode: "main" | "trash",
   projects: string[],
-  tags: string[]
+  tags: string[],
+  tagMode: TagMode
 ): string {
   const params = new URLSearchParams();
   if (mode === "trash") params.set("includeTrashed", "true");
@@ -19,6 +21,9 @@ function listTotalUrl(
   // the same wire shape the paginated list query uses (#130).
   for (const p of projects) params.append("project", p);
   if (tags.length > 0) params.set("tags", tags.join(","));
+  // `tagMode=any` opts into OR; `all` is the server default, so it rides only
+  // when active — keeping the default URL (and its fetch cache key) unchanged.
+  if (tagMode === "any") params.set("tagMode", "any");
   return `/api/chats/list-total?${params.toString()}`;
 }
 
@@ -41,13 +46,14 @@ interface FetchedTotal {
 export function useFilteredTotal(
   mode: "main" | "trash",
   projects: string[],
-  tags: string[]
+  tags: string[],
+  tagMode: TagMode = "all"
 ): number | undefined {
   const [fetched, setFetched] = useState<FetchedTotal | null>(null);
   // The URL fully encodes view + filter, so depending on it re-runs the fetch
   // exactly when the selection changes — no array-identity churn across renders.
   const active = projects.length > 0 || tags.length > 0;
-  const url = active ? listTotalUrl(mode, projects, tags) : null;
+  const url = active ? listTotalUrl(mode, projects, tags, tagMode) : null;
 
   useEffect(() => {
     if (url === null) return;

--- a/web/src/chat/usePaginatedChats.test.tsx
+++ b/web/src/chat/usePaginatedChats.test.tsx
@@ -101,6 +101,31 @@ describe("usePaginatedChats", () => {
     expect(result.current.hasMore).toBe(false);
   });
 
+  it("sends ?tagMode=any on the page request when the Any mode is active", async () => {
+    const urls: string[] = [];
+    server.use(
+      http.get("/api/chats", ({ request }) => {
+        urls.push(request.url);
+        return HttpResponse.json({ chats: [], nextCursor: null });
+      })
+    );
+
+    const { rerender } = renderHook(
+      ({ mode }: { mode: "all" | "any" }) =>
+        usePaginatedChats("updatedAt", "desc", {
+          pageSize: 2,
+          tags: ["bug"],
+          tagMode: mode,
+        }),
+      { initialProps: { mode: "all" as "all" | "any" } }
+    );
+    await waitFor(() => expect(urls.length).toBeGreaterThan(0));
+    expect(urls.at(-1)).not.toContain("tagMode");
+
+    rerender({ mode: "any" });
+    await waitFor(() => expect(urls.at(-1)).toContain("tagMode=any"));
+  });
+
   it("does not fetch more once the last page is reached", async () => {
     // A page large enough to hold every active chat: first page is the last.
     const { result } = renderHook(() =>

--- a/web/src/chat/usePaginatedChats.ts
+++ b/web/src/chat/usePaginatedChats.ts
@@ -3,6 +3,7 @@ import { MAX_PAGE_LIMIT } from "@contract";
 import type { Chat } from "@/types";
 import { useChatMutations, type ChatListSource } from "@/chat/useChatMutations";
 import { useListStream, type ListStreamConnector } from "@/chat/useListStream";
+import type { TagMode } from "@/tags/tagModePreference";
 
 // The sort axes the keyset page endpoint supports. createdAt/updatedAt are the
 // main view's time axes (#129 / ADR-0017); deletedAt is the Trash view's
@@ -72,6 +73,12 @@ interface UsePaginatedChatsOptions {
    */
   tags?: readonly string[];
   /**
+   * How the selected real Tags combine (ADR-0016 update): `all` (default) ANDs
+   * them, `any` ORs them and lets the Untagged group join the union. Rides the
+   * page request as `tagMode=any` only when active; re-anchors on change.
+   */
+  tagMode?: TagMode;
+  /**
    * Trash view scope (#145): when true the page is trashed-only, the inverse of
    * the default active list. Pairs with the `deletedAt` sort axis but also
    * scopes the time axes within Trash. Sent to the keyset query as
@@ -90,6 +97,7 @@ interface UsePaginatedChatsOptions {
 interface ActiveFilter {
   projects: readonly string[];
   tags: readonly string[];
+  tagMode: TagMode;
 }
 
 // Adds the window-reconciling background refresh to the shared source shape; the
@@ -123,6 +131,9 @@ function pageUrl(
   if (filter.tags.length > 0) {
     base += `&tags=${filter.tags.map(encodeURIComponent).join(",")}`;
   }
+  // `tagMode=any` opts into OR; `all` is the server default, so it rides only
+  // when active — keeping the default request URL unchanged.
+  if (filter.tagMode === "any") base += `&tagMode=any`;
   return cursor ? `${base}&cursor=${encodeURIComponent(cursor)}` : base;
 }
 
@@ -153,6 +164,7 @@ export function usePaginatedChats(
     enabled = true,
     projects = [],
     tags = [],
+    tagMode = "all",
     trashedOnly = false,
     connect,
   }: UsePaginatedChatsOptions = {}
@@ -168,8 +180,9 @@ export function usePaginatedChats(
     () => ({
       projects: JSON.parse(projectsKey) as string[],
       tags: JSON.parse(tagsKey) as string[],
+      tagMode,
     }),
-    [projectsKey, tagsKey]
+    [projectsKey, tagsKey, tagMode]
   );
 
   // The loaded window is a list of fetched pages, each carrying the cursors that

--- a/web/src/tags/TagsSection.test.tsx
+++ b/web/src/tags/TagsSection.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { TagsSection } from "./TagsSection";
+import { UNTAGGED } from "./untagged";
+import type { Tag } from "@/types";
+
+const TAGS: Tag[] = [
+  { id: "t-bug", name: "bug", color: "violet" },
+  { id: "t-idea", name: "idea", color: "blue" },
+];
+
+function renderSection(
+  overrides: Partial<React.ComponentProps<typeof TagsSection>> = {}
+) {
+  const props: React.ComponentProps<typeof TagsSection> = {
+    tags: TAGS,
+    countForTag: () => 1,
+    untaggedCount: 3,
+    selected: new Set<string>(),
+    tagMode: "all",
+    onTagModeChange: vi.fn(),
+    onToggle: vi.fn(),
+    onRename: vi.fn(),
+    onRecolor: vi.fn(),
+    onDelete: vi.fn(),
+    ...overrides,
+  };
+  render(<TagsSection {...props} />);
+  return props;
+}
+
+describe("TagsSection — Match All/Any control", () => {
+  it("renders a Match control reflecting the active mode", () => {
+    renderSection({ tagMode: "any" });
+
+    expect(screen.getByTestId("tag-match-all")).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+    expect(screen.getByTestId("tag-match-any")).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+
+  it("calls onTagModeChange when a mode is picked", async () => {
+    const user = userEvent.setup();
+    const props = renderSection({ tagMode: "all" });
+
+    await user.click(screen.getByTestId("tag-match-any"));
+
+    expect(props.onTagModeChange).toHaveBeenCalledWith("any");
+  });
+});
+
+describe("TagsSection — Untagged dimming by mode", () => {
+  it("dims real Tag rows while Untagged is active in All mode", () => {
+    renderSection({ tagMode: "all", selected: new Set([UNTAGGED]) });
+
+    const row = document.querySelector('[data-tag-id="t-bug"]');
+    expect(row).toHaveAttribute("data-dimmed", "true");
+  });
+
+  it("does not dim real Tag rows in Any mode (Untagged joins the union)", () => {
+    renderSection({ tagMode: "any", selected: new Set([UNTAGGED]) });
+
+    const row = document.querySelector('[data-tag-id="t-bug"]');
+    expect(row).not.toHaveAttribute("data-dimmed", "true");
+  });
+});

--- a/web/src/tags/TagsSection.tsx
+++ b/web/src/tags/TagsSection.tsx
@@ -138,7 +138,7 @@ function ManageMenu({
     >
       <PopoverTrigger
         aria-label={`Manage tag ${tag.name}`}
-        className="flex h-6 w-6 shrink-0 items-center justify-center rounded bg-card text-muted-foreground opacity-0 transition hover:bg-white/10 hover:text-foreground focus-visible:opacity-100 group-hover/tag:opacity-100 data-[popup-open]:opacity-100 pointer-events-none focus-visible:pointer-events-auto group-hover/tag:pointer-events-auto data-[popup-open]:pointer-events-auto"
+        className="flex h-6 w-6 shrink-0 items-center justify-center rounded bg-card text-muted-foreground opacity-0 transition hover:bg-white/10 hover:text-foreground focus-visible:opacity-100 group-hover/tag:opacity-100 data-popup-open:opacity-100 pointer-events-none focus-visible:pointer-events-auto group-hover/tag:pointer-events-auto data-popup-open:pointer-events-auto"
       >
         <MoreHorizontal size={14} aria-hidden="true" />
       </PopoverTrigger>

--- a/web/src/tags/TagsSection.tsx
+++ b/web/src/tags/TagsSection.tsx
@@ -14,6 +14,7 @@ import { TAG_COLOR_HEX, type ColorToken } from "@/tags/palette";
 import { ColorSwatches } from "@/tags/ColorSwatches";
 import { sortTagsByName } from "@/tags/sortTags";
 import { UNTAGGED } from "@/tags/untagged";
+import type { TagMode } from "@/tags/tagModePreference";
 
 interface TagsSectionProps {
   tags: Tag[];
@@ -23,10 +24,57 @@ interface TagsSectionProps {
   untaggedCount: number;
   // The active Tag filter: tag ids plus the `UNTAGGED` sentinel. AND within.
   selected: ReadonlySet<string>;
+  // How the selected Tags combine: `all` (AND) or `any` (OR). The Match control
+  // switches it; `any` also drops the Untagged dimming (ADR-0016 update).
+  tagMode: TagMode;
+  onTagModeChange: (mode: TagMode) => void;
   onToggle: (tagId: string) => void;
   onRename: (id: string, name: string) => void;
   onRecolor: (id: string, color: ColorToken) => void;
   onDelete: (id: string) => void;
+}
+
+// The All / Any match control beside the Tags header label. `all` ANDs the
+// selected Tags, `any` ORs them (ADR-0016 update). A bordered segmented control:
+// a hairline frame with the two `aria-pressed` segments flush to it (no inner
+// gap) and a divider between them, the active one on a soft `bg-primary/15`
+// fill. `overflow-hidden` clips the active fill to the frame's rounded corners.
+// A sibling of the collapse toggle, never nested in it.
+function MatchControl({
+  mode,
+  onChange,
+}: {
+  mode: TagMode;
+  onChange: (mode: TagMode) => void;
+}) {
+  const modes = ["all", "any"] as const;
+  return (
+    <div
+      data-testid="tag-match-control"
+      role="group"
+      aria-label="Tag match mode"
+      className="flex items-center overflow-hidden rounded-md border border-border text-[11px] font-medium"
+    >
+      {modes.map((value, i) => (
+        <button
+          key={value}
+          type="button"
+          data-testid={`tag-match-${value}`}
+          aria-pressed={mode === value}
+          onClick={() => onChange(value)}
+          className={`px-2 py-0.5 capitalize transition-colors ${
+            i < modes.length - 1 ? "border-r border-border" : ""
+          } ${
+            mode === value
+              ? "bg-primary/15 text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {value}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 function RenameRow({
@@ -252,6 +300,7 @@ function TagRow({
     <li
       data-testid="tag-manage-row"
       data-tag-id={tag.id}
+      data-dimmed={dimmed ? "true" : undefined}
       className={`group/tag relative flex items-center rounded-md pr-2 text-sm transition ${
         isSelected ? "bg-primary/15" : "hover:bg-card"
       } ${dimmed ? "opacity-40 hover:opacity-100" : ""}`}
@@ -347,6 +396,8 @@ export function TagsSection({
   countForTag,
   untaggedCount,
   selected,
+  tagMode,
+  onTagModeChange,
   onToggle,
   onRename,
   onRecolor,
@@ -354,24 +405,42 @@ export function TagsSection({
 }: TagsSectionProps) {
   const [collapsed, setCollapsed] = useState(false);
   const sorted = useMemo(() => sortTagsByName(tags), [tags]);
-  // While Untagged is the active filter, real Tags can't combine with it, so
-  // they read as dimmed-but-available (clicking one switches the filter).
+  // While Untagged is the active filter in All mode, real Tags can't combine
+  // with it, so they read as dimmed-but-available (clicking one switches the
+  // filter). In Any mode "Untagged OR Tag X" is a real union, so no dimming
+  // (ADR-0016 update).
   const untaggedActive = selected.has(UNTAGGED);
+  const dimRealTags = untaggedActive && tagMode === "all";
 
   return (
     <div data-testid="tags-section" className="flex flex-col">
-      <button
-        type="button"
-        data-testid="tags-header"
-        onClick={() => setCollapsed((c) => !c)}
-        aria-expanded={!collapsed}
-        className="flex items-center justify-between px-2 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <span>Tags</span>
-        <span
+      {/* Header row: "Tags" and the All/Any match control sit together on the
+          left; the "A–Z" order caption stays on the right. Both "Tags" and the
+          A–Z caption are collapse toggles (the caption carries the chevron); the
+          match control is a sibling — never nested — so its buttons don't also
+          collapse the section, and it stays visible while collapsed. */}
+      <div className="flex items-center justify-between px-2 py-1.5 text-xs font-medium text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            data-testid="tags-header"
+            onClick={() => setCollapsed((c) => !c)}
+            aria-expanded={!collapsed}
+            className="transition-colors hover:text-foreground"
+          >
+            Tags
+          </button>
+          {sorted.length > 0 && (
+            <MatchControl mode={tagMode} onChange={onTagModeChange} />
+          )}
+        </div>
+        <button
+          type="button"
           data-testid="tags-order-caption"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-expanded={!collapsed}
           title="Sorted A–Z"
-          className="flex items-center gap-0.5 text-muted-foreground/80"
+          className="flex items-center gap-0.5 text-muted-foreground/80 transition-colors hover:text-foreground"
         >
           A–Z
           <ChevronDown
@@ -379,8 +448,8 @@ export function TagsSection({
             aria-hidden="true"
             className={`transition-transform ${collapsed ? "-rotate-90" : ""}`}
           />
-        </span>
-      </button>
+        </button>
+      </div>
       {!collapsed &&
         (sorted.length === 0 ? (
           <p className="px-2 py-1.5 text-xs text-muted-foreground">
@@ -394,7 +463,7 @@ export function TagsSection({
                 tag={tag}
                 count={countForTag(tag.id)}
                 isSelected={selected.has(tag.id)}
-                dimmed={untaggedActive}
+                dimmed={dimRealTags}
                 onToggle={() => onToggle(tag.id)}
                 onRename={(name) => onRename(tag.id, name)}
                 onRecolor={(color) => onRecolor(tag.id, color)}

--- a/web/src/tags/tagModePreference.test.ts
+++ b/web/src/tags/tagModePreference.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, it, expect } from "vitest";
+import { loadTagMode, saveTagMode } from "./tagModePreference";
+
+const KEY = "chat-logbook:tag-mode:main";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("tagModePreference", () => {
+  it("defaults to 'all' when nothing is stored", () => {
+    expect(loadTagMode(KEY)).toBe("all");
+  });
+
+  it("round-trips a saved mode (restored on reload)", () => {
+    saveTagMode(KEY, "any");
+    expect(loadTagMode(KEY)).toBe("any");
+  });
+
+  it("keeps a separate mode per view key", () => {
+    saveTagMode("chat-logbook:tag-mode:main", "any");
+    saveTagMode("chat-logbook:tag-mode:trash", "all");
+    expect(loadTagMode("chat-logbook:tag-mode:main")).toBe("any");
+    expect(loadTagMode("chat-logbook:tag-mode:trash")).toBe("all");
+  });
+
+  it("falls back to 'all' on a malformed stored value", () => {
+    localStorage.setItem(KEY, "not json");
+    expect(loadTagMode(KEY)).toBe("all");
+  });
+});

--- a/web/src/tags/tagModePreference.ts
+++ b/web/src/tags/tagModePreference.ts
@@ -1,0 +1,32 @@
+/**
+ * Per-view persistence for the Tag filter's Match mode (ADR-0016 update). `all`
+ * (default) ANDs the selected Tags; `any` ORs them and lets `Untagged` join the
+ * union. Persisted per view — keyed like the sort preference — so a chosen `any`
+ * survives reloads. Mirrors the versioned localStorage shape of the sort
+ * preference so a future format change can be detected and ignored.
+ */
+export type TagMode = "all" | "any";
+
+const STORAGE_VERSION = 1;
+
+export function saveTagMode(storageKey: string, mode: TagMode): void {
+  const payload = { version: STORAGE_VERSION, mode };
+  localStorage.setItem(storageKey, JSON.stringify(payload));
+}
+
+export function loadTagMode(storageKey: string): TagMode {
+  const raw = localStorage.getItem(storageKey);
+  if (raw == null) return "all";
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return "all";
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return "all";
+  const record = parsed as Record<string, unknown>;
+  if (record.version !== STORAGE_VERSION) return "all";
+  return record.mode === "any" ? "any" : "all";
+}

--- a/web/src/tags/useTagMode.ts
+++ b/web/src/tags/useTagMode.ts
@@ -1,0 +1,30 @@
+import { useCallback, useState } from "react";
+import {
+  loadTagMode,
+  saveTagMode,
+  type TagMode,
+} from "@/tags/tagModePreference";
+
+/**
+ * Owns the Tag filter's Match mode for one view (ADR-0016 update), persisted per
+ * view under its own storage key so a chosen `any` survives reloads and the main
+ * and Trash views keep independent modes — the same shape as the per-view sort
+ * preference. Returns the current mode and a setter that writes through.
+ */
+export function useTagMode(view: "main" | "trash"): {
+  mode: TagMode;
+  setMode: (mode: TagMode) => void;
+} {
+  const storageKey = `chat-logbook:tag-mode:${view}`;
+  const [mode, setModeState] = useState<TagMode>(() => loadTagMode(storageKey));
+
+  const setMode = useCallback(
+    (next: TagMode) => {
+      saveTagMode(storageKey, next);
+      setModeState(next);
+    },
+    [storageKey]
+  );
+
+  return { mode, setMode };
+}


### PR DESCRIPTION
## Background (Why)

The Tag filter was AND-only: a Chat had to hold every selected Tag. "Chats tagged `bug` **or** `regression`" is as common a question as "tagged both", and the AND-only default can't express it. This adds an opt-in Any (OR) mode alongside the default All (AND), keeping AND the primary and OR one click away (issue #159, ADR-0016 update).

## Approach (How)

A per-view `tagMode` (`all` | `any`, default `all`) chosen in the shared filter predicate. In the SQL, `any` drops the grouped `HAVING count = N` and matches Tag membership directly (`IN (SELECT DISTINCT …)`), turning the intersection into a union; both stay index range scans on `chat_tags`. The one surprising case: in `any` mode the `Untagged` marker ORs into the union ("holds no Tags **or** holds a selected Tag") instead of ANDing to nothing, so the two fragments compose with `OR` there and `AND` in `all` mode.

The mode threads through the keyset page query, the filtered List count, the ChatReader, and the list + list-total HTTP routes (which reject an unknown `tagMode` with 400, mirroring `direction`). Facet counts take no `tagMode`, so they stay independent of the selection and the mode. On the client the mode persists per view like the sort preference and rides the requests as `?tagMode=any` only when active, keeping the default URL (and its fetch cache key) unchanged.

## Changes (What)

- [x] `buildFilterClauses` gains `tagMode`; `any` unions real Tags and ORs in `Untagged`, `all` keeps the AND intersection
- [x] `tagMode` threaded through keyset page, filtered List count, ChatReader, and the list + list-total routes with 400 validation
- [x] A bordered All / Any segmented control beside the Tags header; `any` drops the `Untagged` dimming, `all` keeps it
- [x] Mode persisted per view (`useTagMode` + `tagModePreference`) and sent as `?tagMode=any` from the paginated list and filtered-total requests
- [x] Fixed two pre-existing React-Compiler lint errors surfaced by the strict build (`App` counts-reloader memoization, `useChatCounts` fetch-on-mount false positive)

### Test Verification

- [x] `queryFilteredTotal` / keyset page: `any` unions multiple Tags (AND vs OR)
- [x] `any` + `Untagged` ORs into the union; `Untagged` alone behaves the same in both modes
- [x] HTTP list + list-total accept `?tagMode=any` and return the union; unknown `tagMode` → 400
- [x] `tagModePreference` round-trips per view and restores on reload
- [x] `pageUrl` / `listTotalUrl` append `&tagMode=any` only when active
- [x] `TagsSection` renders the Match control, toggles mode, and drops dimming in `any` mode
- [x] Full suites green: api 307, web 195; `pnpm build` and `pnpm -r lint` pass

## Related Links

- Closes #159