### PR TITLE
feat(web): scroll pill navigation with open-at-bottom and keyboard jumps

### DIFF
--- a/web/e2e/scroll-pill.spec.ts
+++ b/web/e2e/scroll-pill.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from "@playwright/test";
+
+const MESSAGE_COUNT = 500;
+
+// Last message (index 499) is an assistant turn; first (index 0) is a user turn.
+const FIRST_MESSAGE = "User message 1";
+const LAST_MESSAGE = `Assistant response ${MESSAGE_COUNT}`;
+
+function generateMessages(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    role: i % 2 === 0 ? "user" : "assistant",
+    content:
+      i % 2 === 0
+        ? `User message ${i + 1}`
+        : [{ type: "text", text: `Assistant response ${i + 1}` }],
+    timestamp: new Date(1700000000000 + i * 1000).toISOString(),
+  }));
+}
+
+async function openLargeChat(page: import("@playwright/test").Page) {
+  // Benign empty SSE stream so the live-update EventSource connects cleanly.
+  await page.route(/\/api\/chats\/stream(\?|$)/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: ":ok\n\n",
+    })
+  );
+  await page.route(/\/api\/chats\/counts(\?|$)/, (route) =>
+    route.fulfill({
+      json: { total: 1, projects: [], tags: [], untagged: 1 },
+    })
+  );
+  await page.route(/\/api\/chats\/list-total(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1 } })
+  );
+  await page.route(/\/api\/chats(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        chats: [
+          {
+            id: "clog_large1",
+            sourceId: "large-chat",
+            agent: "claude-code",
+            title: "Large conversation",
+            project: "/test/project",
+            sourceFilePath: null,
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000 + MESSAGE_COUNT * 1000,
+          },
+        ],
+      },
+    })
+  );
+  await page.route(/\/api\/chats\/clog_large1(\?|$)/, (route) =>
+    route.fulfill({ json: { messages: generateMessages(MESSAGE_COUNT) } })
+  );
+
+  await page.goto("/");
+  await page.getByText("Large conversation").click();
+}
+
+test.describe("Scroll pill navigation", () => {
+  test("opens the chat at the bottom, showing only the jump-to-top control", async ({
+    page,
+  }) => {
+    await openLargeChat(page);
+
+    // Lands on the latest messages, not the first.
+    await expect(page.getByText(LAST_MESSAGE)).toBeVisible();
+    await expect(page.getByText(FIRST_MESSAGE)).toHaveCount(0);
+
+    // At the bottom only the up half shows.
+    await expect(
+      page.getByRole("button", { name: "Jump to top" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Jump to bottom" })
+    ).toHaveCount(0);
+  });
+
+  test("jumps to the top and back to the bottom instantly", async ({
+    page,
+  }) => {
+    await openLargeChat(page);
+    await expect(page.getByText(LAST_MESSAGE)).toBeVisible();
+
+    // Jump to top -> first message lands, and now only the down half shows.
+    await page.getByRole("button", { name: "Jump to top" }).click();
+    await expect(page.getByText(FIRST_MESSAGE)).toBeVisible();
+    await expect(page.getByText(LAST_MESSAGE)).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Jump to bottom" })
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Jump to top" })).toHaveCount(
+      0
+    );
+
+    // Jump back to the bottom -> last message lands again.
+    await page.getByRole("button", { name: "Jump to bottom" }).click();
+    await expect(page.getByText(LAST_MESSAGE)).toBeVisible();
+    await expect(page.getByText(FIRST_MESSAGE)).toHaveCount(0);
+  });
+
+  test("jumps with Cmd/Ctrl+Arrow and Home/End keys", async ({ page }) => {
+    await openLargeChat(page);
+    await expect(page.getByText(LAST_MESSAGE)).toBeVisible();
+
+    const modifier = process.platform === "darwin" ? "Meta" : "Control";
+
+    // Modifier+ArrowUp -> first message.
+    await page.keyboard.press(`${modifier}+ArrowUp`);
+    await expect(page.getByText(FIRST_MESSAGE)).toBeVisible();
+    await expect(page.getByText(LAST_MESSAGE)).toHaveCount(0);
+
+    // End -> back to the latest message.
+    await page.keyboard.press("End");
+    await expect(page.getByText(LAST_MESSAGE)).toBeVisible();
+
+    // Home -> first message again.
+    await page.keyboard.press("Home");
+    await expect(page.getByText(FIRST_MESSAGE)).toBeVisible();
+    await expect(page.getByText(LAST_MESSAGE)).toHaveCount(0);
+  });
+
+  test("offers jump-to-latest mid-scroll", async ({ page }) => {
+    await openLargeChat(page);
+    await expect(page.getByText(LAST_MESSAGE)).toBeVisible();
+
+    // Scroll up off the bottom edge: away from the bottom, the single pill
+    // offers "jump to latest" (down), not "back to top".
+    await page.getByTestId("conversation-panel").evaluate((el) => {
+      el.scrollTop = el.scrollHeight / 2;
+    });
+
+    await expect(
+      page.getByRole("button", { name: "Jump to bottom" })
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Jump to top" })).toHaveCount(
+      0
+    );
+  });
+});

--- a/web/e2e/virtual-scrolling.spec.ts
+++ b/web/e2e/virtual-scrolling.spec.ts
@@ -69,8 +69,11 @@ test.describe("Virtual scrolling", () => {
     // Click the chat to load messages
     await page.getByText("Large conversation").click();
 
-    // Wait for at least one message to render
-    await expect(page.getByText("User message 1")).toBeVisible();
+    // Wait for at least one message to render. Chats open at the bottom
+    // (latest messages), so the last message is what lands in view (#187).
+    await expect(
+      page.getByText(`Assistant response ${MESSAGE_COUNT}`)
+    ).toBeVisible();
 
     // Count rendered message bubbles (each has a data-role attribute)
     const renderedNodes = await page.locator("[data-role]").count();

--- a/web/src/chat/ChatList.tsx
+++ b/web/src/chat/ChatList.tsx
@@ -11,6 +11,7 @@ import type { Chat } from "@/types";
 import { EditableTitle } from "@/metadata/EditableTitle";
 import { TagChipList } from "@/tags/TagChipList";
 import { useCursorNavigation } from "@/chat/useCursorNavigation";
+import { ActionTooltip } from "@/shared/ActionTooltip";
 
 interface ChatListProps {
   mode?: "main" | "trash";
@@ -129,22 +130,6 @@ function MenuItem({
       </span>
       <span className="text-xs tabular-nums text-muted-foreground">{hint}</span>
     </button>
-  );
-}
-
-function ActionTooltip({ label, hint }: { label: string; hint?: string }) {
-  return (
-    <span
-      aria-hidden="true"
-      className="pointer-events-none absolute right-full top-1/2 mr-1.5 flex -translate-y-1/2 items-center gap-1.5 whitespace-nowrap rounded-md border border-white/10 bg-[#0a0a0a] px-2 py-1 text-xs text-card-foreground opacity-0 shadow-lg transition-opacity duration-100 group-hover/action:opacity-100"
-    >
-      {label}
-      {hint && (
-        <span className="text-xs tabular-nums text-muted-foreground">
-          {hint}
-        </span>
-      )}
-    </span>
   );
 }
 

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -1,10 +1,16 @@
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { RotateCcw } from "lucide-react";
 import type { Message, ContentBlock, Chat, Tag } from "@/types";
 import { MarkdownText } from "@/conversation/MarkdownText";
 import { CollapsibleThinking } from "@/conversation/CollapsibleThinking";
 import { CollapsibleToolCall } from "@/conversation/CollapsibleToolCall";
+import { ScrollPill } from "@/conversation/ScrollPill";
+import {
+  getScrollPillTarget,
+  type ScrollPillTarget,
+} from "@/conversation/scrollPillVisibility";
+import { useScrollShortcuts } from "@/conversation/useScrollShortcuts";
 import { ChatMetadataPopover } from "@/metadata/ChatMetadataPopover";
 import { EditableTitle } from "@/metadata/EditableTitle";
 import { TagStrip } from "@/tags/TagStrip";
@@ -197,15 +203,77 @@ export function ConversationView({
   // that the React Compiler cannot memoize without risking stale UI, so the
   // compiler intentionally skips memoizing this component. This is expected and
   // safe here: the virtualizer values are consumed locally and not passed into
-  // other memoized components/hooks. The warning cannot be compiled away, so we
-  // silence it at the call site rather than disabling the rule globally.
-  // eslint-disable-next-line react-hooks/incompatible-library
+  // other memoized components/hooks.
   const virtualizer = useVirtualizer({
     count: messages.length,
     getScrollElement: () => scrollContainerRef.current,
     estimateSize: () => 100,
     initialRect: { width: 800, height: 600 },
   });
+
+  // Which direction the scroll pill offers. Kept in state (rather than read
+  // during render) so it survives scroll events, jumps, and content that grows
+  // or shrinks as messages expand/collapse. Defaults to hidden until the first
+  // measurement, so the pill never flashes on mount.
+  const [pillTarget, setPillTarget] = useState<ScrollPillTarget>(null);
+  const measurePill = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    setPillTarget(
+      getScrollPillTarget({
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+      })
+    );
+  }, []);
+
+  const jumpTop = useCallback(() => {
+    // Instant index jump, not a smooth scroll: smooth-scrolling across
+    // thousands of virtualized rows is slow and janky.
+    virtualizer.scrollToIndex(0, { align: "start" });
+  }, [virtualizer]);
+  const jumpBottom = useCallback(() => {
+    virtualizer.scrollToIndex(messages.length - 1, { align: "end" });
+  }, [virtualizer, messages.length]);
+
+  // Keyboard equivalents of the pill: Cmd/Ctrl+arrows and Home/End. Enabled
+  // only while a chat with content is open.
+  useScrollShortcuts({
+    enabled: Boolean(chat) && messages.length > 0,
+    onJumpTop: jumpTop,
+    onJumpBottom: jumpBottom,
+  });
+
+  // Open a chat at the bottom (latest messages), matching Claude Code desktop:
+  // the most common recall question is "how did this session end?".
+  const chatId = chat?.id;
+  const landedChatRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!chatId) {
+      landedChatRef.current = null;
+      return;
+    }
+    // Messages load a tick after the chat id is set, so land the moment they
+    // first arrive — not on the initial empty render. Guard by chat id so a
+    // later streamed message doesn't yank an already-positioned view.
+    if (messages.length === 0) return;
+    if (landedChatRef.current === chatId) return;
+    landedChatRef.current = chatId;
+    virtualizer.scrollToIndex(messages.length - 1, { align: "end" });
+    // Re-measure after the jump settles so the pill reflects the landed
+    // position (at the bottom it offers "back to top").
+    const raf = requestAnimationFrame(measurePill);
+    return () => cancelAnimationFrame(raf);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chatId, messages.length]);
+
+  // Keep the pill correct as content height changes (messages expanding or
+  // collapsing) even without a scroll event.
+  const totalSize = virtualizer.getTotalSize();
+  useEffect(() => {
+    measurePill();
+  }, [totalSize, measurePill]);
 
   return (
     <div className="flex h-full flex-col">
@@ -243,27 +311,35 @@ export function ConversationView({
           Select a chat to view the conversation
         </div>
       ) : (
-        <div
-          data-testid="conversation-panel"
-          ref={scrollContainerRef}
-          className="flex-1 overflow-y-auto p-6"
-        >
+        <div className="relative min-h-0 flex-1">
           <div
-            className="relative flex flex-col"
-            style={{ height: `${virtualizer.getTotalSize()}px` }}
+            data-testid="conversation-panel"
+            ref={scrollContainerRef}
+            onScroll={measurePill}
+            className="absolute inset-0 overflow-y-auto p-6"
           >
-            {virtualizer.getVirtualItems().map((virtualItem) => (
-              <div
-                key={virtualItem.index}
-                data-index={virtualItem.index}
-                ref={virtualizer.measureElement}
-                className="absolute left-0 right-0 flex flex-col pb-4"
-                style={{ transform: `translateY(${virtualItem.start}px)` }}
-              >
-                <MessageBubble message={messages[virtualItem.index]} />
-              </div>
-            ))}
+            <div
+              className="relative flex flex-col"
+              style={{ height: `${totalSize}px` }}
+            >
+              {virtualizer.getVirtualItems().map((virtualItem) => (
+                <div
+                  key={virtualItem.index}
+                  data-index={virtualItem.index}
+                  ref={virtualizer.measureElement}
+                  className="absolute left-0 right-0 flex flex-col pb-4"
+                  style={{ transform: `translateY(${virtualItem.start}px)` }}
+                >
+                  <MessageBubble message={messages[virtualItem.index]} />
+                </div>
+              ))}
+            </div>
           </div>
+          <ScrollPill
+            target={pillTarget}
+            onJumpTop={jumpTop}
+            onJumpBottom={jumpBottom}
+          />
         </div>
       )}
     </div>

--- a/web/src/conversation/ScrollPill.test.tsx
+++ b/web/src/conversation/ScrollPill.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ScrollPill } from "@/conversation/ScrollPill";
+
+describe("ScrollPill", () => {
+  it("renders a jump-to-bottom control that fires onJumpBottom", async () => {
+    const user = userEvent.setup();
+    const onJumpBottom = vi.fn();
+
+    render(
+      <ScrollPill
+        target="bottom"
+        onJumpTop={vi.fn()}
+        onJumpBottom={onJumpBottom}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Jump to bottom" }));
+
+    expect(onJumpBottom).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Jump to top" })).toBeNull();
+  });
+
+  it("renders a jump-to-top control that fires onJumpTop", async () => {
+    const user = userEvent.setup();
+    const onJumpTop = vi.fn();
+
+    render(
+      <ScrollPill target="top" onJumpTop={onJumpTop} onJumpBottom={vi.fn()} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Jump to top" }));
+
+    expect(onJumpTop).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Jump to bottom" })).toBeNull();
+  });
+
+  it("renders nothing when there is no target", () => {
+    const { container } = render(
+      <ScrollPill target={null} onJumpTop={vi.fn()} onJumpBottom={vi.fn()} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/conversation/ScrollPill.tsx
+++ b/web/src/conversation/ScrollPill.tsx
@@ -1,0 +1,47 @@
+import { ChevronUp, ChevronDown } from "lucide-react";
+import type { ScrollPillTarget } from "@/conversation/scrollPillVisibility";
+import { ActionTooltip } from "@/shared/ActionTooltip";
+import { modifierHint } from "@/shared/platform";
+
+interface ScrollPillProps {
+  target: ScrollPillTarget;
+  onJumpTop: () => void;
+  onJumpBottom: () => void;
+}
+
+/**
+ * Floating navigation for long conversations: a single round button tucked into
+ * the pane's bottom-right corner (over the margin, clear of the reading column).
+ * It shows one contextual direction — "back to top" once pinned at the bottom,
+ * otherwise "jump to latest" — matching the single scroll button in Slack /
+ * Discord / ChatGPT. Positioned absolutely against the (non-scrolling) pane
+ * wrapper, it stays put while the conversation scrolls beneath it.
+ */
+export function ScrollPill({
+  target,
+  onJumpTop,
+  onJumpBottom,
+}: ScrollPillProps) {
+  if (target === null) return null;
+
+  const isTop = target === "top";
+  const Icon = isTop ? ChevronUp : ChevronDown;
+  const label = isTop ? "Jump to top" : "Jump to bottom";
+  const hint = modifierHint(isTop ? "↑" : "↓");
+
+  return (
+    <div className="absolute bottom-6 right-6 z-10">
+      <span className="group/action relative">
+        <button
+          type="button"
+          aria-label={label}
+          onClick={isTop ? onJumpTop : onJumpBottom}
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-border/60 bg-card/80 text-muted-foreground shadow-lg backdrop-blur-md transition-colors hover:bg-card hover:text-foreground focus-visible:outline-none focus-visible:text-foreground focus-visible:ring-2 focus-visible:ring-primary/50"
+        >
+          <Icon size={18} aria-hidden="true" />
+        </button>
+        <ActionTooltip label={label} hint={hint} />
+      </span>
+    </div>
+  );
+}

--- a/web/src/conversation/scrollPillVisibility.test.ts
+++ b/web/src/conversation/scrollPillVisibility.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { getScrollPillTarget } from "@/conversation/scrollPillVisibility";
+
+describe("getScrollPillTarget", () => {
+  it("offers jump-to-bottom when scrolled to the top", () => {
+    expect(
+      getScrollPillTarget({
+        scrollTop: 0,
+        scrollHeight: 2000,
+        clientHeight: 600,
+      })
+    ).toBe("bottom");
+  });
+
+  it("offers jump-to-bottom mid-scroll", () => {
+    expect(
+      getScrollPillTarget({
+        scrollTop: 700,
+        scrollHeight: 2000,
+        clientHeight: 600,
+      })
+    ).toBe("bottom");
+  });
+
+  it("offers back-to-top only once pinned at the bottom", () => {
+    expect(
+      getScrollPillTarget({
+        scrollTop: 1400,
+        scrollHeight: 2000,
+        clientHeight: 600,
+      })
+    ).toBe("top");
+  });
+
+  it("hides the pill when the content is too short to scroll", () => {
+    expect(
+      getScrollPillTarget({
+        scrollTop: 0,
+        scrollHeight: 500,
+        clientHeight: 600,
+      })
+    ).toBeNull();
+  });
+});

--- a/web/src/conversation/scrollPillVisibility.ts
+++ b/web/src/conversation/scrollPillVisibility.ts
@@ -1,0 +1,27 @@
+export interface ScrollMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+// Where the (single) scroll pill would take you if tapped. Chat logs anchor on
+// the latest message, so whenever you are away from the bottom the pill offers
+// "jump to latest"; only once pinned at the bottom does it offer "back to top".
+// null hides the pill (content too short to scroll). This mirrors the single
+// contextual button in Slack / Discord / ChatGPT.
+export type ScrollPillTarget = "top" | "bottom" | null;
+
+// A few pixels of slack so sub-pixel scroll offsets and fractional layout
+// heights still register as "pinned to the edge" rather than mid-scroll.
+const EDGE_THRESHOLD = 8;
+
+export function getScrollPillTarget(
+  { scrollTop, scrollHeight, clientHeight }: ScrollMetrics,
+  threshold: number = EDGE_THRESHOLD
+): ScrollPillTarget {
+  const scrollable = scrollHeight - clientHeight > threshold;
+  if (!scrollable) return null;
+
+  const atBottom = scrollTop + clientHeight >= scrollHeight - threshold;
+  return atBottom ? "top" : "bottom";
+}

--- a/web/src/conversation/useScrollShortcuts.test.tsx
+++ b/web/src/conversation/useScrollShortcuts.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useScrollShortcuts } from "@/conversation/useScrollShortcuts";
+
+function Harness(props: {
+  enabled: boolean;
+  onJumpTop: () => void;
+  onJumpBottom: () => void;
+}) {
+  useScrollShortcuts(props);
+  return <input data-testid="field" />;
+}
+
+function setup(overrides?: Partial<Parameters<typeof Harness>[0]>) {
+  const onJumpTop = vi.fn();
+  const onJumpBottom = vi.fn();
+  render(
+    <Harness
+      enabled={true}
+      onJumpTop={onJumpTop}
+      onJumpBottom={onJumpBottom}
+      {...overrides}
+    />
+  );
+  return { onJumpTop, onJumpBottom };
+}
+
+describe("useScrollShortcuts", () => {
+  it("jumps to the bottom on Cmd/Ctrl+ArrowDown", () => {
+    const { onJumpBottom } = setup();
+
+    fireEvent.keyDown(document.body, { key: "ArrowDown", metaKey: true });
+    fireEvent.keyDown(document.body, { key: "ArrowDown", ctrlKey: true });
+
+    expect(onJumpBottom).toHaveBeenCalledTimes(2);
+  });
+
+  it("jumps to the top on Cmd/Ctrl+ArrowUp", () => {
+    const { onJumpTop } = setup();
+
+    fireEvent.keyDown(document.body, { key: "ArrowUp", metaKey: true });
+
+    expect(onJumpTop).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps End to the bottom and Home to the top", () => {
+    const { onJumpTop, onJumpBottom } = setup();
+
+    fireEvent.keyDown(document.body, { key: "End" });
+    fireEvent.keyDown(document.body, { key: "Home" });
+
+    expect(onJumpBottom).toHaveBeenCalledTimes(1);
+    expect(onJumpTop).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a bare ArrowDown to the list cursor (no modifier)", () => {
+    const { onJumpBottom } = setup();
+
+    fireEvent.keyDown(document.body, { key: "ArrowDown" });
+
+    expect(onJumpBottom).not.toHaveBeenCalled();
+  });
+
+  it("ignores the keys while typing in a field", () => {
+    const { onJumpTop, onJumpBottom } = setup();
+    const field = screen.getByTestId("field");
+    field.focus();
+
+    fireEvent.keyDown(field, { key: "ArrowDown", metaKey: true });
+    fireEvent.keyDown(field, { key: "Home" });
+
+    expect(onJumpBottom).not.toHaveBeenCalled();
+    expect(onJumpTop).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when disabled", () => {
+    const { onJumpTop, onJumpBottom } = setup({ enabled: false });
+
+    fireEvent.keyDown(document.body, { key: "ArrowDown", metaKey: true });
+    fireEvent.keyDown(document.body, { key: "End" });
+
+    expect(onJumpBottom).not.toHaveBeenCalled();
+    expect(onJumpTop).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/conversation/useScrollShortcuts.ts
+++ b/web/src/conversation/useScrollShortcuts.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+
+interface ScrollShortcuts {
+  /** Off while no chat is open, so the keys don't fire on an empty pane. */
+  enabled: boolean;
+  onJumpTop: () => void;
+  onJumpBottom: () => void;
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  return /^(input|textarea|select)$/i.test(target.tagName);
+}
+
+/**
+ * Keyboard jumps for the conversation pane: Cmd/Ctrl+↑/↓ and Home/End land
+ * instantly at the first / last message — the macOS "top/bottom of document"
+ * convention, reinforcing what the browser would do but routed through the
+ * virtualizer's index jump. Ignored while typing in a field so it never steals
+ * caret movement or title edits.
+ */
+export function useScrollShortcuts({
+  enabled,
+  onJumpTop,
+  onJumpBottom,
+}: ScrollShortcuts): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (isTypingTarget(e.target)) return;
+
+      const primary = e.metaKey || e.ctrlKey;
+      if (primary && e.key === "ArrowDown") {
+        e.preventDefault();
+        onJumpBottom();
+      } else if (primary && e.key === "ArrowUp") {
+        e.preventDefault();
+        onJumpTop();
+      } else if (!primary && !e.altKey && !e.shiftKey && e.key === "End") {
+        e.preventDefault();
+        onJumpBottom();
+      } else if (!primary && !e.altKey && !e.shiftKey && e.key === "Home") {
+        e.preventDefault();
+        onJumpTop();
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [enabled, onJumpTop, onJumpBottom]);
+}

--- a/web/src/shared/ActionTooltip.tsx
+++ b/web/src/shared/ActionTooltip.tsx
@@ -1,0 +1,35 @@
+/**
+ * The app's hover tooltip for icon buttons: a dark pill that fades in to the
+ * left of its trigger, showing a label and an optional keyboard hint (e.g. `⌫`
+ * or `⌘↓`). Purely presentational and `aria-hidden` — the trigger button
+ * carries the accessible name. Wrap the trigger and this together in a
+ * `group/action relative` element so hover reveals it:
+ *
+ * ```tsx
+ * <span className="group/action relative">
+ *   <button aria-label="Move to Trash">…</button>
+ *   <ActionTooltip label="Move to Trash" hint="⌫" />
+ * </span>
+ * ```
+ */
+export function ActionTooltip({
+  label,
+  hint,
+}: {
+  label: string;
+  hint?: string;
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className="pointer-events-none absolute right-full top-1/2 mr-1.5 flex -translate-y-1/2 items-center gap-1.5 whitespace-nowrap rounded-md border border-white/10 bg-[#0a0a0a] px-2 py-1 text-xs text-card-foreground opacity-0 shadow-lg transition-opacity duration-100 group-hover/action:opacity-100"
+    >
+      {label}
+      {hint && (
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {hint}
+        </span>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
## Background (Why)

Long conversations in the third pane had no fast way to move between the start and the latest messages — you scrolled by hand across hundreds of virtualized rows. Chats also opened at the top, even though the most common recall question about a past session is "how did this end?".

## Approach (How)

- A single **contextual** button in the pane's bottom-right corner, not a two-way control: away from the bottom it offers "jump to latest", once pinned at the bottom it offers "back to top". This is the Slack / Discord / ChatGPT pattern and keeps the button out of the reading column. The direction logic lives in a pure function (`getScrollPillTarget`) so it is unit-tested in isolation.
- Jumps are **instant virtualizer index jumps** (`scrollToIndex`), not smooth scrolls — smooth-scrolling across thousands of virtualized rows is slow and janky.
- Chats **open at the bottom**. The landing is keyed on the chat id and fires when messages first arrive (they load a tick after the id is set), guarded so a later streamed message never yanks an already-positioned view.
- **Keyboard jumps** (`useScrollShortcuts`): Cmd/Ctrl+↑/↓ and Home/End, ignored while typing in a field, enabled only while a chat is open. Cmd/Ctrl+↑/↓ reinforces the native macOS "top/bottom of document" convention, routed through the virtualizer.
- The button reuses the app's existing hover tooltip, which is extracted from `ChatList` into a shared `ActionTooltip` component; the shortcut hint is platform-aware (`⌘↑` on macOS, `Ctrl+↑` elsewhere) via `modifierHint`.
- The pill sits in a non-scrolling wrapper (scroll container is `absolute inset-0`) so it stays put while the conversation scrolls beneath it.

## Changes (What)

- [x] `ScrollPill` — single contextual round button, bottom-right, with tooltip
- [x] `getScrollPillTarget` pure function for conditional direction
- [x] `useScrollShortcuts` hook — Cmd/Ctrl+↑/↓ and Home/End
- [x] `ConversationView` — open-at-bottom, scroll tracking, jump wiring
- [x] Extract `ActionTooltip` into a shared component (reused by `ChatList`)

### Screenshots or Recordings

<img width="882" height="186" alt="截圖 2026-07-09 下午6 11 46" src="https://github.com/user-attachments/assets/4fb83897-20fd-43f9-82f2-8881ea6b7fa7" />

### Test Verification

- [x] Direction logic: top → down, mid → down, bottom → up, non-scrollable → hidden (unit)
- [x] `ScrollPill` renders the right control and fires the right callback; nothing when no target (unit)
- [x] Keyboard: Cmd/Ctrl+↓/↑, Home/End, bare ArrowDown ignored, typing-in-field ignored, disabled no-op (unit)
- [x] E2E: opens at bottom (only ↑ shows), ↑/↓ jump to first/last, keyboard jumps, mid-scroll offers "jump to latest"
- [x] Full suite green: web 241 unit, api 310 unit, 8 e2e; typecheck + lint clean

## Additional Notes

Home/End have no dedicated keys on most Mac keyboards (use Fn+←/→), so the tooltip only advertises ⌘↑/⌘↓; Home/End stay wired as a silent alias.

The virtualizer does not render items under jsdom (zero-height viewport), so jump / open-at-bottom behavior is covered by Playwright e2e — the repo's established pattern (`virtual-scrolling.spec.ts`).

## Related Links

- Closes #187