### PR TITLE
fix(web): list cursor ignores modifier-held arrows

### DIFF
--- a/web/src/chat/useCursorNavigation.test.tsx
+++ b/web/src/chat/useCursorNavigation.test.tsx
@@ -129,6 +129,33 @@ describe("useCursorNavigation", () => {
     expect(onOpen).not.toHaveBeenCalled();
   });
 
+  it("ignores Cmd/Ctrl-modified arrows so they stay the conversation jump", () => {
+    const onOpen = vi.fn();
+    const { result } = renderHook(() =>
+      useCursorNavigation({ chats, openId: "a", onOpen })
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowDown",
+          metaKey: true,
+          bubbles: true,
+        })
+      );
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowUp",
+          ctrlKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    expect(result.current.cursorId).toBeNull();
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
   it("ignores arrows while an editable element (a title input) holds focus", () => {
     const onOpen = vi.fn();
     const { result } = renderHook(() =>

--- a/web/src/chat/useCursorNavigation.ts
+++ b/web/src/chat/useCursorNavigation.ts
@@ -63,6 +63,11 @@ export function useCursorNavigation({
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+      // Only bare arrows walk the Cursor. A modifier makes it a different
+      // shortcut — Cmd/Ctrl+Arrow is the conversation's jump-to-top/bottom
+      // (see useScrollShortcuts) — so leave those alone or the same keypress
+      // moves the list Cursor and jumps the conversation at once.
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
 
       // Typing in a title field owns its own arrows; never hijack them.
       const target = e.target as HTMLElement | null;


### PR DESCRIPTION
## Background (Why)

v0.18.0 added Cmd/Ctrl+↑/↓ jumps to the conversation pane. But the chat-list Cursor (`useCursorNavigation`) reacted to `ArrowUp`/`ArrowDown` without checking modifier keys, and both hooks listen on `window` keydown. So one `⌘↑` / `⌘↓` keypress fired both: it walked the list Cursor — and debounce-opened a different chat — while also jumping the conversation. The two shortcuts clashed.

## Approach (How)

The defect is the Cursor handler's over-broad key filter: a bare-arrow shortcut should assert that no modifier is held. Bail out of the Cursor handler when Cmd/Ctrl/Alt is down, so bare arrows walk the list and modified arrows belong solely to the conversation jump. The fix lives in the existing hook, next to its other guards (editable fields, popovers).

## Changes (What)

- [x] `useCursorNavigation` ignores `ArrowUp`/`ArrowDown` when `metaKey`, `ctrlKey`, or `altKey` is held

### Test Verification

- [x] Regression test at the hook seam: `⌘↓` / `Ctrl↑` no longer move the Cursor or open a chat (written failing first, then green)
- [x] Existing Cursor tests still pass (bare arrows walk and debounce-open as before)
- [x] `useScrollShortcuts` tests still pass (the conversation jump is unaffected)
- [x] Full web suite green (242) + typecheck clean

## Additional Notes

A latent over-reach that only surfaced once a modifier-held arrow shortcut existed. Scope is a single guard; no architectural change needed. Ships as the 0.18.1 patch.

## Related Links

- Follow-up to #202 (introduced the Cmd/Ctrl+Arrow jumps in v0.18.0)