### PR TITLE
feat(web): platform-aware keyboard hint symbols (⌘ vs Ctrl)

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -711,8 +711,9 @@ describe("Undo toast on delete", () => {
 
     const toast = await screen.findByTestId("toast");
     expect(within(toast).getByText(/chat deleted/i)).toBeInTheDocument();
-    // The Undo action shows its keyboard shortcut hint.
-    expect(within(toast).getByText("⌘Z")).toBeInTheDocument();
+    // The Undo action shows its platform-aware keyboard shortcut hint (#179).
+    // jsdom reports no macOS platform, so the hint resolves to the Ctrl branch.
+    expect(within(toast).getByText("Ctrl+Z")).toBeInTheDocument();
 
     await user.click(within(toast).getByRole("button", { name: /undo/i }));
 
@@ -759,9 +760,10 @@ describe("Batch Move to Trash", () => {
       ).not.toBeInTheDocument();
     });
 
-    // Undo restores both; the toast shows the ⌘Z hint.
+    // Undo restores both; the toast shows the platform-aware hint (#179).
+    // jsdom reports no macOS platform, so the hint resolves to the Ctrl branch.
     const toast = await screen.findByTestId("toast");
-    expect(within(toast).getByText("⌘Z")).toBeInTheDocument();
+    expect(within(toast).getByText("Ctrl+Z")).toBeInTheDocument();
     await user.click(within(toast).getByRole("button", { name: /undo/i }));
     await waitFor(() => {
       expect(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { useTags } from "@/tags/useTags";
 import { useTagMode } from "@/tags/useTagMode";
 import { useMessages } from "@/conversation/useMessages";
 import { useToast } from "@/shared/useToast";
+import { modifierHint } from "@/shared/platform";
 import { useChatOrder } from "@/chat/sort/useChatOrder";
 import { useSortPreference } from "@/chat/sort/useSortPreference";
 import { CHAT_SORT_CONFIG, TRASH_SORT_CONFIG } from "@/chat/sort/sortConfig";
@@ -340,7 +341,7 @@ function App() {
     showToast({
       message: "Chat deleted.",
       actionLabel: "Undo",
-      actionHint: "⌘Z",
+      actionHint: modifierHint("Z"),
       onAction: () => {
         void restore(id);
         void counts.reload();
@@ -373,7 +374,7 @@ function App() {
     showToast({
       message: `${n} chat${n > 1 ? "s" : ""} moved to Trash.`,
       actionLabel: "Undo",
-      actionHint: "⌘Z",
+      actionHint: modifierHint("Z"),
       onAction: () => {
         void restoreBatch(chatIds);
         refreshCounts();

--- a/web/src/shared/platform.test.ts
+++ b/web/src/shared/platform.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { isMacPlatform, modifierHint } from "./platform";
+
+describe("modifierHint", () => {
+  it("joins the ⌘ glyph directly to the key on macOS", () => {
+    expect(modifierHint("Z", true)).toBe("⌘Z");
+  });
+
+  it("joins Ctrl to the key with a + on non-macOS", () => {
+    expect(modifierHint("Z", false)).toBe("Ctrl+Z");
+  });
+});
+
+describe("isMacPlatform", () => {
+  it("detects a macOS navigator", () => {
+    const nav = { platform: "MacIntel" } as Navigator;
+    expect(isMacPlatform(nav)).toBe(true);
+  });
+
+  it("returns false for a non-mac navigator", () => {
+    const nav = { platform: "Win32" } as Navigator;
+    expect(isMacPlatform(nav)).toBe(false);
+  });
+
+  it("defaults to false (Ctrl) when the platform is unknown", () => {
+    const nav = { platform: "" } as Navigator;
+    expect(isMacPlatform(nav)).toBe(false);
+  });
+
+  it("resolves the current platform when no navigator is passed", () => {
+    // jsdom reports an empty platform, so the no-arg call should not throw and
+    // falls back to the Ctrl branch.
+    expect(modifierHint("Z")).toBe("Ctrl+Z");
+  });
+});

--- a/web/src/shared/platform.ts
+++ b/web/src/shared/platform.ts
@@ -1,0 +1,36 @@
+// Platform-aware keyboard hint symbols (#179).
+//
+// Most hint glyphs are universal and render the same on every platform (`⌫`
+// Backspace, `↵` Enter, `F2`) — those stay hardcoded at their call sites. Only
+// the *primary modifier* differs: macOS shows `⌘`, everywhere else `Ctrl`.
+//
+// This module is the single place that difference lives. Every Cmd/Ctrl hint
+// should route through `modifierHint` so a Windows/Linux user never sees a bare
+// `⌘` (e.g. the Undo toast, and future select-all `Cmd/Ctrl+A` in #164/#166).
+
+/**
+ * True on macOS, false everywhere else. Detected from the browser's reported
+ * platform; falls back to `false` (the Ctrl branch) when the platform is
+ * unknown or `navigator` is unavailable. Pass an explicit `nav` in tests to
+ * exercise either branch.
+ */
+export function isMacPlatform(
+  nav: Navigator | undefined = typeof navigator === "undefined"
+    ? undefined
+    : navigator
+): boolean {
+  return /mac/i.test(nav?.platform ?? "");
+}
+
+/**
+ * The full keyboard hint for a primary-modifier shortcut: `⌘Z` on macOS,
+ * `Ctrl+Z` elsewhere. This is the single entry point for Cmd/Ctrl hints — new
+ * shortcuts (e.g. select-all in #164/#166) should call this rather than
+ * hardcoding a `⌘`. `isMac` defaults to the detected platform; pass it in tests.
+ */
+export function modifierHint(
+  key: string,
+  isMac: boolean = isMacPlatform()
+): string {
+  return isMac ? `⌘${key}` : `Ctrl+${key}`;
+}


### PR DESCRIPTION
## Background (Why)

Modifier-key hints are hardcoded today. Most glyphs (`⌫` Backspace, `↵` Enter, `F2`) are universal and render the same everywhere, but the primary modifier is not: the Undo toast introduced in #161 shows a literal `⌘Z`, which is wrong on Windows/Linux where the shortcut is `Ctrl+Z`.

## Approach (How)

Introduce one shared helper that resolves the primary modifier symbol from the platform, detected once from the browser, and route every Cmd/Ctrl hint through it. Detection is split from rendering so the logic is testable on any host: `isMacPlatform` takes an injectable `Navigator`, so both branches are exercised from a single `vitest run` on macOS. It defaults to the `Ctrl` branch when the platform is unknown or `navigator` is unavailable.

## Changes (What)

- [x] Add `web/src/shared/platform.ts` — `isMacPlatform(nav?)` (injectable, sensible default) and `modifierHint(key, isMac?)` resolving `⌘Z` on macOS / `Ctrl+Z` elsewhere
- [x] Document `modifierHint` as the single entry point future Cmd/Ctrl hints must use (e.g. select-all `Cmd/Ctrl+A` in #164/#166) rather than hardcoding `⌘`
- [x] Route both Undo toasts in `App.tsx` (single + batch trash) through the helper
- [x] Leave universal glyphs (`⌫`, `↵`, `F2`) unchanged

### Test Verification

- [x] `modifierHint("Z", true)` → `⌘Z` (macOS)
- [x] `modifierHint("Z", false)` → `Ctrl+Z` (non-macOS, `+` separator)
- [x] `isMacPlatform` detects a macOS navigator (`MacIntel`) and rejects a non-mac one (`Win32`)
- [x] `isMacPlatform` defaults to `false` (Ctrl) when the platform is unknown / empty
- [x] `modifierHint("Z")` resolves the current platform with no navigator passed (jsdom → `Ctrl+Z`)
- [x] Updated the two `App.test.tsx` Undo-toast assertions to the new `Ctrl+Z` behavior; full suite green (web 221, api 310)

## Additional Notes

Detection reads `navigator.platform`. The default was chosen to be `Ctrl`, the safer cross-platform assumption when detection can't tell.

## Related Links

- Closes #179
- Prepares for select-all hints in #164 / #166