### PR TITLE
feat(web): restore markdown typography in the conversation pane

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       "@playwright/test":
         specifier: ^1.59.1
         version: 1.59.1
+      "@tailwindcss/typography":
+        specifier: ^0.5.20
+        version: 0.5.20(tailwindcss@4.2.2)
       "@testing-library/jest-dom":
         specifier: ^6.9.1
         version: 6.9.1
@@ -2206,6 +2209,14 @@ packages:
         integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==,
       }
     engines: { node: ">= 20" }
+
+  "@tailwindcss/typography@0.5.20":
+    resolution:
+      {
+        integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==,
+      }
+    peerDependencies:
+      tailwindcss: ">=3.0.0 || >=4.0.0 || insiders"
 
   "@tailwindcss/vite@4.2.2":
     resolution:
@@ -5903,6 +5914,13 @@ packages:
       yaml:
         optional: true
 
+  postcss-selector-parser@6.0.10:
+    resolution:
+      {
+        integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==,
+      }
+    engines: { node: ">=4" }
+
   postcss-selector-parser@7.1.1:
     resolution:
       {
@@ -8666,6 +8684,11 @@ snapshots:
       "@tailwindcss/oxide-win32-arm64-msvc": 4.2.2
       "@tailwindcss/oxide-win32-x64-msvc": 4.2.2
 
+  "@tailwindcss/typography@0.5.20(tailwindcss@4.2.2)":
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.2.2
+
   "@tailwindcss/vite@4.2.2(vite@8.0.3(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))":
     dependencies:
       "@tailwindcss/node": 4.2.2
@@ -10986,6 +11009,11 @@ snapshots:
       postcss: 8.5.8
       tsx: 4.21.0
       yaml: 2.8.3
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@7.1.1:
     dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.59.1",
+    "@tailwindcss/typography": "^0.5.20",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/web/src/conversation/CollapsibleThinking.tsx
+++ b/web/src/conversation/CollapsibleThinking.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { MarkdownText } from "@/conversation/MarkdownText";
 
 interface CollapsibleThinkingProps {
   thinking: string;
@@ -18,7 +19,7 @@ export function CollapsibleThinking({ thinking }: CollapsibleThinkingProps) {
       </button>
       {isExpanded && (
         <div className="mt-1 rounded bg-card p-2 text-xs italic text-muted-foreground">
-          {thinking}
+          <MarkdownText>{thinking}</MarkdownText>
         </div>
       )}
     </div>

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { ConversationView } from "@/conversation/ConversationView";
+import type { Chat, Message } from "@/types";
+
+const chat: Chat = {
+  id: "c1",
+  sourceId: "s1",
+  agent: "claude",
+  title: "Typography demo",
+  project: "/home/dev/proj",
+  projectPath: null,
+  sourceFilePath: null,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+function renderMessages(messages: Message[]) {
+  return render(<ConversationView chat={chat} messages={messages} />);
+}
+
+function assistant(text: string): Message {
+  return {
+    role: "assistant",
+    content: text,
+    timestamp: "2024-01-01T00:00:00Z",
+  };
+}
+
+describe("Conversation markdown typography", () => {
+  it("renders markdown links that open in a new tab", async () => {
+    renderMessages([assistant("See the [docs](https://example.com) page.")]);
+
+    const link = await screen.findByRole("link", { name: "docs" });
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel")).toContain("noreferrer");
+  });
+
+  it("wraps wide tables in a horizontal-scroll container", async () => {
+    renderMessages([
+      assistant("| Name | Value |\n| --- | --- |\n| alpha | 1 |\n"),
+    ]);
+
+    const table = await screen.findByRole("table");
+    expect(table.closest(".overflow-x-auto")).not.toBeNull();
+  });
+
+  it("renders expanded thinking content as markdown", async () => {
+    const user = userEvent.setup();
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            role: "assistant",
+            content: [{ type: "thinking", thinking: "- first\n- second\n" }],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    await user.click(await screen.findByText("Thinking..."));
+
+    const items = await screen.findAllByRole("listitem");
+    expect(items.map((el) => el.textContent)).toEqual(["first", "second"]);
+  });
+
+  it("keeps a very long unbroken string inside a wrapping container", async () => {
+    const longToken = "a".repeat(400);
+    renderMessages([assistant(longToken)]);
+
+    const text = await screen.findByText(longToken);
+    const prose = text.closest(".prose");
+    expect(prose).not.toBeNull();
+    // overflow-wrap:anywhere is what lets the token break instead of
+    // overflowing the pane; assert the container carries it.
+    expect(prose?.className).toContain("[overflow-wrap:anywhere]");
+  });
+});

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -1,10 +1,8 @@
 import { useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { RotateCcw } from "lucide-react";
-import Markdown from "react-markdown";
-import rehypeHighlight from "rehype-highlight";
-import remarkGfm from "remark-gfm";
 import type { Message, ContentBlock, Chat, Tag } from "@/types";
+import { MarkdownText } from "@/conversation/MarkdownText";
 import { CollapsibleThinking } from "@/conversation/CollapsibleThinking";
 import { CollapsibleToolCall } from "@/conversation/CollapsibleToolCall";
 import { ChatMetadataPopover } from "@/metadata/ChatMetadataPopover";
@@ -123,14 +121,6 @@ function ConversationHeader({
         </>
       )}
     </div>
-  );
-}
-
-function MarkdownText({ children }: { children: string }) {
-  return (
-    <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-      {children}
-    </Markdown>
   );
 }
 

--- a/web/src/conversation/MarkdownText.tsx
+++ b/web/src/conversation/MarkdownText.tsx
@@ -1,0 +1,48 @@
+import Markdown, { type Components } from "react-markdown";
+import rehypeHighlight from "rehype-highlight";
+import remarkGfm from "remark-gfm";
+
+const markdownComponents: Components = {
+  a: ({ children, ...props }) => (
+    <a {...props} target="_blank" rel="noreferrer noopener">
+      {children}
+    </a>
+  ),
+  table: ({ children, ...props }) => (
+    <div className="overflow-x-auto">
+      <table {...props}>{children}</table>
+    </div>
+  ),
+};
+
+// prose-sm keeps chat turns tighter than prose's article-scale defaults.
+// The margin overrides pull paragraphs and lists closer for conversation
+// density. overflow-wrap:anywhere lets unbroken strings (paths, ids) break so
+// they can never blow out the pane; `pre` keeps `white-space: pre` so code
+// lines scroll horizontally instead of wrapping.
+//
+// Code blocks are left to the highlight.js solarized-dark theme: prose's `pre`
+// background and padding are cleared so the `.hljs` surface (bg #002b36, 1em
+// padding) is the only frame — no double box. Font size is set once on `pre`
+// (its `code` child inherits); inline code is sized via a :not(pre) selector so
+// the two never compound.
+const PROSE_CLASS =
+  "prose prose-sm prose-invert max-w-none [overflow-wrap:anywhere] " +
+  "prose-p:my-2 prose-headings:mt-4 prose-headings:mb-2 " +
+  "prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5 " +
+  "prose-pre:bg-transparent prose-pre:p-0 prose-pre:my-3 prose-pre:text-[0.875em] " +
+  "[&_pre_code]:text-[1em] [&_:not(pre)>code]:text-[0.875em]";
+
+export function MarkdownText({ children }: { children: string }) {
+  return (
+    <div className={PROSE_CLASS}>
+      <Markdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeHighlight]}
+        components={markdownComponents}
+      >
+        {children}
+      </Markdown>
+    </div>
+  );
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -4,6 +4,8 @@
 @import "@fontsource-variable/geist";
 @import "highlight.js/styles/base16/solarized-dark.min.css";
 
+@plugin "@tailwindcss/typography";
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {


### PR DESCRIPTION
## Background (Why)

Messages in the conversation pane already parse markdown (react-markdown + remark-gfm), but Tailwind preflight strips all element styling, so headings, lists, tables, and blockquotes rendered as flat text. Expanded thinking content rendered as plain text too. This restores full, conversation-tuned typography.

## Approach (How)

Add the official `@tailwindcss/typography` plugin (registered via `@plugin` in `index.css`, Tailwind v4) and route all message and thinking markdown through a shared `MarkdownText` component that wraps output in a `prose prose-sm prose-invert` container tuned for chat density. Code blocks are deliberately left to the existing highlight.js solarized-dark theme: prose's `pre` background and padding are cleared so the `.hljs` surface is the sole frame, and font sizing is applied once (no em compounding).

## Changes (What)

- [x] Install `@tailwindcss/typography`; register it in `index.css`
- [x] Extract a shared `MarkdownText` (prose wrapper + component overrides); use it for message text and expanded thinking
- [x] Links open in a new tab (`target="_blank"`, `rel="noreferrer noopener"`)
- [x] Wide tables wrap in an `overflow-x-auto` container so the pane never scrolls horizontally
- [x] `overflow-wrap:anywhere` so long unbroken strings can't blow out the pane
- [x] Inline and block code sized at 0.875em; solarized-dark highlighting preserved

### Test Verification

New `ConversationView.test.tsx` covers the behavioral criteria; full suite green (web 228, api 310).

- [x] Markdown links render with `target="_blank"` + `rel`
- [x] Wide table is wrapped in a horizontal-scroll container
- [x] Expanded thinking content renders as markdown (list → `<li>`)
- [x] A very long unbroken string sits inside a wrapping (`overflow-wrap`) container
- [x] Existing conversation-view tests still pass

## Additional Notes

Visual tuning (compact spacing, code font size, solarized preservation) is not unit-testable in jsdom and was verified by driving the running app. No source directories or storage layer touched.

## Related Links

- Closes #185