### PR TITLE
feat(web): shared centered-modal TagPickerDialog

### DIFF
--- a/web/src/shared/ui/dialog.tsx
+++ b/web/src/shared/ui/dialog.tsx
@@ -1,0 +1,66 @@
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+
+import { cn } from "@/shared/utils";
+
+// A viewport-centered modal built on Base UI's Dialog. This wrapper owns the
+// modal "chrome" — the dimming scrim, centered positioning, entrance/exit
+// animation, z-index, and Esc / outside-click dismissal — so each consumer only
+// supplies its own body. Mirrors the shape of popover.tsx.
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: DialogPrimitive.Popup.Props) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Backdrop
+        data-slot="dialog-backdrop"
+        className="fixed inset-0 z-50 bg-black/50 duration-150 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0"
+      />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 flex w-[min(100vw-2rem,28rem)] -translate-x-1/2 -translate-y-1/2 flex-col gap-3 rounded-xl bg-popover p-4 text-sm text-popover-foreground shadow-xl ring-1 ring-foreground/10 outline-hidden duration-150 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Popup>
+    </DialogPrimitive.Portal>
+  );
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger };

--- a/web/src/tags/TagPickerDialog.test.tsx
+++ b/web/src/tags/TagPickerDialog.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import type { Tag } from "@/types";
+import { TagPickerDialog } from "@/tags/TagPickerDialog";
+
+const TAGS: Tag[] = [
+  { id: "t1", name: "bug", color: "red" },
+  { id: "t2", name: "design", color: "blue" },
+];
+
+function renderPicker(
+  overrides: Partial<React.ComponentProps<typeof TagPickerDialog>> = {}
+) {
+  const props = {
+    title: "Add tags",
+    tags: TAGS,
+    stateFor: () => "none" as const,
+    onToggle: vi.fn(),
+    onCreate: vi.fn(async () => null),
+    ...overrides,
+  };
+  render(<TagPickerDialog {...props} />);
+  return props;
+}
+
+describe("TagPickerDialog", () => {
+  it("opens a centered dialog listing each tag as a row with its name", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+
+    await user.click(screen.getByTestId("add-tag-button"));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent("Add tags");
+    expect(within(dialog).getByText("bug")).toBeInTheDocument();
+    expect(within(dialog).getByText("design")).toBeInTheDocument();
+  });
+
+  it("renders a dimming scrim overlay and closes on outside click", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+
+    await user.click(screen.getByTestId("add-tag-button"));
+    await screen.findByRole("dialog");
+
+    // A scrim dims the page behind the modal and catches outside clicks.
+    const backdrop = document.querySelector('[data-slot="dialog-backdrop"]');
+    expect(backdrop).not.toBeNull();
+    expect(backdrop).toHaveClass("bg-black/50");
+
+    await user.click(backdrop as Element);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes on Escape", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+
+    await user.click(screen.getByTestId("add-tag-button"));
+    await screen.findByRole("dialog");
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("reflects stateFor on each row's tri-state checkbox", async () => {
+    const user = userEvent.setup();
+    renderPicker({
+      stateFor: (id) => (id === "t1" ? "all" : id === "t2" ? "some" : "none"),
+      tags: [
+        { id: "t1", name: "bug", color: "red" },
+        { id: "t2", name: "design", color: "blue" },
+        { id: "t3", name: "wip", color: "green" },
+      ],
+    });
+
+    await user.click(screen.getByTestId("add-tag-button"));
+    const dialog = await screen.findByRole("dialog");
+
+    const rowFor = (name: string) =>
+      within(dialog).getByText(name).closest("[data-tag-id]") as HTMLElement;
+    const checkbox = (name: string) =>
+      within(rowFor(name)).getByRole("checkbox");
+
+    expect(checkbox("bug")).toBeChecked();
+    expect(checkbox("wip")).not.toBeChecked();
+    expect(checkbox("design")).toHaveAttribute("aria-checked", "mixed");
+  });
+
+  it("calls onToggle with the tag id when a row is clicked", async () => {
+    const user = userEvent.setup();
+    const { onToggle } = renderPicker();
+
+    await user.click(screen.getByTestId("add-tag-button"));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByText("bug"));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith("t1");
+  });
+
+  it("finds by filtering and creates a new tag with the name-derived color", async () => {
+    const user = userEvent.setup();
+    const { onCreate } = renderPicker();
+
+    await user.click(screen.getByTestId("add-tag-button"));
+
+    // Typing an existing name filters the list and offers no create.
+    await user.type(screen.getByLabelText("Find or create a tag"), "bug");
+    expect(screen.getByText("bug")).toBeInTheDocument();
+    expect(screen.queryByText("design")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("create-tag-button")).not.toBeInTheDocument();
+
+    // Typing a brand-new name offers create; clicking it calls onCreate.
+    await user.clear(screen.getByLabelText("Find or create a tag"));
+    await user.type(screen.getByLabelText("Find or create a tag"), "urgent");
+    await user.click(screen.getByTestId("create-tag-button"));
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate).toHaveBeenCalledWith("urgent", expect.any(String));
+  });
+
+  it("creates with an overridden color via Enter after clicking a swatch", async () => {
+    const user = userEvent.setup();
+    const { onCreate } = renderPicker();
+
+    await user.click(screen.getByTestId("add-tag-button"));
+    await user.type(screen.getByLabelText("Find or create a tag"), "urgent");
+
+    // Override the auto-picked color, which moves focus onto the swatch button.
+    await user.click(screen.getByLabelText("Color blue"));
+    // Enter must still create the tag from the input.
+    await user.keyboard("{Enter}");
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate).toHaveBeenCalledWith("urgent", "blue");
+  });
+
+  it("does not render a Done button in single mode", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+
+    await user.click(screen.getByTestId("add-tag-button"));
+    await screen.findByRole("dialog");
+
+    expect(
+      screen.queryByRole("button", { name: /done/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/tags/TagPickerDialog.tsx
+++ b/web/src/tags/TagPickerDialog.tsx
@@ -1,8 +1,13 @@
 import { useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
-import { Check, Plus, Search } from "lucide-react";
+import { Check, Minus, Plus, Search } from "lucide-react";
 import type { Tag } from "@/types";
-import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/shared/ui/dialog";
 import {
   TAG_COLOR_HEX,
   defaultColorFor,
@@ -11,17 +16,18 @@ import {
 import { ColorSwatches } from "@/tags/ColorSwatches";
 import { sortTagsByName } from "@/tags/sortTags";
 
-interface AddTagPopoverProps {
-  // Tags currently assigned to this chat.
-  assigned: Tag[];
-  // The full Tag catalog to filter over.
-  allTags: Tag[];
-  onAssign: (tagId: string) => void;
-  onRemove: (tagId: string) => void;
-  // Create a Tag, then assign it to this chat. Returns the created Tag (or null
-  // on failure).
+export type TagState = "all" | "some" | "none";
+
+interface TagPickerDialogProps {
+  title: string;
+  tags: Tag[];
+  // Assignment state of a tag across the target(s). A single chat only ever
+  // returns "all" or "none"; batch mode also returns "some" (indeterminate).
+  stateFor: (tagId: string) => TagState;
+  // Caller maps a toggle to add/remove (single) or stage (batch).
+  onToggle: (tagId: string) => void;
   onCreate: (name: string, color: ColorToken) => Promise<Tag | null>;
-  // Trigger overrides — lets the same popover hang off both the "+ Tag" button
+  // Trigger overrides — lets the same dialog hang off both the "+ Tag" button
   // and the "+N" overflow pill.
   triggerTestId?: string;
   triggerAriaLabel?: string;
@@ -32,38 +38,33 @@ interface AddTagPopoverProps {
 const DEFAULT_TRIGGER_CLASS =
   "flex h-7 shrink-0 items-center gap-1 rounded-full border border-dashed border-border px-2 text-xs text-muted-foreground transition-colors hover:border-foreground/40 hover:text-foreground focus-visible:outline-2 focus-visible:outline-ring";
 
-export function AddTagPopover({
-  assigned,
-  allTags,
-  onAssign,
-  onRemove,
-  onCreate,
+export function TagPickerDialog({
+  title,
+  tags,
   triggerTestId = "add-tag-button",
   triggerAriaLabel = "Add tag",
   triggerClassName = DEFAULT_TRIGGER_CLASS,
   triggerContent,
-}: AddTagPopoverProps) {
+  stateFor,
+  onToggle,
+  onCreate,
+}: TagPickerDialogProps) {
   const [query, setQuery] = useState("");
   // null means "follow the name-derived default"; a value means the user picked.
   const [override, setOverride] = useState<ColorToken | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  const assignedIds = useMemo(
-    () => new Set(assigned.map((t) => t.id)),
-    [assigned]
-  );
 
   const trimmed = query.trim();
   const filtered = useMemo(() => {
     const q = trimmed.toLowerCase();
     const matched =
       q.length === 0
-        ? allTags
-        : allTags.filter((t) => t.name.toLowerCase().includes(q));
+        ? tags
+        : tags.filter((t) => t.name.toLowerCase().includes(q));
     return sortTagsByName(matched);
-  }, [allTags, trimmed]);
+  }, [tags, trimmed]);
 
-  const exactMatch = allTags.some(
+  const exactMatch = tags.some(
     (t) => t.name.toLowerCase() === trimmed.toLowerCase()
   );
   const canCreate = trimmed.length > 0 && !exactMatch;
@@ -81,8 +82,8 @@ export function AddTagPopover({
   };
 
   return (
-    <Popover onOpenChange={(open) => !open && reset()}>
-      <PopoverTrigger
+    <Dialog onOpenChange={(open) => !open && reset()}>
+      <DialogTrigger
         data-testid={triggerTestId}
         aria-label={triggerAriaLabel}
         className={triggerClassName}
@@ -93,18 +94,18 @@ export function AddTagPopover({
             Tag
           </>
         )}
-      </PopoverTrigger>
-      <PopoverContent
-        data-testid="add-tag-popover"
-        align="end"
-        sideOffset={6}
-        className="w-64 gap-2 p-2"
+      </DialogTrigger>
+      <DialogContent
+        data-testid="tag-picker-dialog"
+        className="w-[min(100vw-2rem,34rem)]"
       >
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+
         <div className="relative">
           <Search
-            size={14}
+            size={16}
             aria-hidden="true"
-            className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+            className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground"
           />
           <input
             ref={inputRef}
@@ -122,56 +123,47 @@ export function AddTagPopover({
             }}
             placeholder="Find or create a tag…"
             aria-label="Find or create a tag"
-            className="w-full rounded-md border border-border bg-transparent py-1.5 pr-2 pl-7 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-primary"
+            className="w-full rounded-lg border border-border bg-transparent py-2.5 pr-3 pl-10 text-[15px] text-foreground outline-none placeholder:text-muted-foreground focus:border-primary"
           />
         </div>
 
-        <ul className="flex max-h-56 flex-col gap-0.5 overflow-y-auto">
+        <ul className="flex max-h-[22rem] flex-col gap-0.5 overflow-y-auto">
           {filtered.map((tag) => {
-            const isAssigned = assignedIds.has(tag.id);
+            const state = stateFor(tag.id);
             return (
               <li key={tag.id}>
                 <button
                   type="button"
                   data-testid="add-tag-option"
                   data-tag-id={tag.id}
-                  aria-pressed={isAssigned}
-                  onClick={() =>
-                    isAssigned ? onRemove(tag.id) : onAssign(tag.id)
-                  }
-                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-white/6"
+                  onClick={() => onToggle(tag.id)}
+                  className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[15px] transition-colors hover:bg-white/6"
                 >
+                  <TriStateCheckbox state={state} />
                   <span
                     aria-hidden="true"
                     className="h-2.5 w-2.5 shrink-0 rounded-full"
                     style={{ backgroundColor: TAG_COLOR_HEX[tag.color] }}
                   />
                   <span className="min-w-0 flex-1 truncate">{tag.name}</span>
-                  {isAssigned && (
-                    <Check
-                      size={14}
-                      aria-hidden="true"
-                      className="shrink-0 text-primary"
-                    />
-                  )}
                 </button>
               </li>
             );
           })}
           {filtered.length === 0 && !canCreate && (
-            <li className="px-2 py-1.5 text-xs text-muted-foreground">
+            <li className="px-2.5 py-2 text-sm text-muted-foreground">
               No tags yet.
             </li>
           )}
         </ul>
 
         {canCreate && (
-          <div className="flex flex-col gap-2 border-t border-border pt-2">
+          <div className="flex flex-col gap-2 border-t border-border pt-3">
             <button
               type="button"
               data-testid="create-tag-button"
               onClick={() => void handleCreate()}
-              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-white/6"
+              className="flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[15px] transition-colors hover:bg-white/6"
             >
               <span
                 aria-hidden="true"
@@ -187,14 +179,38 @@ export function AddTagPopover({
               onChange={(color) => {
                 setOverride(color);
                 // Picking a swatch moves focus to its button. Return focus to
-                // the input so Enter still creates the tag (instead of the
-                // keystroke escaping to the global shortcut handler).
+                // the input so Enter still creates the tag.
                 inputRef.current?.focus();
               }}
             />
           </div>
         )}
-      </PopoverContent>
-    </Popover>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// Leading checkbox for a tag row. "all" → checked, "none" → empty, "some" →
+// indeterminate (only ever reached in batch mode). Presentational: the row
+// button owns the click, so this is aria-hidden with the state exposed via the
+// role="checkbox" wrapper.
+function TriStateCheckbox({ state }: { state: TagState }) {
+  return (
+    <span
+      role="checkbox"
+      aria-checked={state === "all" ? true : state === "some" ? "mixed" : false}
+      className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border ${
+        state === "none"
+          ? "border-muted-foreground/60"
+          : "border-primary bg-primary text-primary-foreground"
+      }`}
+    >
+      {state === "all" && (
+        <Check size={12} strokeWidth={3} aria-hidden="true" />
+      )}
+      {state === "some" && (
+        <Minus size={12} strokeWidth={3} aria-hidden="true" />
+      )}
+    </span>
   );
 }

--- a/web/src/tags/TagStrip.tsx
+++ b/web/src/tags/TagStrip.tsx
@@ -1,8 +1,8 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { Tag } from "@/types";
 import type { ColorToken } from "@/tags/palette";
 import { TagChip } from "@/tags/TagChip";
-import { AddTagPopover } from "@/tags/AddTagPopover";
+import { TagPickerDialog } from "@/tags/TagPickerDialog";
 import { sortTagsByName } from "@/tags/sortTags";
 
 interface TagStripProps {
@@ -71,6 +71,17 @@ export function TagStrip({
   const visible = sorted.slice(0, visibleCount);
   const hiddenCount = sorted.length - visible.length;
 
+  // A single chat's assignment is binary — a tag is either on it or not. Map
+  // that onto the dialog's tri-state contract so "some" never appears here.
+  const assignedIds = useMemo(
+    () => new Set(assigned.map((t) => t.id)),
+    [assigned]
+  );
+  const stateFor = (tagId: string) =>
+    assignedIds.has(tagId) ? ("all" as const) : ("none" as const);
+  const handleToggle = (tagId: string) =>
+    assignedIds.has(tagId) ? onRemove(chatId, tagId) : onAssign(chatId, tagId);
+
   return (
     <div
       data-testid="tag-strip"
@@ -103,11 +114,11 @@ export function TagStrip({
           />
         ))}
         {hiddenCount > 0 && (
-          <AddTagPopover
-            assigned={assigned}
-            allTags={allTags}
-            onAssign={(tagId) => onAssign(chatId, tagId)}
-            onRemove={(tagId) => onRemove(chatId, tagId)}
+          <TagPickerDialog
+            title="Add tags"
+            tags={allTags}
+            stateFor={stateFor}
+            onToggle={handleToggle}
             onCreate={(name, color) => onCreate(chatId, name, color)}
             triggerTestId="tag-overflow"
             triggerAriaLabel={`Show ${hiddenCount} more tags`}
@@ -115,11 +126,11 @@ export function TagStrip({
             triggerContent={`+${hiddenCount}`}
           />
         )}
-        <AddTagPopover
-          assigned={assigned}
-          allTags={allTags}
-          onAssign={(tagId) => onAssign(chatId, tagId)}
-          onRemove={(tagId) => onRemove(chatId, tagId)}
+        <TagPickerDialog
+          title="Add tags"
+          tags={allTags}
+          stateFor={stateFor}
+          onToggle={handleToggle}
           onCreate={(name, color) => onCreate(chatId, name, color)}
         />
       </div>


### PR DESCRIPTION
## Background (Why)

The single-chat add-tag UI lived in `AddTagPopover` — a Base UI **popover** anchored to the "+ Tag" / "+N" triggers. The batch-tag work (#163) needs the same find-or-create picker as a **centered modal** with tri-state rows, and building it twice would drift. This PR extracts the picker into a shared `TagPickerDialog` whose interface already anticipates batch mode, so #163 adds staged behavior without another refactor.

Ships via the `integration/batch-tag` branch (targets `integration/batch-tag`, not `main`).

## Approach (How)

Split the modal "chrome" from the picker body:

- **`shared/ui/dialog.tsx`** — a thin wrapper over Base UI's `Dialog` (mirroring the existing `popover.tsx`) that owns the reusable chrome: a dimming scrim, viewport-centered positioning, entrance/exit animation, z-index, and `Esc` / outside-click dismissal. A *deep* wrapper (hides real complexity), not a pass-through.
- **`TagPickerDialog`** — owns only the tag-picking body. Its interface is mode-agnostic: `stateFor(tagId) → "all" | "some" | "none"` + `onToggle(tagId)`. A single chat maps binary assignment onto `all`/`none` (never `some`); batch mode (#163) will return `some` and add a staged `Done` footer. Rows are a leading tri-state checkbox + color dot + name.
- **`TagStrip`** maps its binary assigned-set onto the tri-state contract and drops both `AddTagPopover` usages.

## Changes (What)

- [x] Add `shared/ui/dialog.tsx` — centered-modal wrapper with a dimming scrim
- [x] Add `TagPickerDialog` with a batch-ready interface (`stateFor` / `onToggle` / `onCreate`); tri-state checkbox rows, unchecked box visible without hover
- [x] Rewire `TagStrip` to use `TagPickerDialog` (both "+ Tag" and "+N" triggers)
- [x] Remove `AddTagPopover`
- [x] Update issue #162 to reflect the transparent → dimming-scrim design revision

### Screenshots

<img width="1512" height="860" alt="截圖 2026-07-08 中午12 25 58" src="https://github.com/user-attachments/assets/3fddc46a-a5c4-4d17-9b5f-1a028c7f2e9a" />


<img width="1512" height="861" alt="截圖 2026-07-08 中午12 26 29" src="https://github.com/user-attachments/assets/5cda612f-a3b6-400c-a079-bc34ae127514" />

### Test Verification

`TagPickerDialog.test.tsx` (8 behavior tests, driven TDD one slice at a time):

- [x] Opens a centered dialog listing each tag as a row with its name
- [x] Renders a dimming scrim and closes on outside click
- [x] Closes on `Esc`
- [x] Row checkbox reflects `stateFor` (all → checked, none → empty, some → indeterminate)
- [x] Clicking a row calls `onToggle(tagId)`
- [x] Find-or-create: existing name filters + offers no create; new name creates with the name-derived color
- [x] Color override via swatch then `Enter` creates with the picked color
- [x] No `Done` button in single mode
- [x] Regression: existing `TagFlow.test.tsx` end-to-end (via `TagStrip`) stays green
- [x] Full suite green (web 232, api 310) + typecheck + lint via pre-commit hooks

## Related Links

- Closes #162