### PR TITLE
feat(web): add keyboard Cursor navigation to the chat list

### DIFF
--- a/web/src/chat/ChatList.test.tsx
+++ b/web/src/chat/ChatList.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import type { Chat } from "@/types";
@@ -86,6 +92,31 @@ describe("ChatList virtualization", () => {
     const rows = await screen.findAllByTestId("chat-row");
     expect(rows.length).toBeGreaterThan(0);
     expect(rows.length).toBeLessThan(total);
+  });
+});
+
+describe("ChatList keyboard cursor", () => {
+  it("renders the focus-ring Cursor on the row ArrowDown lands on", async () => {
+    render(
+      <ChatList
+        chats={makeChats(5)}
+        selectedId={null}
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    await screen.findAllByTestId("chat-row");
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "ArrowDown" });
+    });
+
+    await waitFor(() => {
+      const cursorRow = document.querySelector('[data-cursor="true"]');
+      expect(cursorRow).not.toBeNull();
+      expect(cursorRow).toHaveTextContent("Chat 0");
+    });
   });
 });
 

--- a/web/src/chat/ChatList.tsx
+++ b/web/src/chat/ChatList.tsx
@@ -10,6 +10,7 @@ import { ArrowLeft, Pencil, RotateCcw, Trash2 } from "lucide-react";
 import type { Chat } from "@/types";
 import { EditableTitle } from "@/metadata/EditableTitle";
 import { TagChipList } from "@/tags/TagChipList";
+import { useCursorNavigation } from "@/chat/useCursorNavigation";
 
 interface ChatListProps {
   mode?: "main" | "trash";
@@ -177,6 +178,23 @@ export function ChatList({
     // measured offsets, anchoring scroll to the content under the viewport.
     getItemKey: (index) => chats[index]?.id ?? index,
   });
+
+  // The Cursor: ArrowUp/ArrowDown walk a focus-ring row through the list and,
+  // debounced, open it (opening = the Open Chat, i.e. onSelect). Distinct from
+  // the Open Chat and the Selection (see CONTEXT.md).
+  const { cursorId, cursorIndex } = useCursorNavigation({
+    chats,
+    openId: selectedId,
+    onOpen: onSelect,
+  });
+
+  // Keep the Cursor visible: scroll its row into the virtualized window as it
+  // moves. The Cursor may be far outside the rendered window, so scroll by
+  // index through the virtualizer rather than a DOM ref.
+  useEffect(() => {
+    if (cursorIndex < 0) return;
+    virtualizer.scrollToIndex(cursorIndex, { align: "auto" });
+  }, [cursorIndex, virtualizer]);
 
   // Keep the selected chat visible after a sort change; otherwise scroll to top.
   // The selected row may be far outside the rendered window, so scroll by index
@@ -365,9 +383,18 @@ export function ChatList({
             {virtualizer.getVirtualItems().map((virtualItem) => {
               const chat = chats[virtualItem.index];
               const isSelected = chat.id === selectedId;
+              const isCursor = chat.id === cursorId;
+              // The Cursor wears the same accent as the Open Chat, so moving it
+              // by keyboard looks exactly like clicking a row — and shows before
+              // the debounced open lands (no visual lag).
+              const isAccented = isSelected || isCursor;
               const isEditing = editingId === chat.id && !!onRenameTitle;
-              const rowClassName = `flex w-full flex-col gap-1 border-b border-border px-4 py-3 text-left transition-colors hover:bg-card ${
-                isSelected
+              // The row's accent is our left-border affordance, driven by state
+              // (Open Chat / Cursor). Suppress the browser's focus-visible
+              // outline so a mouse-clicked row doesn't strand a ring when
+              // keyboard navigation then moves the Cursor off it.
+              const rowClassName = `flex w-full flex-col gap-1 border-b border-border px-4 py-3 text-left transition-colors hover:bg-card focus-visible:outline-none ${
+                isAccented
                   ? "border-l-2 border-l-primary bg-card"
                   : "border-l-2 border-l-transparent"
               }`;
@@ -415,6 +442,7 @@ export function ChatList({
                   data-index={virtualItem.index}
                   ref={virtualizer.measureElement}
                   data-testid="chat-row"
+                  data-cursor={isCursor || undefined}
                   className="group absolute left-0 right-0 top-0"
                   style={{ transform: `translateY(${virtualItem.start}px)` }}
                   onContextMenu={(e) => handleContextMenu(e, chat.id)}

--- a/web/src/chat/useCursorNavigation.test.tsx
+++ b/web/src/chat/useCursorNavigation.test.tsx
@@ -1,0 +1,177 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import type { Chat } from "@/types";
+import { useCursorNavigation } from "@/chat/useCursorNavigation";
+
+function chat(id: string): Chat {
+  return {
+    id,
+    sourceId: id.toUpperCase(),
+    agent: "claude-code",
+    title: id,
+    project: "p",
+    projectPath: null,
+    sourceFilePath: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+const chats = [chat("a"), chat("b"), chat("c")];
+
+function pressArrow(key: "ArrowDown" | "ArrowUp") {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useCursorNavigation", () => {
+  it("moves the Cursor to the row after the Open Chat on ArrowDown", () => {
+    const { result } = renderHook(() =>
+      useCursorNavigation({ chats, openId: "a", onOpen: vi.fn() })
+    );
+
+    expect(result.current.cursorId).toBeNull();
+
+    pressArrow("ArrowDown");
+
+    expect(result.current.cursorId).toBe("b");
+    expect(result.current.cursorIndex).toBe(1);
+  });
+
+  it("moves the Cursor up one row on ArrowUp", () => {
+    const { result } = renderHook(() =>
+      useCursorNavigation({ chats, openId: "b", onOpen: vi.fn() })
+    );
+
+    pressArrow("ArrowDown"); // from Open Chat "b" (index 1) -> "c" (index 2)
+    expect(result.current.cursorId).toBe("c");
+
+    pressArrow("ArrowUp");
+    expect(result.current.cursorId).toBe("b");
+    expect(result.current.cursorIndex).toBe(1);
+  });
+
+  it("clamps the Cursor at the last row on ArrowDown", () => {
+    const { result } = renderHook(() =>
+      useCursorNavigation({ chats, openId: "c", onOpen: vi.fn() })
+    );
+
+    pressArrow("ArrowDown"); // already the Open Chat at the last row
+    pressArrow("ArrowDown");
+
+    expect(result.current.cursorId).toBe("c");
+    expect(result.current.cursorIndex).toBe(2);
+  });
+
+  it("clamps the Cursor at the first row on ArrowUp", () => {
+    const { result } = renderHook(() =>
+      useCursorNavigation({ chats, openId: "a", onOpen: vi.fn() })
+    );
+
+    pressArrow("ArrowUp"); // first move from Open Chat "a" at the head
+    pressArrow("ArrowUp");
+
+    expect(result.current.cursorId).toBe("a");
+    expect(result.current.cursorIndex).toBe(0);
+  });
+
+  it("opens the landed Chat once, debounced, after rapid arrow presses", () => {
+    vi.useFakeTimers();
+    const onOpen = vi.fn();
+    renderHook(() =>
+      useCursorNavigation({ chats, openId: "a", onOpen, debounceMs: 150 })
+    );
+
+    pressArrow("ArrowDown"); // -> "b"
+    pressArrow("ArrowDown"); // -> "c"
+
+    // Nothing opens mid-flight, before the debounce elapses.
+    act(() => vi.advanceTimersByTime(149));
+    expect(onOpen).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen).toHaveBeenCalledWith("c");
+  });
+
+  it("re-anchors the Cursor to the Open Chat when it changes by mouse click", () => {
+    const { result, rerender } = renderHook(
+      ({ openId }) => useCursorNavigation({ chats, openId, onOpen: vi.fn() }),
+      { initialProps: { openId: "a" as string } }
+    );
+
+    // A mouse click on row "c" flows through the parent as a new Open Chat.
+    rerender({ openId: "c" });
+    expect(result.current.cursorId).toBe("c");
+
+    // Keyboard now continues from the clicked row, not a stale position.
+    pressArrow("ArrowUp");
+    expect(result.current.cursorId).toBe("b");
+  });
+
+  it("does not re-open the Chat when the Cursor syncs to an external open change", () => {
+    vi.useFakeTimers();
+    const onOpen = vi.fn();
+    const { rerender } = renderHook(
+      ({ openId }) =>
+        useCursorNavigation({ chats, openId, onOpen, debounceMs: 150 }),
+      { initialProps: { openId: "a" as string } }
+    );
+
+    rerender({ openId: "c" }); // mouse click, not a keyboard move
+    act(() => vi.advanceTimersByTime(200));
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("ignores arrows while an editable element (a title input) holds focus", () => {
+    const onOpen = vi.fn();
+    const { result } = renderHook(() =>
+      useCursorNavigation({ chats, openId: "a", onOpen })
+    );
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })
+      );
+    });
+
+    expect(result.current.cursorId).toBeNull();
+    expect(onOpen).not.toHaveBeenCalled();
+
+    input.remove();
+  });
+
+  it("ignores arrows while focus sits inside an open popover", () => {
+    const onOpen = vi.fn();
+    const { result } = renderHook(() =>
+      useCursorNavigation({ chats, openId: "a", onOpen })
+    );
+
+    const popover = document.createElement("div");
+    popover.setAttribute("data-slot", "popover-content");
+    const swatch = document.createElement("button"); // a non-editable target
+    popover.appendChild(swatch);
+    document.body.appendChild(popover);
+
+    act(() => {
+      swatch.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })
+      );
+    });
+
+    expect(result.current.cursorId).toBeNull();
+    expect(onOpen).not.toHaveBeenCalled();
+
+    popover.remove();
+  });
+});

--- a/web/src/chat/useCursorNavigation.ts
+++ b/web/src/chat/useCursorNavigation.ts
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from "react";
+import type { Chat } from "@/types";
+
+interface UseCursorNavigationParams {
+  /** The ordered chats the Cursor walks through; drives index <-> id mapping. */
+  chats: Chat[];
+  /** The current Open Chat id; the Cursor starts from — and re-anchors to — it. */
+  openId: string | null;
+  /** Called (debounced) when a keyboard move lands the Cursor on a row. */
+  onOpen: (id: string) => void;
+  /** Debounce window before a landed Cursor opens its Chat. */
+  debounceMs?: number;
+}
+
+interface CursorNavigation {
+  /** The id of the row the Cursor rests on, or null before the first move. */
+  cursorId: string | null;
+  /** The index of the Cursor row, or -1 before the first move. */
+  cursorIndex: number;
+}
+
+/**
+ * The Cursor: the keyboard-focused row that ArrowUp/ArrowDown move through the
+ * chat list. Distinct from the Open Chat and the Selection (see CONTEXT.md). A
+ * plain arrow also opens the landed Chat, debounced so holding or rapidly
+ * pressing the arrows fetches once, not once per row.
+ *
+ * Keyboard and mouse stay in sync: when the Open Chat changes on its own — a
+ * mouse click on a row — the Cursor re-anchors to it, so the next arrow
+ * continues from where the mouse left off, not a stale position. That sync
+ * never re-opens the Chat (only a keyboard move does), so a click costs one
+ * fetch, not two.
+ */
+export function useCursorNavigation({
+  chats,
+  openId,
+  onOpen,
+  debounceMs = 150,
+}: UseCursorNavigationParams): CursorNavigation {
+  const [cursorIndex, setCursorIndex] = useState(-1);
+
+  // Re-anchor the Cursor to the Open Chat whenever it changes externally (a
+  // mouse click on a row). Adjusting state during render on a prop change is the
+  // sanctioned React pattern and beats an effect: no extra paint, no stale tick.
+  const [lastOpenId, setLastOpenId] = useState(openId);
+  if (openId !== lastOpenId) {
+    setLastOpenId(openId);
+    setCursorIndex(chats.findIndex((chat) => chat.id === openId));
+  }
+
+  // Mirror the latest cursorIndex and onOpen into refs so the keydown handler
+  // reads current values without re-subscribing the window listener each render.
+  const cursorIndexRef = useRef(cursorIndex);
+  useEffect(() => {
+    cursorIndexRef.current = cursorIndex;
+  }, [cursorIndex]);
+  const onOpenRef = useRef(onOpen);
+  useEffect(() => {
+    onOpenRef.current = onOpen;
+  }, [onOpen]);
+  const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+
+      // Typing in a title field owns its own arrows; never hijack them.
+      const target = e.target as HTMLElement | null;
+      const isEditable =
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable === true;
+      if (isEditable) return;
+      // Keystrokes inside an open popover (find-or-create, recolor, metadata…)
+      // belong to that popover, not the Cursor.
+      if (
+        target instanceof Element &&
+        target.closest('[data-slot="popover-content"]')
+      )
+        return;
+
+      e.preventDefault();
+      const delta = e.key === "ArrowDown" ? 1 : -1;
+      const current = cursorIndexRef.current;
+      const start =
+        current >= 0 ? current : chats.findIndex((chat) => chat.id === openId);
+      // Clamp within the list so the Cursor never runs off either end.
+      const next = Math.max(0, Math.min(start + delta, chats.length - 1));
+      // A move against the end is a no-op: don't churn state or re-open.
+      if (next === current) return;
+
+      cursorIndexRef.current = next;
+      setCursorIndex(next);
+
+      // Debounce the open so holding or rapidly pressing the arrows fetches
+      // once, for the row the Cursor finally rests on, not once per row.
+      const landedId = chats[next]?.id;
+      if (!landedId) return;
+      if (openTimerRef.current) clearTimeout(openTimerRef.current);
+      openTimerRef.current = setTimeout(() => {
+        onOpenRef.current(landedId);
+      }, debounceMs);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [chats, openId, debounceMs]);
+
+  useEffect(
+    () => () => {
+      if (openTimerRef.current) clearTimeout(openTimerRef.current);
+    },
+    []
+  );
+
+  const cursorId = cursorIndex >= 0 ? (chats[cursorIndex]?.id ?? null) : null;
+  return { cursorId, cursorIndex };
+}


### PR DESCRIPTION
## Background (Why)

The chat list had no keyboard navigation. Reaching a Chat meant finding and clicking its row. This adds the **Cursor** — the keyboard-focused row — so `↑` / `↓` walk through the list and open Chats without the mouse, while staying consistent with the existing click-to-open behavior.

## Approach (How)

The Cursor lives in a new deep module, `useCursorNavigation`, with a small surface (`chats`, `openId`, `onOpen`) that hides all the navigation, debounce, and guard logic. `ChatList` consumes it: it reads `cursorId` to paint the
accent, scrolls the Cursor into view through the existing virtualizer, and wires `onOpen` to the same `onSelect` a click uses.

Key decisions:

- **Debounced open (~150ms):** moving the Cursor opens the landed Chat on a timer, so holding or rapidly pressing the arrows fetches once — for the row the Cursor finally rests on — not once per row.
- **Keyboard/mouse sync:** clicking a row re-anchors the Cursor to it (state adjusted during render on the `openId` prop change, the sanctioned React pattern), so the next arrow continues from the click. That sync never re-opens the Chat — only a keyboard move does — so a click costs one fetch, not two.
- **Same look as a click:** the Cursor wears the Open Chat's left-border accent(not a separate ring) and suppresses the browser's `focus-visible` outline, so keyboard navigation looks exactly like clicking and never strands an outline on a stale, previously-clicked row.
- **Guards:** arrow handling is suppressed while an editable element (a title input) or an open popover holds focus, mirroring the app's existing global keyboard guards.

## Changes (What)

- [x] Add `web/src/chat/useCursorNavigation.ts` — the Cursor hook (navigation, clamp, debounced open, editable/popover guards, keyboard↔mouse sync)
- [x] Integrate into `ChatList`: render the Cursor accent via `data-cursor` + the left border, scroll it into view, suppress the focus-visible outline
- [x] Add `web/src/chat/useCursorNavigation.test.tsx` and extend `ChatList.test.tsx`

### Test Verification

- [x] `↓` from the Open Chat moves the Cursor to the next row; `↑` moves up one
- [x] The Cursor clamps at the first and last rows
- [x] Rapid arrow presses open the landed Chat once, after ~150ms (fake timers)
- [x] Arrows are ignored while an editable element (title input) holds focus
- [x] Arrows are ignored while focus sits inside an open popover
- [x] A mouse click re-anchors the Cursor; the next arrow continues from it
- [x] The click→sync does not re-open the Chat (no redundant fetch)
- [x] `ChatList` renders the Cursor accent on the landed row
- [x] Full suite green (web 196, api 304), typecheck + lint clean

## Additional Notes

The `Shift`+arrow range-selection behavior the glossary describes for the Cursor is out of scope here (follow-up #161); this hook leaves a clean seam for it.

## Related Links

- Closes #160