### PR TITLE
feat(web): reconcile removals on user-initiated reload

### DIFF
--- a/web/src/chat/usePaginatedChats.test.tsx
+++ b/web/src/chat/usePaginatedChats.test.tsx
@@ -296,6 +296,86 @@ describe("usePaginatedChats", () => {
     // Refresh is a no-op on failure; the window stays intact, nothing throws.
     expect(result.current.chats.map((c) => c.id)).toEqual(before);
   });
+
+  it("drops a row that left the active filter on a user-initiated reload (#176)", async () => {
+    // Active by updatedAt desc, filtered to my-web-app: chat-1, chat-3.
+    const { result } = renderHook(() =>
+      usePaginatedChats("updatedAt", "desc", {
+        pageSize: 10,
+        projects: ["my-web-app"],
+      })
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.chats.map((c) => c.id)).toEqual(["chat-1", "chat-3"]);
+
+    // A mutation moves chat-3 out of the active filter (its project changes), so a
+    // same-window, same-filter refetch no longer returns it.
+    fakeChats.find((c) => c.id === "chat-3")!.project = "backend-api";
+
+    await act(async () => {
+      await result.current.reload();
+    });
+
+    // The reconciling reload drops the departed row; membership is
+    // server-authoritative — the client never re-derives the filter (#176).
+    expect(result.current.chats.map((c) => c.id)).toEqual(["chat-1"]);
+  });
+
+  it("keeps a row that left the active filter on a background refresh (#176)", async () => {
+    // Same setup as the reload case, but the background pass must stay grow-only:
+    // a Chat under the viewport is never dropped by a bounded background refetch.
+    const { result } = renderHook(() =>
+      usePaginatedChats("updatedAt", "desc", {
+        pageSize: 10,
+        projects: ["my-web-app"],
+      })
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.chats.map((c) => c.id)).toEqual(["chat-1", "chat-3"]);
+
+    // chat-3 leaves the active filter, so the refetch no longer returns it.
+    fakeChats.find((c) => c.id === "chat-3")!.project = "backend-api";
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    // Grow-only: the departed row is retained, not dropped.
+    expect(result.current.chats.map((c) => c.id)).toEqual(["chat-1", "chat-3"]);
+  });
+
+  it("keeps the still-present rows in place when a reload drops one (#176)", async () => {
+    // Active by updatedAt desc: chat-2, chat-1, chat-3, chat-missing.
+    const { result } = renderHook(() =>
+      usePaginatedChats("updatedAt", "desc", { pageSize: 10 })
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.chats.map((c) => c.id)).toEqual([
+      "chat-2",
+      "chat-1",
+      "chat-3",
+      "chat-missing",
+    ]);
+
+    // A middle row leaves the active list (soft-deleted), while a surviving row
+    // also gets a field update to prove the refetch is merged, not ignored.
+    fakeChats.find((c) => c.id === "chat-1")!.isDeleted = true;
+    fakeChats.find((c) => c.id === "chat-3")!.defaultTitle = "Renamed utils";
+
+    await act(async () => {
+      await result.current.reload();
+    });
+
+    // The departed row is gone; every still-present row keeps its relative place,
+    // and the surviving row carries its refreshed field.
+    expect(result.current.chats.map((c) => c.id)).toEqual([
+      "chat-2",
+      "chat-3",
+      "chat-missing",
+    ]);
+    const byId = new Map(result.current.chats.map((c) => [c.id, c]));
+    expect(byId.get("chat-3")!.title).toBe("Renamed utils");
+  });
 });
 
 // Bounded loaded window / page eviction (#132). The loaded window is capped at

--- a/web/src/chat/usePaginatedChats.ts
+++ b/web/src/chat/usePaginatedChats.ts
@@ -309,39 +309,64 @@ export function usePaginatedChats(
     });
   }, [sort, direction, pageSize, filter, trashedOnly, maxWindowPages]);
 
-  // Re-read the head of the loaded window and reconcile it in place (live-update
-  // path, #132). Only acts when the head page is still loaded: new Chats appear
-  // at the list head (newest-first), so a window scrolled far past the head has
-  // nothing at the top to reconcile, and re-reading the head there would fight
-  // eviction. Sized to the loaded window but clamped to the page-limit cap so a
-  // large window never asks for more than the endpoint allows (#147).
-  const refresh = useCallback(async () => {
-    const current = pagesRef.current;
-    if (current.length === 0 || current[0].fromCursor !== null) return;
-    const windowLen = current.reduce((n, p) => n + p.chats.length, 0);
-    const limit = Math.min(Math.max(windowLen, pageSize), MAX_PAGE_LIMIT);
-    const data = await fetchPage(
-      pageUrl(sort, direction, limit, filter, trashedOnly)
-    );
-    if (!data) return;
-    setPages((prev) => {
-      if (prev.length === 0) return prev;
-      const incomingById = new Map(data.chats.map((c) => [c.id, c]));
-      const loadedIds = new Set(prev.flatMap((p) => p.chats).map((c) => c.id));
-      // Refresh fields in place for chats the server still returns; keep loaded
-      // rows the refetch no longer covers (the window only grows here).
-      const updated = prev.map((p) => ({
-        ...p,
-        chats: p.chats.map((c) => incomingById.get(c.id) ?? c),
-      }));
-      // Brand-new chats now ranking into the window slot onto the head page, in
-      // server order; the frozen-sort layer places them among the held rows.
-      const added = data.chats.filter((c) => !loadedIds.has(c.id));
-      if (added.length === 0) return updated;
-      const [head, ...rest] = updated;
-      return [{ ...head, chats: [...added, ...head.chats] }, ...rest];
-    });
-  }, [sort, direction, pageSize, filter, trashedOnly]);
+  // Re-read the head of the loaded window and reconcile it against a fresh
+  // same-window, same-filter refetch (#132). Only acts when the head page is
+  // still loaded: new Chats appear at the list head (newest-first), so a window
+  // scrolled far past the head has nothing at the top to reconcile, and
+  // re-reading the head there would fight eviction. Sized to the loaded window
+  // but clamped to the page-limit cap so a large window never asks for more than
+  // the endpoint allows (#147).
+  //
+  // `drop` splits the two reconcile intents (#176). Background passes call with
+  // `drop=false` (grow-only): a Chat you are looking at must not vanish because a
+  // bounded background page happened not to include it. A user-initiated reload
+  // calls with `drop=true`: rows the refetch no longer returns leave the window,
+  // so a mutation that moves a Chat out of the active filter is reflected.
+  // Membership stays server-authoritative either way — the client never
+  // re-derives the filter (ADR-0016); it just trusts the refetch. Page
+  // boundaries and their cursors are preserved, so scroll anchoring and the
+  // bounded window survive a reconciling reload.
+  const reconcileHead = useCallback(
+    async (drop: boolean) => {
+      const current = pagesRef.current;
+      if (current.length === 0 || current[0].fromCursor !== null) return;
+      const windowLen = current.reduce((n, p) => n + p.chats.length, 0);
+      const limit = Math.min(Math.max(windowLen, pageSize), MAX_PAGE_LIMIT);
+      const data = await fetchPage(
+        pageUrl(sort, direction, limit, filter, trashedOnly)
+      );
+      if (!data) return;
+      setPages((prev) => {
+        if (prev.length === 0) return prev;
+        const incomingById = new Map(data.chats.map((c) => [c.id, c]));
+        const loadedIds = new Set(
+          prev.flatMap((p) => p.chats).map((c) => c.id)
+        );
+        // Refresh fields in place for chats the server still returns. Grow-only
+        // keeps a loaded row the refetch no longer covers; a reconciling reload
+        // drops it, leaving the page shorter but its cursors intact.
+        const updated = prev.map((p) => ({
+          ...p,
+          chats: drop
+            ? p.chats
+                .filter((c) => incomingById.has(c.id))
+                .map((c) => incomingById.get(c.id) as Chat)
+            : p.chats.map((c) => incomingById.get(c.id) ?? c),
+        }));
+        // Brand-new chats now ranking into the window slot onto the head page, in
+        // server order; the frozen-sort layer places them among the held rows.
+        const added = data.chats.filter((c) => !loadedIds.has(c.id));
+        if (added.length === 0) return updated;
+        const [head, ...rest] = updated;
+        return [{ ...head, chats: [...added, ...head.chats] }, ...rest];
+      });
+    },
+    [sort, direction, pageSize, filter, trashedOnly]
+  );
+
+  // Background reconcile: grow-only, so ingestion surfaces without ever dropping
+  // a row under the viewport. Exposed so the interval and tests drive it.
+  const refresh = useCallback(() => reconcileHead(false), [reconcileHead]);
 
   // Primary trigger: reconcile the window head on each server-pushed change, so
   // ingestion shows up the instant it settles instead of on a fixed poll
@@ -363,11 +388,12 @@ export function usePaginatedChats(
     return () => clearInterval(id);
   }, [enabled, refresh]);
 
-  // A user-initiated reload: reconcile the window, then re-anchor the order.
+  // A user-initiated reload: reconcile the window with drop (rows the refetch no
+  // longer returns leave the list), then re-anchor the order (#176).
   const reload = useCallback(async () => {
-    await refresh();
+    await reconcileHead(true);
     bumpEpoch();
-  }, [refresh, bumpEpoch]);
+  }, [reconcileHead, bumpEpoch]);
 
   // Bridge the mutations' flat-list optimistic updates onto the page model.
   // Mutations only update fields or drop a row by id, so re-distributing the


### PR DESCRIPTION
## Background (Why)

The paginated read hook had one reconcile path (`refresh`): it updated fields in place for chats the server still returned and **kept** any loaded row the refetch no longer covered — the window only grew. That is correct for background ingestion (a Chat you are looking at must not vanish because a bounded background page happened not to include it), but wrong for a reload that follows a user mutation: after a batch Tag remove under a Tag filter — or any change that moves a Chat out of the active filter — the departed Chats should leave the list, and a grow-only reload keeps them.

## Approach (How)

Split the two reconcile intents behind one helper. `reconcileHead(drop)` does the same-window, same-filter refetch (head-page guard, window-sized-and-clamped limit, page/cursor structure preserved), then either keeps or drops the rows the refetch no longer returns:

- `drop=false` — grow-only. `refresh()` (server push + safety-floor interval) stays exactly as before.
- `drop=true` — reconciling. `reload()` (user-initiated) drops departed rows, leaving each page shorter but its cursors intact, then re-anchors the order.

Membership stays **server-authoritative** — the client never re-derives `buildFilterClauses` (ADR-0016); it trusts the refetch. Because page boundaries and their cursors are preserved, scroll anchoring and the bounded window survive a reconciling reload.

This is the enabling seam so batch Tag add/remove (#163) and future filter-scoped batches lean on the server for membership instead of hand-rolling filter logic on the client.

## Changes (What)

- [x] Factor `refresh`'s in-place reconcile into `reconcileHead(drop: boolean)` in `usePaginatedChats`
- [x] `refresh()` delegates with `drop=false` (grow-only, unchanged background behavior)
- [x] `reload()` delegates with `drop=true` (drops rows the refetch no longer returns), then bumps the sort epoch
- [x] No client-side filter/membership re-derivation — removal is driven purely by the server refetch

### Test Verification

- [x] A user-initiated `reload()` drops a row that left the active filter (project filter)
- [x] A background `refresh()` keeps that same departed row (grow-only)
- [x] Still-present rows keep their relative place across a reconciling reload, and a surviving row carries its refreshed field
- [x] Existing coverage stays green: grow-only merge of new/updated rows, stream reconcile, failed-refresh no-op, bounded-window eviction/scroll-back
- [x] Full suite: 534 passed (web 224, api 310), typecheck clean

## Additional Notes

Scope is the enabling seam only. Batch Move to Trash (#161) could later drop its optimistic removal and lean on this reconciling reload, but that cleanup is out of scope here.

## Related Links

- Closes #176