### PR TITLE
feat: select-all-matching over the live filter (filter-branch batch)

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -1764,3 +1764,225 @@ describe("Batch tag apply and grouped read (archive-backed)", () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe("Batch filter branch — select-all-matching (#164, ADR-0021)", () => {
+  function makeApp() {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+    const app = createApp({
+      archive,
+      metadata,
+      tags,
+      pageQuery: createChatPageQuery({ dataDir }),
+      countsQuery: createChatCountsQuery({ dataDir }),
+    });
+    return { archive, metadata, tags, app };
+  }
+
+  it("POST /api/chats/batch/tags with { filter } tags every chat matching the filter", async () => {
+    const { archive, tags, app } = makeApp();
+    seedChat(archive, {
+      sourceId: "s1",
+      firstSeenAt: new Date(1700000000000),
+      project: "work",
+    });
+    seedChat(archive, {
+      sourceId: "s2",
+      firstSeenAt: new Date(1700000000001),
+      project: "work",
+    });
+    seedChat(archive, {
+      sourceId: "s3",
+      firstSeenAt: new Date(1700000000002),
+      project: "home",
+    });
+    const idea = tags.createTag("idea", "violet");
+    const row1 = archive.read.findChatBySourceId("s1")!;
+    const row2 = archive.read.findChatBySourceId("s2")!;
+    const row3 = archive.read.findChatBySourceId("s3")!;
+
+    const res = await app.request("/api/chats/batch/tags", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        filter: { projects: ["work"] },
+        excludeIds: [],
+        add: [idea.id],
+        remove: [],
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ count: 2 });
+
+    // Every chat matching the filter is tagged — not just a loaded window.
+    expect(tags.listTagsForChat(row1.id)).toEqual([idea]);
+    expect(tags.listTagsForChat(row2.id)).toEqual([idea]);
+    // A chat outside the filter is untouched.
+    expect(tags.listTagsForChat(row3.id)).toEqual([]);
+  });
+
+  it("subtracts excludeIds from the filter-matched set", async () => {
+    const { archive, tags, app } = makeApp();
+    seedChat(archive, {
+      sourceId: "s1",
+      firstSeenAt: new Date(1700000000000),
+      project: "work",
+    });
+    seedChat(archive, {
+      sourceId: "s2",
+      firstSeenAt: new Date(1700000000001),
+      project: "work",
+    });
+    seedChat(archive, {
+      sourceId: "s3",
+      firstSeenAt: new Date(1700000000002),
+      project: "work",
+    });
+    const idea = tags.createTag("idea", "violet");
+    const row1 = archive.read.findChatBySourceId("s1")!;
+    const row2 = archive.read.findChatBySourceId("s2")!;
+    const row3 = archive.read.findChatBySourceId("s3")!;
+
+    const res = await app.request("/api/chats/batch/tags", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        filter: { projects: ["work"] },
+        // s2 was unchecked after selecting all — it stays untagged.
+        excludeIds: [wireIdFor(archive, "s2")],
+        add: [idea.id],
+        remove: [],
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ count: 2 });
+
+    expect(tags.listTagsForChat(row1.id)).toEqual([idea]);
+    expect(tags.listTagsForChat(row2.id)).toEqual([]);
+    expect(tags.listTagsForChat(row3.id)).toEqual([idea]);
+  });
+
+  it("honors tagMode 'any' when resolving the filter-matched set", async () => {
+    const { archive, tags, app } = makeApp();
+    seedChat(archive, { sourceId: "s1", firstSeenAt: new Date(1700000000000) });
+    seedChat(archive, { sourceId: "s2", firstSeenAt: new Date(1700000000001) });
+    seedChat(archive, { sourceId: "s3", firstSeenAt: new Date(1700000000002) });
+    const bug = tags.createTag("bug", "red");
+    const chore = tags.createTag("chore", "orange");
+    const star = tags.createTag("star", "violet");
+    const row1 = archive.read.findChatBySourceId("s1")!;
+    const row2 = archive.read.findChatBySourceId("s2")!;
+    const row3 = archive.read.findChatBySourceId("s3")!;
+    // s1 holds bug, s2 holds chore, s3 holds neither.
+    tags.assignTag(row1.id, bug.id);
+    tags.assignTag(row2.id, chore.id);
+
+    // "any" of {bug, chore} matches s1 and s2, but not s3.
+    const res = await app.request("/api/chats/batch/tags", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        filter: { tags: [bug.id, chore.id], tagMode: "any" },
+        excludeIds: [],
+        add: [star.id],
+        remove: [],
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ count: 2 });
+
+    expect(tags.listTagsForChat(row1.id)).toContainEqual(star);
+    expect(tags.listTagsForChat(row2.id)).toContainEqual(star);
+    expect(tags.listTagsForChat(row3.id)).toEqual([]);
+  });
+
+  it("POST /api/chats/batch/trash honors the filter branch, minus exclusions", async () => {
+    const { archive, app } = makeApp();
+    seedChat(archive, {
+      sourceId: "s1",
+      firstSeenAt: new Date(1700000000000),
+      project: "work",
+    });
+    seedChat(archive, {
+      sourceId: "s2",
+      firstSeenAt: new Date(1700000000001),
+      project: "work",
+    });
+    seedChat(archive, {
+      sourceId: "s3",
+      firstSeenAt: new Date(1700000000002),
+      project: "home",
+    });
+
+    const res = await app.request("/api/chats/batch/trash", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        filter: { projects: ["work"] },
+        excludeIds: [wireIdFor(archive, "s2")],
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ count: 1 });
+
+    const list = await app.request("/api/chats?limit=200");
+    const body = (await list.json()) as { chats: ChatResponse[] };
+    const ids = body.chats.map((c) => c.sourceId);
+    // s1 matched and was not excluded → trashed; s2 excluded, s3 outside filter.
+    expect(ids).not.toContain("s1");
+    expect(ids).toContain("s2");
+    expect(ids).toContain("s3");
+  });
+
+  it("drops unresolvable excludeIds instead of failing the batch", async () => {
+    const { archive, tags, app } = makeApp();
+    seedChat(archive, {
+      sourceId: "s1",
+      firstSeenAt: new Date(1700000000000),
+      project: "work",
+    });
+    const idea = tags.createTag("idea", "violet");
+    const row1 = archive.read.findChatBySourceId("s1")!;
+
+    const res = await app.request("/api/chats/batch/tags", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        filter: { projects: ["work"] },
+        excludeIds: ["clog_zzzzzz", "not-an-id"],
+        add: [idea.id],
+        remove: [],
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ count: 1 });
+    expect(tags.listTagsForChat(row1.id)).toEqual([idea]);
+  });
+
+  it("GET /api/chats/filtered-tag-counts returns per-tag counts scoped to the filter", async () => {
+    const { archive, tags, app } = makeApp();
+    const w1 = archive.ensureChat("claude-code", "w1", new Date(1), "work");
+    const w2 = archive.ensureChat("claude-code", "w2", new Date(2), "work");
+    archive.ensureChat("claude-code", "h1", new Date(3), "home");
+    const bug = tags.createTag("bug", "red");
+    const idea = tags.createTag("idea", "violet");
+    // In "work": w1 holds bug+idea, w2 holds bug. h1 (home) holds bug too.
+    tags.assignTag(w1, bug.id);
+    tags.assignTag(w1, idea.id);
+    tags.assignTag(w2, bug.id);
+    tags.assignTag(archive.read.findChatBySourceId("h1")!.id, bug.id);
+
+    const res = await app.request(
+      "/api/chats/filtered-tag-counts?project=work"
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      tags: Array<{ tagId: string; count: number }>;
+    };
+    const byTag = new Map(body.tags.map((t) => [t.tagId, t.count]));
+    // Only the two "work" chats count: bug on both, idea on one.
+    expect(byTag.get(bug.id)).toBe(2);
+    expect(byTag.get(idea.id)).toBe(1);
+  });
+});

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -208,11 +208,60 @@ export function createApp({
     return c.json({ total });
   });
 
-  // Resolve a batch request body's `{ chatIds: [...] }` into the internal ids
-  // the metadata write flips (#161, ADR-0021 explicit-ids branch). Unknown or
-  // malformed ids are dropped rather than failing the batch, so an id already
-  // purged from the Archive can't 500 the whole action. Returns null when the
-  // body is not a `chatIds` string array at all.
+  // Per-Tag counts scoped to the active filter (#164), so the batch dialog's
+  // tri-state under select-all-matching is accurate even when a Project/Tag
+  // filter narrows the set. Same query parsing as `/list-total`; the client
+  // subtracts the excluded Chats' own Tags locally (ADR-0021). Registered before
+  // `/api/chats/:id` so the literal segment is not captured as an id.
+  app.get("/api/chats/filtered-tag-counts", (c) => {
+    if (!countsQuery) {
+      return c.json({ error: "Counts are not available" }, 501);
+    }
+    const includeTrashed = c.req.query("includeTrashed") === "true";
+    const projects = c.req.queries("project");
+    const tagsParam = c.req.query("tags");
+    const tags = tagsParam === undefined ? undefined : tagsParam.split(",");
+    const tagMode = c.req.query("tagMode") ?? "all";
+    if (tagMode !== "all" && tagMode !== "any") {
+      return c.json({ error: "Invalid tagMode" }, 400);
+    }
+    return c.json({
+      tags: countsQuery.queryFilteredTagCounts({
+        includeTrashed,
+        projects,
+        tags,
+        tagMode,
+      }),
+    });
+  });
+
+  // Map a list of wire ids to the internal ids the metadata write flips,
+  // dropping any that no longer resolve (e.g. purged from the Archive) so one
+  // stale id can't 500 the whole batch.
+  function toInternalIds(wireIds: unknown): string[] {
+    if (!Array.isArray(wireIds)) return [];
+    const internalIds: string[] = [];
+    for (const wireId of wireIds) {
+      if (typeof wireId !== "string") continue;
+      const row = reader.findChat(wireId);
+      if (row) internalIds.push(row.id);
+    }
+    return internalIds;
+  }
+
+  function toStringArray(v: unknown): string[] | undefined {
+    return Array.isArray(v)
+      ? v.filter((x): x is string => typeof x === "string")
+      : undefined;
+  }
+
+  // Resolve a batch request body to the internal ids the metadata write flips
+  // (ADR-0021). The body is one of two branches: `{ chatIds: [...] }` — the
+  // explicit set the user checked (#161) — or `{ filter, excludeIds }` —
+  // select-all-matching, every Chat matching the active filter minus a small
+  // exclusion set, resolved server-side through the same `buildFilterClauses`
+  // predicate the list uses so no id list is shipped over the wire (#164).
+  // Returns null when the body is neither branch.
   async function resolveBatchIds(c: {
     req: { json: () => Promise<unknown> };
   }): Promise<string[] | null> {
@@ -223,14 +272,27 @@ export function createApp({
       return null;
     }
     const chatIds = (body as { chatIds?: unknown })?.chatIds;
-    if (!Array.isArray(chatIds)) return null;
-    const internalIds: string[] = [];
-    for (const wireId of chatIds) {
-      if (typeof wireId !== "string") continue;
-      const row = reader.findChat(wireId);
-      if (row) internalIds.push(row.id);
+    if (Array.isArray(chatIds)) return toInternalIds(chatIds);
+
+    const filter = (body as { filter?: unknown })?.filter;
+    if (filter && typeof filter === "object" && countsQuery) {
+      const f = filter as {
+        projects?: unknown;
+        tags?: unknown;
+        tagMode?: unknown;
+        includeTrashed?: unknown;
+      };
+      return countsQuery.queryFilteredIds({
+        projects: toStringArray(f.projects),
+        tags: toStringArray(f.tags),
+        tagMode: f.tagMode === "any" ? "any" : "all",
+        includeTrashed: f.includeTrashed === true,
+        excludeIds: toInternalIds(
+          (body as { excludeIds?: unknown })?.excludeIds
+        ),
+      });
     }
-    return internalIds;
+    return null;
   }
 
   // Registered before `/api/chats/:id/restore` so the literal `batch` segment is

--- a/api/src/list-counts.test.ts
+++ b/api/src/list-counts.test.ts
@@ -565,3 +565,45 @@ describe("ChatCountsQuery.queryFilteredTotal — cross-type and view", () => {
     countsQuery.close();
   });
 });
+
+describe("ChatCountsQuery.queryFilteredTagCounts — per-tag counts within a filter (#164)", () => {
+  it("counts each tag only over the chats matching the active filter", () => {
+    const archive = createArchiveRepository({ dataDir });
+    createMetadataRepository({ dataDir });
+    const tags = createTagRepository({ dataDir });
+
+    const w1 = seedChat(archive, {
+      sourceId: "w1",
+      firstSeenAt: new Date(1),
+      project: "work",
+    });
+    const w2 = seedChat(archive, {
+      sourceId: "w2",
+      firstSeenAt: new Date(2),
+      project: "work",
+    });
+    const h1 = seedChat(archive, {
+      sourceId: "h1",
+      firstSeenAt: new Date(3),
+      project: "home",
+    });
+
+    const bug = tags.createTag("bug", "red");
+    const idea = tags.createTag("idea", "violet");
+    // In "work": w1 holds bug+idea, w2 holds bug. In "home": h1 holds bug.
+    tags.assignTag(w1, bug.id);
+    tags.assignTag(w1, idea.id);
+    tags.assignTag(w2, bug.id);
+    tags.assignTag(h1, bug.id);
+
+    const countsQuery = createChatCountsQuery({ dataDir });
+    const counts = countsQuery.queryFilteredTagCounts({ projects: ["work"] });
+
+    const byTag = new Map(counts.map((t) => [t.tagId, t.count]));
+    // Only the two "work" chats count: bug on both, idea on one. h1 excluded.
+    expect(byTag.get(bug.id)).toBe(2);
+    expect(byTag.get(idea.id)).toBe(1);
+
+    countsQuery.close();
+  });
+});

--- a/api/src/list-counts.ts
+++ b/api/src/list-counts.ts
@@ -62,6 +62,34 @@ export interface ChatCountsQuery {
      */
     tagMode?: TagMode;
   }): number;
+  /**
+   * Resolve the filter branch of a batch action (#164, ADR-0021) to the set of
+   * internal Chat ids it targets: every Chat matching the active view + filter,
+   * minus `excludeIds` (the small set the user unchecked after selecting all).
+   * Reuses the same `buildFilterClauses` predicate as the list, so the batch
+   * write can never disagree with what the list showed as matching. `excludeIds`
+   * are internal Chat ids, resolved from the wire ids by the caller.
+   */
+  queryFilteredIds(opts: {
+    includeTrashed?: boolean;
+    projects?: string[];
+    tags?: string[];
+    tagMode?: TagMode;
+    excludeIds?: string[];
+  }): string[];
+  /**
+   * Per-Tag counts over the Chats matching the active view + filter (#164) —
+   * unlike `queryCounts`, which counts each Tag over the whole view, this scopes
+   * the count to the same `buildFilterClauses` set the filtered list shows. It
+   * feeds the batch dialog's tri-state under select-all-matching, so a narrowing
+   * Project/Tag filter stays accurate. Empty when there is no Metadata store.
+   */
+  queryFilteredTagCounts(opts: {
+    includeTrashed?: boolean;
+    projects?: string[];
+    tags?: string[];
+    tagMode?: TagMode;
+  }): TagCount[];
   close(): void;
 }
 
@@ -150,7 +178,13 @@ export function createChatCountsQuery({
     return { total, projects, tags, untagged };
   }
 
-  function queryFilteredTotal({
+  /**
+   * The view + Project/Tag filter WHERE shared by the filtered count and the
+   * filter-branch id resolution (#130, #164). Returns `null` when the view is
+   * provably empty without SQL (Trash with no Metadata store). The clauses live
+   * in `buildFilterClauses` so every filtered read path applies one predicate.
+   */
+  function buildViewAndFilter({
     includeTrashed = false,
     projects,
     tags,
@@ -160,7 +194,7 @@ export function createChatCountsQuery({
     projects?: string[];
     tags?: string[];
     tagMode?: TagMode;
-  }): number {
+  }): { clauses: string[]; params: (string | number)[] } | null {
     const clauses: string[] = [];
     const params: (string | number)[] = [];
 
@@ -173,7 +207,7 @@ export function createChatCountsQuery({
       );
     } else if (includeTrashed) {
       // No Metadata store: nothing is trashed, so the Trash view is empty.
-      return 0;
+      return null;
     }
 
     // The Project/Tag filter is the same predicate the keyset page applies
@@ -181,18 +215,86 @@ export function createChatCountsQuery({
     const filter = buildFilterClauses({ projects, tags, tagMode, hasMetadata });
     clauses.push(...filter.clauses);
     params.push(...filter.params);
+    return { clauses, params };
+  }
+
+  function queryFilteredTotal(opts: {
+    includeTrashed?: boolean;
+    projects?: string[];
+    tags?: string[];
+    tagMode?: TagMode;
+  }): number {
+    const built = buildViewAndFilter(opts);
+    if (built === null) return 0;
+    const where =
+      built.clauses.length > 0 ? `WHERE ${built.clauses.join(" AND ")}` : "";
+    return (
+      archive
+        .prepare(`SELECT count(*) AS n FROM chats c ${where}`)
+        .get(...built.params) as { n: number }
+    ).n;
+  }
+
+  function queryFilteredIds({
+    excludeIds,
+    ...filterOpts
+  }: {
+    includeTrashed?: boolean;
+    projects?: string[];
+    tags?: string[];
+    tagMode?: TagMode;
+    excludeIds?: string[];
+  }): string[] {
+    const built = buildViewAndFilter(filterOpts);
+    if (built === null) return [];
+    const { clauses, params } = built;
+
+    // The exclusions are the rows the user unchecked after selecting all — a
+    // small `NOT IN` (ADR-0021), bound, never interpolated.
+    if (excludeIds && excludeIds.length > 0) {
+      const placeholders = excludeIds.map(() => "?").join(", ");
+      clauses.push(`c.id NOT IN (${placeholders})`);
+      params.push(...excludeIds);
+    }
 
     const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
     return (
       archive
-        .prepare(`SELECT count(*) AS n FROM chats c ${where}`)
-        .get(...params) as { n: number }
-    ).n;
+        .prepare(`SELECT c.id AS id FROM chats c ${where}`)
+        .all(...params) as { id: string }[]
+    ).map((r) => r.id);
+  }
+
+  function queryFilteredTagCounts(opts: {
+    includeTrashed?: boolean;
+    projects?: string[];
+    tags?: string[];
+    tagMode?: TagMode;
+  }): TagCount[] {
+    // No Metadata store means no tags exist at all.
+    if (!hasMetadata) return [];
+    const built = buildViewAndFilter(opts);
+    if (built === null) return [];
+    const where =
+      built.clauses.length > 0 ? `WHERE ${built.clauses.join(" AND ")}` : "";
+    // Join the filter-matched chats to their tags and group — the same shape as
+    // the view-wide facet, but scoped to the filter instead of the whole view.
+    return archive
+      .prepare(
+        `SELECT ct.tag_id AS tagId, count(*) AS count
+         FROM meta.chat_tags ct
+         JOIN chats c ON c.id = ct.chat_id
+         ${where}
+         GROUP BY ct.tag_id`
+      )
+      .all(...built.params) as TagCount[];
   }
 
   return {
     queryCounts,
     queryFilteredTotal,
+    queryFilteredIds,
+    queryFilteredTagCounts,
     close() {
       archive.close();
     },

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,53 @@
+# Design guidelines
+
+The rules we actually follow, written down as they get decided. Each entry exists because a real change forced the decision — nothing here is aspirational. If a rule and the code disagree, one of them is a bug; fix whichever is wrong rather than living with the gap. Known to be incomplete by design (see ADR-0024 for the first rules' rationale).
+
+## Vocabulary
+
+- **Emphasized action** — the one action a surface most wants you to take. At most one per surface.
+- **Quiet action** — every other action on the surface, including all exits: clear, cancel, back, dismiss.
+- **Destructive action** — deletes or discards user data. Destructive beats emphasized: a surface whose main act is deletion styles it as destructive, not emphasized.
+- **State indicator** — color used to show status (active Project, non-default sort, Tag accents), not to invite a click. Indicators are outside the action hierarchy.
+
+## Rules
+
+### 1. Text actions follow the emphasis hierarchy
+
+| Rank        | Classes                                                                                      |
+| ----------- | -------------------------------------------------------------------------------------------- |
+| Emphasized  | `text-primary hover:text-primary-hover` (+ `font-medium` when a quiet action sits beside it) |
+| Quiet       | `text-card-foreground hover:text-foreground-bright`                                          |
+| Destructive | `text-destructive`, hover per the icon-button pattern already in `ChatList`                  |
+
+Never use `--muted-foreground` for an action label: 2.42:1 on the card surface fails AA. It stays reserved for non-interactive supporting text.
+
+Exception: an inline link inside prose (the empty state's "Check Trash…") keeps `text-primary` with `hover:underline` — a color-only hover on a word mid-sentence reads as a typo.
+
+### 2. Hover brightens
+
+The theme is always dark, so brighter means more active. Hover targets are the brighter tokens (`--primary-hover`, `--foreground-bright`). Never dim with opacity (`hover:text-primary/80` and friends) — lowering opacity over a dark surface darkens the text.
+
+### 3. Colors are tokens
+
+New colors enter `web/src/index.css` as a CSS variable wired through `@theme inline`, then get used via the Tailwind utility. No inline hex in components. A palette change must stay a token remap.
+
+### 4. Text contrast clears WCAG AA
+
+Text of any size clears 4.5:1 against the surface it renders on. Measure against the actual surface (`--card` for the batch bar, `--background` for the sidebar), not a guess. Known debt: `--primary` itself sits at 4.12:1 — tracked as a palette-level issue, don't fix it per-button.
+
+## Tokens
+
+The action-facing subset of `web/src/index.css` (Solarized dark):
+
+| Token                 | Value     | Role                                     |
+| --------------------- | --------- | ---------------------------------------- |
+| `--primary`           | `#2aa198` | Emphasized actions, state indicators     |
+| `--primary-hover`     | `#35cabf` | Emphasized hover (cyan at 50% lightness) |
+| `--card-foreground`   | `#93a1a1` | Quiet actions, card body text (base1)    |
+| `--foreground-bright` | `#eee8d5` | Quiet hover (base2)                      |
+| `--muted-foreground`  | `#586e75` | Non-interactive supporting text only     |
+| `--destructive`       | `#dc322f` | Destructive actions                      |
+
+## Verifying style changes
+
+`hover:` utilities exist only after Tailwind builds. Type checks and jsdom tests pass whether or not a utility name is real, so a typo fails silently with everything green. Verify with `pnpm build` plus a grep of the emitted CSS, then hover in a live browser. The in-app browser's CDP does not raise `:hover`; use Playwright.

--- a/docs/adr/0024-action-emphasis-hierarchy.md
+++ b/docs/adr/0024-action-emphasis-hierarchy.md
@@ -1,0 +1,14 @@
+# Text actions follow an emphasis hierarchy, not per-action colors
+
+A text action's color comes from its rank in the surface it sits on, not from what the action does. Each surface gets at most one emphasized action in `--primary`; exit actions (`Clear`, `Clear selection`, `Back`) are always quiet in `--card-foreground`; destructive actions take `--destructive` regardless of rank; hover always brightens. The rules themselves live in `docs/DESIGN.md` — this ADR records why they are what they are.
+
+We first framed the rule as color-encodes-direction (forward actions teal, retreating actions gray) and rejected it before commit. Direction gives the same answer as emphasis on the surface that prompted the rule — the batch bar, where `Select all N` and `Clear` sat side by side in the same teal and had to be read to be told apart — but it bends elsewhere: a Toast's Undo is semantically a retreat yet clearly the toast's one emphasized action, and a destructive confirmation's primary action would be "forward" and therefore teal when it must be red. Emphasis handles both without exceptions, and it is the framing Material, Apple HIG, and Polaris readers already know, so future contributors and agents apply it at zero cost.
+
+Quiet actions use `--card-foreground` (Solarized base1) rather than `--muted-foreground`, the codebase's usual neutral, because muted sits at 2.42:1 on the card surface — well under the 4.5:1 WCAG AA floor for small text — while base1 clears it at 4.86:1. Hover brightens (base1 → base2, teal → `--primary-hover`) because the theme is always dark and brighter reads as more active; the previous `hover:text-primary/80` pattern dimmed instead, an artifact of lowering opacity over a dark surface rather than a design choice.
+
+## Consequences
+
+- Adding a text action asks one question — is it this surface's main act, an exit, or destructive — and `docs/DESIGN.md` maps the answer to classes. No per-button color debates.
+- The hierarchy governs actions only. `--primary` as a state indicator (active Project, non-default sort, Tag accents, the unread divider) is untouched and out of scope.
+- Trade-off, unresolved: `--primary` on dark surfaces is 4.12:1, just under AA. Every state indicator in the app reads that token, so fixing it is a palette-level decision tracked separately rather than smuggled into an action-color rule. Hover reaching 6.41:1 helps whoever already found the link, not whoever is still looking for it.
+- Trade-off: a surface with two genuinely coequal candidates for emphasis has no answer here; one of them must be demoted to quiet. So far no surface has needed two.

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2251,3 +2251,197 @@ describe("Chat list pagination", () => {
     );
   });
 });
+
+describe("Select all matching (#164)", () => {
+  // Mark two chats so the batch bar appears with a Selection smaller than the
+  // filtered total — the precondition for the `Select all N` escalation.
+  async function markTwo() {
+    const list = screen.getByTestId("chat-list");
+    await within(list).findByText("Fix database migration");
+    fireEvent.click(
+      within(list).getByText("Build a login page").closest("button")!,
+      { metaKey: true }
+    );
+    fireEvent.click(
+      within(list).getByText("Fix database migration").closest("button")!,
+      { metaKey: true }
+    );
+    return within(await screen.findByTestId("batch-bar"));
+  }
+
+  it("escalates the Selection to every matching chat and says so", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const bar = await markTwo();
+    expect(bar.getByText("2 selected")).toBeInTheDocument();
+
+    await user.click(bar.getByRole("button", { name: /Select all 4/ }));
+
+    // The count now stands for the filtered total, and a banner states the mode.
+    expect(await screen.findByText("4 selected")).toBeInTheDocument();
+    const banner = await screen.findByTestId("select-all-banner");
+    expect(banner).toHaveTextContent(
+      "All 4 chats matching this filter are selected"
+    );
+    // Nothing left to escalate to, so the link retires.
+    expect(
+      screen.queryByRole("button", { name: /Select all/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it("sends the live filter as the batch target, not the marked ids", async () => {
+    const user = userEvent.setup();
+    const bodies: unknown[] = [];
+    server.use(
+      http.post("/api/chats/batch/trash", async ({ request }) => {
+        bodies.push(await request.json());
+        return HttpResponse.json({ count: 4 });
+      })
+    );
+    render(<App />);
+
+    const bar = await markTwo();
+    await user.click(bar.getByRole("button", { name: /Select all 4/ }));
+    await screen.findByText("4 selected");
+    await user.click(
+      within(await screen.findByTestId("batch-bar")).getByRole("button", {
+        name: /Move to Trash/i,
+      })
+    );
+
+    // The ids are never sent — the server re-resolves the filter, so the write
+    // cannot drift from what the list matched (ADR-0021).
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(bodies[0]).toEqual({
+      filter: {
+        projects: [],
+        tags: [],
+        tagMode: "all",
+        includeTrashed: false,
+      },
+      excludeIds: [],
+    });
+  });
+
+  it("sends a chat unmarked after the escalation as an exclusion", async () => {
+    const user = userEvent.setup();
+    const bodies: unknown[] = [];
+    server.use(
+      http.post("/api/chats/batch/trash", async ({ request }) => {
+        bodies.push(await request.json());
+        return HttpResponse.json({ count: 3 });
+      })
+    );
+    render(<App />);
+
+    const list = screen.getByTestId("chat-list");
+    const bar = await markTwo();
+    await user.click(bar.getByRole("button", { name: /Select all 4/ }));
+    await screen.findByText("4 selected");
+
+    // Cmd+click under select-all-matching excludes rather than deselects.
+    fireEvent.click(
+      within(list).getByText("Refactor utils").closest("button")!,
+      { metaKey: true }
+    );
+    expect(await screen.findByText("3 selected")).toBeInTheDocument();
+
+    await user.click(
+      within(await screen.findByTestId("batch-bar")).getByRole("button", {
+        name: /Move to Trash/i,
+      })
+    );
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(bodies[0]).toMatchObject({ excludeIds: ["chat-3"] });
+  });
+
+  it("optimistically drops every loaded row the escalation covers", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const list = screen.getByTestId("chat-list");
+    const bar = await markTwo();
+    await user.click(bar.getByRole("button", { name: /Select all 4/ }));
+    await screen.findByText("4 selected");
+    await user.click(
+      within(await screen.findByTestId("batch-bar")).getByRole("button", {
+        name: /Move to Trash/i,
+      })
+    );
+
+    // "Refactor utils" was never Cmd+clicked, but the escalation covers it.
+    await waitFor(() => {
+      expect(
+        within(list).queryByText("Refactor utils")
+      ).not.toBeInTheDocument();
+      expect(
+        within(list).queryByText("Build a login page")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("leaves the mode via Clear", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const bar = await markTwo();
+    await user.click(bar.getByRole("button", { name: /Select all 4/ }));
+    await screen.findByTestId("select-all-banner");
+
+    await user.click(
+      within(await screen.findByTestId("batch-bar")).getByRole("button", {
+        name: /^Clear$/,
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("select-all-banner")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("batch-bar")).not.toBeInTheDocument();
+    });
+  });
+
+  it("derives batch tag tri-state from server-side filtered counts", async () => {
+    const user = userEvent.setup();
+    seedTags([
+      { id: "tag-bug", name: "bug", color: "red" },
+      { id: "tag-idea", name: "idea", color: "violet" },
+    ]);
+    // bug on every main-list chat → all; idea on one → some.
+    seedChatTags({
+      "chat-1": ["tag-bug"],
+      "chat-2": ["tag-bug"],
+      "chat-3": ["tag-bug", "tag-idea"],
+      "chat-missing": ["tag-bug"],
+    });
+    render(<App />);
+
+    const bar = await markTwo();
+    await user.click(bar.getByRole("button", { name: /Select all 4/ }));
+    await screen.findByText("4 selected");
+
+    await user.click(
+      within(await screen.findByTestId("batch-bar")).getByRole("button", {
+        name: /Add\/Remove Tag/i,
+      })
+    );
+
+    // The client holds no ids here — the state comes from filtered-tag-counts.
+    const dialog = await screen.findByTestId("tag-picker-dialog");
+    await waitFor(() => {
+      expect(
+        dialog
+          .querySelector('[data-tag-id="tag-bug"]')!
+          .querySelector('[role="checkbox"]')!
+          .getAttribute("aria-checked")
+      ).toBe("true");
+    });
+    expect(
+      dialog
+        .querySelector('[data-tag-id="tag-idea"]')!
+        .querySelector('[role="checkbox"]')!
+        .getAttribute("aria-checked")
+    ).toBe("mixed");
+  });
+});

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2281,9 +2281,7 @@ describe("Select all matching (#164)", () => {
     // The count now stands for the filtered total, and a banner states the mode.
     expect(await screen.findByText("4 selected")).toBeInTheDocument();
     const banner = await screen.findByTestId("select-all-banner");
-    expect(banner).toHaveTextContent(
-      "All 4 chats matching this filter are selected"
-    );
+    expect(banner).toHaveTextContent("All 4 chats are selected");
     // Nothing left to escalate to, so the link retires.
     expect(
       screen.queryByRole("button", { name: /Select all/ })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,7 @@ import { FilterPanel } from "@/chat/FilterPanel";
 import { ChatList } from "@/chat/ChatList";
 import { BatchTagButton } from "@/tags/BatchTagButton";
 import { useSelection } from "@/chat/useSelection";
+import type { BatchTarget } from "@/chat/batchTarget";
 import { SortControl } from "@/chat/sort/SortControl";
 import { ConversationView } from "@/conversation/ConversationView";
 import { Toast } from "@/shared/Toast";
@@ -213,10 +214,37 @@ function App() {
   // set). Range selection walks the visible order.
   const visibleIds = visibleChats.map((c) => c.id);
   const selectionResetKey = `${mode}:${[...selectedProjects].sort().join(",")}:${[...selectedTags].sort().join(",")}:${tagMode.mode}`;
+
+  // The "Chats N" header total: server-derived in both cases. Unfiltered, it is
+  // the view's facet total (#131 Phase A); filtered, it is the server's
+  // post-filter count (#131 Phase B) — accurate even when the paginated window
+  // holds only a page of the filtered set. Computed here (above the Selection) so
+  // select-all-matching can count the whole matching set, not the loaded window.
+  const filterActive = selectedProjects.size + selectedTags.size > 0;
+  const filteredTotal = useFilteredTotal(
+    mode,
+    [...selectedProjects],
+    [...selectedTags],
+    tagMode.mode
+  );
+  // While the first filtered total is still loading (filteredTotal undefined),
+  // hold the view's facet total rather than letting the header fall back to the
+  // paginated window count (the page size) — that would flash a wrong number
+  // for a frame before the real filtered total lands (#131).
+  const listTotal = filterActive
+    ? (filteredTotal ?? counts.counts.total)
+    : counts.counts.total;
+
+  // The Selection (batch Move to Trash, #161) with the Open Chat as its primary
+  // member. Keyed to filter + view so it re-seeds to the primary on a filter
+  // change or view switch but rides sort changes and background refreshes (an id
+  // set). Range selection walks the visible order. `filteredTotal` lets select-
+  // all-matching (#164) count every matching Chat, not just the loaded window.
   const selection = useSelection({
     orderedIds: visibleIds,
     primaryId: selectedId,
     resetKey: selectionResetKey,
+    filteredTotal: listTotal,
   });
 
   // Open a Chat: it becomes the Open Chat and the sole Selection (a plain click
@@ -273,30 +301,75 @@ function App() {
     else selection.clear();
   }, [selectedId, selection]);
 
+  // The batch target for the current Selection (ADR-0021): the live filter plus
+  // exclusions under select-all-matching (#164), else the explicit checked ids
+  // (#161). Its shape is the request body both batch endpoints accept.
+  const currentBatchTarget = useCallback((): BatchTarget => {
+    if (selection.allMatching) {
+      return {
+        filter: {
+          projects: [...selectedProjects],
+          tags: [...selectedTags],
+          tagMode: tagMode.mode,
+          includeTrashed: mode === "trash",
+        },
+        excludeIds: [...selection.excludeIds],
+      };
+    }
+    return { chatIds: [...selection.selectedIds] };
+  }, [selection, selectedProjects, selectedTags, tagMode.mode, mode]);
+
+  // The loaded rows to flip optimistically: under select-all only the visible,
+  // non-excluded window (the server still acts on the whole matching set); in
+  // explicit mode the checked ids themselves.
+  const selectionOptimisticIds = useCallback(
+    () =>
+      selection.allMatching
+        ? visibleIds.filter((id) => selection.isSelected(id))
+        : [...selection.selectedIds],
+    [selection, visibleIds]
+  );
+
+  // Per-Tag counts scoped to the active filter (#164), for the batch dialog's
+  // tri-state under select-all-matching — the client subtracts the excluded
+  // Chats' own Tags locally (ADR-0021). Mirrors useFilteredTotal's URL shape.
+  const fetchFilteredTagCounts = useCallback(async () => {
+    const params = new URLSearchParams();
+    if (mode === "trash") params.set("includeTrashed", "true");
+    for (const p of selectedProjects) params.append("project", p);
+    if (selectedTags.size > 0) params.set("tags", [...selectedTags].join(","));
+    if (tagMode.mode === "any") params.set("tagMode", "any");
+    try {
+      const res = await fetch(
+        `/api/chats/filtered-tag-counts?${params.toString()}`
+      );
+      if (!res.ok) return [];
+      const { tags } = (await res.json()) as {
+        tags: Array<{ tagId: string; count: number }>;
+      };
+      return tags;
+    } catch {
+      return [];
+    }
+  }, [mode, selectedProjects, selectedTags, tagMode.mode]);
+
+  // The Tag ids held by each excluded, currently-loaded Chat — subtracted from
+  // the filtered per-Tag counts so the dialog's tri-state reflects the live
+  // Selection under select-all-matching (#164).
+  const excludedChatTags = useMemo(
+    () =>
+      visibleChats
+        .filter((c) => selection.excludeIds.has(c.id))
+        .map((c) => (c.tags ?? []).map((t) => t.id)),
+    [visibleChats, selection.excludeIds]
+  );
+
   // Tag and Untagged counts are server-derived per view (main vs Trash). They
   // state each group's size in this view, not the post-filter result, so
   // selecting a Tag never moves the numbers.
   const countForTag = counts.tagCount;
   const untaggedCount = counts.counts.untagged;
 
-  // The "Chats N" header total: server-derived in both cases. Unfiltered, it is
-  // the view's facet total (#131 Phase A); filtered, it is the server's
-  // post-filter count (#131 Phase B) — accurate even when the paginated window
-  // holds only a page of the filtered set.
-  const filterActive = selectedProjects.size + selectedTags.size > 0;
-  const filteredTotal = useFilteredTotal(
-    mode,
-    [...selectedProjects],
-    [...selectedTags],
-    tagMode.mode
-  );
-  // While the first filtered total is still loading (filteredTotal undefined),
-  // hold the view's facet total rather than letting the header fall back to the
-  // paginated window count (the page size) — that would flash a wrong number
-  // for a frame before the real filtered total lands (#131).
-  const listTotal = filterActive
-    ? (filteredTotal ?? counts.counts.total)
-    : counts.counts.total;
   // Create a Tag and immediately assign it to the chat the popover is on.
   const createTagForChat = useCallback(
     async (
@@ -353,17 +426,21 @@ function App() {
     });
   };
 
-  // Batch Move to Trash over the Selection (#161). One request flips the whole
-  // set (ADR-0021 explicit-ids branch); the client reloads its window and the
-  // facet counts rather than mutating rows in place, then raises an Undo toast
-  // whose inverse is a batch restore. Selection clears immediately so the bar
-  // dismisses without waiting on the round-trip.
+  // Batch Move to Trash over the Selection (#161, #164). One request flips the
+  // whole target — the checked ids or the live filter minus exclusions (ADR-
+  // 0021); the client optimistically drops the loaded window's rows, reloads the
+  // facet counts, and raises an Undo toast whose inverse is a batch restore.
+  // Selection clears immediately so the bar dismisses without waiting on the
+  // round-trip.
   const handleBatchTrash = () => {
-    const chatIds = [...selection.selectedIds];
-    if (chatIds.length === 0) return;
+    const n = selection.selectedCount;
+    if (n === 0) return;
+    const target = currentBatchTarget();
+    const optimisticIds = selectionOptimisticIds();
     // The batch trashes the primary too, so move the Open Chat to the first
-    // surviving row (or empty), then collapse the Selection.
-    const trashed = new Set(chatIds);
+    // surviving (visible, non-trashed) row (or empty), then collapse the
+    // Selection.
+    const trashed = new Set(optimisticIds);
     const nextOpen = visibleIds.find((x) => !trashed.has(x)) ?? null;
     setSelectedId(nextOpen);
     selection.clear();
@@ -371,29 +448,28 @@ function App() {
       void counts.reload();
       void trashCounts.reload();
     };
-    void softDeleteBatch(chatIds);
+    void softDeleteBatch(target, optimisticIds);
     refreshCounts();
-    const n = chatIds.length;
     showToast({
-      message: `${n} chat${n > 1 ? "s" : ""} moved to Trash.`,
+      message: `${n.toLocaleString()} chat${n > 1 ? "s" : ""} moved to Trash.`,
       actionLabel: "Undo",
       actionHint: modifierHint("Z"),
       onAction: () => {
-        void restoreBatch(chatIds);
+        void restoreBatch(target, optimisticIds);
         refreshCounts();
       },
     });
   };
 
-  // Apply the staged batch Tag diff over the Selection (#163). One request
-  // carries the add/remove diff (ADR-0021 explicit-ids branch), then the
-  // drop-reconcile reload (#176) drops any Chat the change moved out of an active
-  // filter. That reload reports which ids left the list, so the Selection prunes
-  // to exactly those — it never dangles on Chats you can no longer see, and a
-  // Chat merely scrolled out of the window (not a drop) is untouched.
+  // Apply the staged batch Tag diff over the Selection (#163, #164). One request
+  // carries the target + add/remove diff (ADR-0021), then the drop-reconcile
+  // reload (#176) drops any Chat the change moved out of an active filter. That
+  // reload reports which ids left the list, so the Selection prunes to exactly
+  // those — it never dangles on Chats you can no longer see, and a Chat merely
+  // scrolled out of the window (not a drop) is untouched.
   const applyBatchTag = useCallback(
-    async (chatIds: string[], diff: { add: string[]; remove: string[] }) => {
-      await assignTagsBatch(chatIds, diff);
+    async (target: BatchTarget, diff: { add: string[]; remove: string[] }) => {
+      await assignTagsBatch(target, diff);
       const dropped = await reload();
       void reloadCounts();
       if (dropped.length > 0) selection.deselect(dropped);
@@ -403,19 +479,18 @@ function App() {
 
   // The Undo toast replays the inverse diff (add↔remove) through the same path.
   const handleBatchTag = (
-    chatIds: string[],
+    target: BatchTarget,
     diff: { add: string[]; remove: string[] }
   ) => {
-    if (chatIds.length === 0) return;
     if (diff.add.length === 0 && diff.remove.length === 0) return;
-    void applyBatchTag(chatIds, diff);
-    const n = chatIds.length;
+    const n = selection.selectedCount;
+    void applyBatchTag(target, diff);
     showToast({
-      message: `Tags updated on ${n} chat${n > 1 ? "s" : ""}.`,
+      message: `Tags updated on ${n.toLocaleString()} chat${n > 1 ? "s" : ""}.`,
       actionLabel: "Undo",
       actionHint: modifierHint("Z"),
       onAction: () => {
-        void applyBatchTag(chatIds, { add: diff.remove, remove: diff.add });
+        void applyBatchTag(target, { add: diff.remove, remove: diff.add });
       },
     });
   };
@@ -473,6 +548,21 @@ function App() {
         e.preventDefault();
         toast.onAction();
         dismissToast();
+        return;
+      }
+
+      // Cmd/Ctrl+A selects every Chat matching the current filter (#164) — the
+      // keyboard entry into select-all-matching, alongside the batch bar's
+      // `Select all N` link. Only in the main list, where selection lives.
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        (e.key === "a" || e.key === "A") &&
+        mode === "main" &&
+        visibleIds.length > 0
+      ) {
+        e.preventDefault();
+        selection.selectAllMatching();
+        return;
       }
     };
     window.addEventListener("keydown", handler);
@@ -524,6 +614,11 @@ function App() {
             hasPrevious={source.hasPrevious}
             onLoadPrevious={source.loadPrevious}
             selectedIds={selection.selectedIds}
+            isSelected={selection.isSelected}
+            selectedCount={selection.selectedCount}
+            allMatching={selection.allMatching}
+            filteredTotal={listTotal}
+            onSelectAllMatching={selection.selectAllMatching}
             onToggleSelect={toggleSelect}
             onRangeSelect={rangeSelect}
             onClearSelection={clearSelection}
@@ -533,6 +628,11 @@ function App() {
                 selectedIds={selection.selectedIds}
                 allTags={tagCatalog}
                 fetchTagsByChat={fetchTagsByChat}
+                allMatching={selection.allMatching}
+                selectedCount={selection.selectedCount}
+                batchTarget={currentBatchTarget()}
+                fetchFilteredTagCounts={fetchFilteredTagCounts}
+                excludedChatTags={excludedChatTags}
                 onApply={handleBatchTag}
                 onCreate={createTag}
               />

--- a/web/src/chat/ChatList.tsx
+++ b/web/src/chat/ChatList.tsx
@@ -60,6 +60,26 @@ interface ChatListProps {
    * batch bar appears once at least one Chat is marked.
    */
   selectedIds?: ReadonlySet<string>;
+  /**
+   * Whether a row renders as selected — the Selection's own predicate, so the
+   * list doesn't branch on select-all-matching (#164). Falls back to
+   * `selectedIds` membership when absent.
+   */
+  isSelected?: (id: string) => boolean;
+  /**
+   * The effective count of marked Chats: the plain Selection size, or the
+   * filtered total minus exclusions under select-all-matching (#164). Drives the
+   * batch bar's count and, with `filteredTotal`, the `Select all N` link.
+   */
+  selectedCount?: number;
+  /** True while select-all-matching is active (#164): the banner shows and the
+   * batch bar stays up even as exclusions shrink the visible Selection. */
+  allMatching?: boolean;
+  /** How many Chats match the current filter across the whole store (#131), for
+   * the `Select all N` escalation link and the banner total. */
+  filteredTotal?: number;
+  /** Enter select-all-matching — the batch bar's `Select all N` link (#164). */
+  onSelectAllMatching?: () => void;
   /** `Cmd`/`Ctrl`+click on a row: toggle that Chat's Selection membership. */
   onToggleSelect?: (id: string) => void;
   /**
@@ -182,6 +202,11 @@ export function ChatList({
   hasPrevious = false,
   onLoadPrevious,
   selectedIds,
+  isSelected,
+  selectedCount,
+  allMatching = false,
+  filteredTotal,
+  onSelectAllMatching,
   onToggleSelect,
   onRangeSelect,
   onClearSelection,
@@ -370,6 +395,24 @@ export function ChatList({
   // #161); the Trash view's batch Restore is a later issue.
   const selectionEnabled = !!onToggleSelect && !isTrash;
   const selectionCount = selectedIds?.size ?? 0;
+  // A row renders as selected via the Selection's own predicate (so select-all-
+  // matching stays out of the list's logic), falling back to plain membership.
+  const rowSelected = (id: string) =>
+    isSelected ? isSelected(id) : (selectedIds?.has(id) ?? false);
+  // The count the batch bar shows and the escalation link compares against: the
+  // effective Selection size (filtered total minus exclusions under select-all).
+  const barCount = selectedCount ?? selectionCount;
+  // The batch bar is up for a real multi-selection or whenever select-all-
+  // matching is active (exclusions can shrink the visible set below two).
+  const batchBarVisible =
+    selectionEnabled && (allMatching || selectionCount >= 2);
+  // The `Select all N` escalation appears once a Selection exists and there are
+  // more matching Chats than are currently marked (#164).
+  const canSelectAll =
+    !allMatching &&
+    !!onSelectAllMatching &&
+    filteredTotal !== undefined &&
+    barCount < filteredTotal;
 
   // A plain row-body click opens the Chat (collapsing the Selection to it); a
   // modifier click is a Selection gesture instead. Shift takes precedence so
@@ -398,7 +441,7 @@ export function ChatList({
   // multi-selection (≥ 2) so a lone Open Chat's Esc still falls through to the
   // app-level handler (Trash → main).
   useEffect(() => {
-    if (selectionCount < 2 || !onClearSelection) return;
+    if ((selectionCount < 2 && !allMatching) || !onClearSelection) return;
     const onEsc = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.stopPropagation();
@@ -408,7 +451,7 @@ export function ChatList({
     // Capture so the Selection clears before App's global Esc (view switch).
     window.addEventListener("keydown", onEsc, true);
     return () => window.removeEventListener("keydown", onEsc, true);
-  }, [selectionCount, onClearSelection]);
+  }, [selectionCount, allMatching, onClearSelection]);
 
   return (
     <div data-testid="chat-list" className="relative flex h-full flex-col">
@@ -442,6 +485,25 @@ export function ChatList({
           </>
         )}
       </div>
+      {allMatching && (
+        <div
+          data-testid="select-all-banner"
+          className="flex shrink-0 items-center justify-center gap-2 border-b border-border bg-[#00222b] px-4 py-2 text-center text-xs text-muted-foreground"
+        >
+          <span>
+            {filteredTotal !== undefined && barCount < filteredTotal
+              ? `${barCount.toLocaleString()} chats matching this filter are selected`
+              : `All ${barCount.toLocaleString()} chats matching this filter are selected`}
+          </span>
+          <button
+            type="button"
+            onClick={() => onClearSelection?.()}
+            className="text-card-foreground transition-colors hover:text-foreground-bright"
+          >
+            Clear selection
+          </button>
+        </div>
+      )}
       <div
         ref={scrollContainerRef}
         data-testid="chat-scroll"
@@ -487,7 +549,7 @@ export function ChatList({
             onClick={(e) => {
               if (
                 selectionEnabled &&
-                selectionCount >= 2 &&
+                (selectionCount >= 2 || allMatching) &&
                 e.target === e.currentTarget
               ) {
                 onClearSelection?.();
@@ -498,7 +560,7 @@ export function ChatList({
               const chat = chats[virtualItem.index];
               const isSelected = chat.id === selectedId;
               const isCursor = chat.id === cursorId;
-              const isInSelection = selectedIds?.has(chat.id) ?? false;
+              const isInSelection = rowSelected(chat.id);
               // Two-tier highlight: the primary (Open Chat, or the Cursor before
               // its debounced open lands) wears the strong accent — left primary
               // border + fill — exactly like a clicked row. A Selection member
@@ -684,14 +746,14 @@ export function ChatList({
           }
         />
       )}
-      {selectionEnabled && selectionCount >= 2 && (
+      {batchBarVisible && (
         <div
           data-testid="batch-bar"
           className="absolute inset-x-4 bottom-4 z-20 flex items-center justify-between gap-3 rounded-lg border border-border bg-card px-3 py-2 text-sm shadow-lg"
         >
           <span className="flex items-center gap-3">
             <span className="font-medium tabular-nums text-accent-foreground">
-              {selectionCount} selected
+              {barCount.toLocaleString()} selected
             </span>
             {/* Batch Tag (#163) and Move to Trash join into one segmented
                 control — recessed chips sharing a single divider (#215) — set
@@ -720,14 +782,27 @@ export function ChatList({
               </span>
             </span>
           </span>
-          {/* Matches the filter panel's "Clear" — a plain primary text link. */}
-          <button
-            type="button"
-            onClick={() => onClearSelection?.()}
-            className="text-xs text-primary transition-colors hover:text-primary/80"
-          >
-            Clear
-          </button>
+          <span className="flex items-center gap-3">
+            {/* Escalate the Selection to every matching Chat (#164). Appears once
+                a Selection exists and more Chats match than are marked. */}
+            {canSelectAll && filteredTotal !== undefined && (
+              <button
+                type="button"
+                onClick={() => onSelectAllMatching?.()}
+                className="text-xs font-medium text-primary transition-colors hover:text-primary-hover"
+              >
+                Select all {filteredTotal.toLocaleString()}
+              </button>
+            )}
+            {/* Matches the filter panel's "Clear" — a plain primary text link. */}
+            <button
+              type="button"
+              onClick={() => onClearSelection?.()}
+              className="text-xs text-primary transition-colors hover:text-primary/80"
+            >
+              Clear
+            </button>
+          </span>
         </div>
       )}
     </div>

--- a/web/src/chat/ChatList.tsx
+++ b/web/src/chat/ChatList.tsx
@@ -461,7 +461,7 @@ export function ChatList({
             <button
               type="button"
               onClick={onBack}
-              className="flex items-center gap-1 text-xs text-primary transition-colors hover:text-primary/80"
+              className="flex items-center gap-1 text-xs text-card-foreground transition-colors hover:text-foreground-bright"
             >
               <ArrowLeft size={14} aria-hidden="true" />
               Back
@@ -794,11 +794,13 @@ export function ChatList({
                 Select all {filteredTotal.toLocaleString()}
               </button>
             )}
-            {/* Matches the filter panel's "Clear" — a plain primary text link. */}
+            {/* Clear is the escape hatch (also on Esc), so it stays neutral and
+                lets the primary-toned escalation next to it carry the weight.
+                base1 over the card clears 4.5:1; muted-foreground would not. */}
             <button
               type="button"
               onClick={() => onClearSelection?.()}
-              className="text-xs text-primary transition-colors hover:text-primary/80"
+              className="text-xs text-card-foreground transition-colors hover:text-foreground-bright"
             >
               Clear
             </button>

--- a/web/src/chat/ChatList.tsx
+++ b/web/src/chat/ChatList.tsx
@@ -492,8 +492,8 @@ export function ChatList({
         >
           <span>
             {filteredTotal !== undefined && barCount < filteredTotal
-              ? `${barCount.toLocaleString()} chats matching this filter are selected`
-              : `All ${barCount.toLocaleString()} chats matching this filter are selected`}
+              ? `${barCount.toLocaleString()} chats are selected`
+              : `All ${barCount.toLocaleString()} chats are selected`}
           </span>
           <button
             type="button"

--- a/web/src/chat/FilterSummary.tsx
+++ b/web/src/chat/FilterSummary.tsx
@@ -22,7 +22,7 @@ export function FilterSummary({ activeCount, onClear }: FilterSummaryProps) {
         type="button"
         data-testid="filters-clear"
         onClick={onClear}
-        className="text-primary transition-colors hover:text-primary/80"
+        className="text-card-foreground transition-colors hover:text-foreground-bright"
       >
         Clear
       </button>

--- a/web/src/chat/batchTarget.ts
+++ b/web/src/chat/batchTarget.ts
@@ -1,0 +1,24 @@
+import type { TagMode } from "@/tags/tagModePreference";
+
+/**
+ * The Project/Tag/view filter a select-all-matching batch targets (#164), the
+ * wire shape the server resolves through `buildFilterClauses` (ADR-0021). An
+ * empty-string Tag entry is the `Untagged` marker; `includeTrashed` scopes it to
+ * the Trash view.
+ */
+export interface BatchFilter {
+  projects?: string[];
+  tags?: string[];
+  tagMode?: TagMode;
+  includeTrashed?: boolean;
+}
+
+/**
+ * What a batch action targets: either the explicit ids the user checked (#161),
+ * or every Chat matching the filter minus a small exclusion set (#164). The
+ * object doubles as the request body — the server discriminates on the presence
+ * of `chatIds` vs `filter` (ADR-0021).
+ */
+export type BatchTarget =
+  | { chatIds: string[] }
+  | { filter: BatchFilter; excludeIds: string[] };

--- a/web/src/chat/useChatMutations.ts
+++ b/web/src/chat/useChatMutations.ts
@@ -1,17 +1,22 @@
 import { useCallback } from "react";
 import type { Chat } from "@/types";
+import type { BatchTarget } from "@/chat/batchTarget";
 
 export interface ChatMutations {
   softDelete: (id: string) => Promise<void>;
   restore: (id: string) => Promise<void>;
   setTitle: (id: string, title: string) => Promise<void>;
-  // Batch Move to Trash / Restore over the Selection (#161). Each applies one
-  // optimistic pass over the id set — so the trashed rows leave (or return to)
-  // the list at once — then fires a single batch request (ADR-0021 explicit-ids
-  // branch). The optimistic pass is what removes the rows: the window refresh
-  // only grows, never drops, so a reload alone would keep the trashed rows.
-  softDeleteBatch: (ids: string[]) => Promise<void>;
-  restoreBatch: (ids: string[]) => Promise<void>;
+  // Batch Move to Trash / Restore over the Selection (#161, #164). The request
+  // targets either the checked ids or the live filter minus exclusions (ADR-
+  // 0021); `optimisticIds` are the loaded rows to flip locally so they leave (or
+  // return to) the list at once — the window refresh only grows, never drops, so
+  // a reload alone would keep the trashed rows. Under select-all-matching the
+  // server acts on the whole matching set; the optimism only covers the window.
+  softDeleteBatch: (
+    target: BatchTarget,
+    optimisticIds: string[]
+  ) => Promise<void>;
+  restoreBatch: (target: BatchTarget, optimisticIds: string[]) => Promise<void>;
 }
 
 // The shared shape both chat-list read hooks expose: the loaded chats plus the
@@ -103,9 +108,9 @@ export function useChatMutations(
   );
 
   const softDeleteBatch = useCallback(
-    async (ids: string[]) => {
-      if (ids.length === 0) return;
-      const idSet = new Set(ids);
+    async (target: BatchTarget, optimisticIds: string[]) => {
+      if ("chatIds" in target && target.chatIds.length === 0) return;
+      const idSet = new Set(optimisticIds);
       const now = Date.now();
       setChats((prev) =>
         prev.map((c) =>
@@ -116,16 +121,16 @@ export function useChatMutations(
       await fetch("/api/chats/batch/trash", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ chatIds: ids }),
+        body: JSON.stringify(target),
       });
     },
     [setChats, bumpEpoch]
   );
 
   const restoreBatch = useCallback(
-    async (ids: string[]) => {
-      if (ids.length === 0) return;
-      const idSet = new Set(ids);
+    async (target: BatchTarget, optimisticIds: string[]) => {
+      if ("chatIds" in target && target.chatIds.length === 0) return;
+      const idSet = new Set(optimisticIds);
       setChats((prev) =>
         prev.map((c) =>
           idSet.has(c.id) ? { ...c, isDeleted: false, deletedAt: null } : c
@@ -135,7 +140,7 @@ export function useChatMutations(
       await fetch("/api/chats/batch/restore", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ chatIds: ids }),
+        body: JSON.stringify(target),
       });
     },
     [setChats, bumpEpoch]

--- a/web/src/chat/useSelection.test.tsx
+++ b/web/src/chat/useSelection.test.tsx
@@ -116,3 +116,93 @@ describe("useSelection", () => {
     expect([...result.current.selectedIds]).toEqual([]);
   });
 });
+
+describe("useSelection — select-all-matching (#164)", () => {
+  it("enters select-all-matching, counting the whole filtered total", () => {
+    const { result } = renderHook(() =>
+      useSelection({
+        orderedIds: ORDER,
+        primaryId: null,
+        resetKey: "k",
+        filteredTotal: 1234,
+      })
+    );
+
+    expect(result.current.allMatching).toBe(false);
+
+    act(() => result.current.selectAllMatching());
+
+    expect(result.current.allMatching).toBe(true);
+    // The count is the whole matching set, not just the loaded window.
+    expect(result.current.selectedCount).toBe(1234);
+    // Every visible row reads as selected.
+    expect(result.current.isSelected("a")).toBe(true);
+    expect([...result.current.excludeIds]).toEqual([]);
+  });
+
+  it("toggling under select-all records and clears exclusions", () => {
+    const { result } = renderHook(() =>
+      useSelection({
+        orderedIds: ORDER,
+        primaryId: null,
+        resetKey: "k",
+        filteredTotal: 10,
+      })
+    );
+
+    act(() => result.current.selectAllMatching());
+
+    // A toggle deselects one matching row: it lands in excludeIds.
+    act(() => result.current.toggle("b"));
+    expect([...result.current.excludeIds]).toEqual(["b"]);
+    expect(result.current.isSelected("b")).toBe(false);
+    expect(result.current.isSelected("a")).toBe(true);
+    expect(result.current.selectedCount).toBe(9);
+
+    // A second toggle re-selects it: the exclusion clears.
+    act(() => result.current.toggle("b"));
+    expect([...result.current.excludeIds]).toEqual([]);
+    expect(result.current.isSelected("b")).toBe(true);
+    expect(result.current.selectedCount).toBe(10);
+  });
+
+  it("leaves select-all-matching on clear()", () => {
+    const { result } = renderHook(() =>
+      useSelection({
+        orderedIds: ORDER,
+        primaryId: null,
+        resetKey: "k",
+        filteredTotal: 10,
+      })
+    );
+
+    act(() => result.current.selectAllMatching());
+    act(() => result.current.toggle("b"));
+    act(() => result.current.clear());
+
+    expect(result.current.allMatching).toBe(false);
+    expect([...result.current.excludeIds]).toEqual([]);
+    expect(result.current.selectedCount).toBe(0);
+  });
+
+  it("leaves select-all-matching when the filter/view resetKey changes", () => {
+    const { result, rerender } = renderHook(
+      ({ resetKey }) =>
+        useSelection({
+          orderedIds: ORDER,
+          primaryId: null,
+          resetKey,
+          filteredTotal: 10,
+        }),
+      { initialProps: { resetKey: "k1" } }
+    );
+
+    act(() => result.current.selectAllMatching());
+    act(() => result.current.toggle("b"));
+
+    rerender({ resetKey: "k2" });
+
+    expect(result.current.allMatching).toBe(false);
+    expect([...result.current.excludeIds]).toEqual([]);
+  });
+});

--- a/web/src/chat/useSelection.test.tsx
+++ b/web/src/chat/useSelection.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { act, renderHook } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { useSelection } from "@/chat/useSelection";
@@ -5,6 +6,23 @@ import { useSelection } from "@/chat/useSelection";
 const ORDER = ["a", "b", "c", "d", "e"];
 
 describe("useSelection", () => {
+  // The app mounts under StrictMode, which double-invokes state updaters to
+  // surface side effects hidden inside them. Every other test here renders
+  // bare, so a toggle that writes other state from inside an updater passes
+  // them and still does nothing in the real app (#164).
+  it("toggles under StrictMode, where updaters run twice", () => {
+    const { result } = renderHook(
+      () => useSelection({ orderedIds: ORDER, primaryId: null, resetKey: "k" }),
+      { wrapper: StrictMode }
+    );
+
+    act(() => result.current.toggle("b"));
+    expect([...result.current.selectedIds]).toEqual(["b"]);
+
+    act(() => result.current.toggle("b"));
+    expect([...result.current.selectedIds]).toEqual([]);
+  });
+
   it("collapses to a single id on selectOnly", () => {
     const { result } = renderHook(() =>
       useSelection({ orderedIds: ORDER, primaryId: null, resetKey: "k" })

--- a/web/src/chat/useSelection.ts
+++ b/web/src/chat/useSelection.ts
@@ -19,6 +19,12 @@ interface UseSelectionParams {
    * it holds steady (sort change, background refresh) — see CONTEXT.md, #161.
    */
   resetKey: string;
+  /**
+   * How many Chats match the current filter across the whole store, not just the
+   * loaded window (#131). Under select-all-matching the effective count is this
+   * total minus the excluded rows; defaults to 0 when unknown.
+   */
+  filteredTotal?: number;
 }
 
 export interface Selection {
@@ -48,6 +54,31 @@ export interface Selection {
    * Chats you can no longer see (#163). A no-op for ids not currently selected.
    */
   deselect: (ids: Iterable<string>) => void;
+  /**
+   * Enter select-all-matching (#164): every Chat matching the current filter is
+   * marked, expressed as "all minus `excludeIds`" rather than an id list the
+   * client cannot enumerate (ADR-0021). A plain click, a range, `clear`, or a
+   * filter/view change all leave the mode.
+   */
+  selectAllMatching: () => void;
+  /** True while in select-all-matching mode. */
+  allMatching: boolean;
+  /**
+   * The rows the user unchecked after selecting all (`Cmd/Ctrl+click`), the
+   * "all matching except these" set. Empty and inert outside select-all-matching.
+   */
+  excludeIds: ReadonlySet<string>;
+  /**
+   * The effective number of marked Chats: the plain Selection size normally, or
+   * the filtered total minus exclusions under select-all-matching.
+   */
+  selectedCount: number;
+  /**
+   * Whether a row renders as selected — membership in the Selection normally, or
+   * "not excluded" under select-all-matching. The one predicate the list rows
+   * read so they don't branch on the mode themselves.
+   */
+  isSelected: (id: string) => boolean;
 }
 
 /**
@@ -59,35 +90,72 @@ export function useSelection({
   orderedIds,
   primaryId,
   resetKey,
+  filteredTotal = 0,
 }: UseSelectionParams): Selection {
   const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(() =>
     primaryId ? new Set([primaryId]) : new Set()
   );
+  // Select-all-matching (#164): the mode flag plus its "all minus these"
+  // exclusion set. Both are inert until `selectAllMatching` turns the mode on.
+  const [allMatching, setAllMatching] = useState(false);
+  const [excludeIds, setExcludeIds] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
 
   // Collapse to the primary on filter/view change without an effect: adjusting
   // state during render on a changed prop is the sanctioned React pattern. Sort
-  // and refresh never change resetKey, so the Selection survives them.
+  // and refresh never change resetKey, so the Selection survives them. A filter/
+  // view change also leaves select-all-matching — the matched set is no longer
+  // the one the user selected over.
   const [lastResetKey, setLastResetKey] = useState(resetKey);
   if (resetKey !== lastResetKey) {
     setLastResetKey(resetKey);
     setSelectedIds(primaryId ? new Set([primaryId]) : new Set());
+    setAllMatching(false);
+    setExcludeIds(new Set());
   }
 
-  const selectOnly = useCallback((id: string) => {
-    setSelectedIds(new Set([id]));
+  // Leave select-all-matching and reset its exclusions. Called by every gesture
+  // that re-establishes an explicit Selection (plain click, range, clear).
+  const exitAllMatching = useCallback(() => {
+    setAllMatching(false);
+    setExcludeIds(new Set());
   }, []);
 
+  const selectOnly = useCallback(
+    (id: string) => {
+      exitAllMatching();
+      setSelectedIds(new Set([id]));
+    },
+    [exitAllMatching]
+  );
+
   const toggle = useCallback((id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
+    // Under select-all-matching a toggle records an exclusion (the deselect-one
+    // gesture over "all matching"); otherwise it flips plain membership.
+    setAllMatching((matching) => {
+      if (matching) {
+        setExcludeIds((prev) => {
+          const next = new Set(prev);
+          if (next.has(id)) next.delete(id);
+          else next.add(id);
+          return next;
+        });
+      } else {
+        setSelectedIds((prev) => {
+          const next = new Set(prev);
+          if (next.has(id)) next.delete(id);
+          else next.add(id);
+          return next;
+        });
+      }
+      return matching;
     });
   }, []);
 
   const selectRange = useCallback(
     (anchorId: string | null, targetId: string, additive: boolean) => {
+      exitAllMatching();
       if (anchorId === null) {
         setSelectedIds(new Set([targetId]));
         return;
@@ -101,12 +169,13 @@ export function useSelection({
         additive ? new Set([...prev, ...range]) : new Set(range)
       );
     },
-    [orderedIds]
+    [orderedIds, exitAllMatching]
   );
 
   const clear = useCallback(() => {
+    exitAllMatching();
     setSelectedIds(new Set());
-  }, []);
+  }, [exitAllMatching]);
 
   const deselect = useCallback((ids: Iterable<string>) => {
     setSelectedIds((prev) => {
@@ -116,5 +185,31 @@ export function useSelection({
     });
   }, []);
 
-  return { selectedIds, selectOnly, toggle, selectRange, clear, deselect };
+  const selectAllMatching = useCallback(() => {
+    setAllMatching(true);
+    setExcludeIds(new Set());
+  }, []);
+
+  const selectedCount = allMatching
+    ? Math.max(0, filteredTotal - excludeIds.size)
+    : selectedIds.size;
+
+  const isSelected = useCallback(
+    (id: string) => (allMatching ? !excludeIds.has(id) : selectedIds.has(id)),
+    [allMatching, excludeIds, selectedIds]
+  );
+
+  return {
+    selectedIds,
+    selectOnly,
+    toggle,
+    selectRange,
+    clear,
+    deselect,
+    selectAllMatching,
+    allMatching,
+    excludeIds,
+    selectedCount,
+    isSelected,
+  };
 }

--- a/web/src/chat/useSelection.ts
+++ b/web/src/chat/useSelection.ts
@@ -130,28 +130,24 @@ export function useSelection({
     [exitAllMatching]
   );
 
-  const toggle = useCallback((id: string) => {
-    // Under select-all-matching a toggle records an exclusion (the deselect-one
-    // gesture over "all matching"); otherwise it flips plain membership.
-    setAllMatching((matching) => {
-      if (matching) {
-        setExcludeIds((prev) => {
-          const next = new Set(prev);
-          if (next.has(id)) next.delete(id);
-          else next.add(id);
-          return next;
-        });
-      } else {
-        setSelectedIds((prev) => {
-          const next = new Set(prev);
-          if (next.has(id)) next.delete(id);
-          else next.add(id);
-          return next;
-        });
-      }
-      return matching;
-    });
-  }, []);
+  const toggle = useCallback(
+    (id: string) => {
+      // Under select-all-matching a toggle records an exclusion (the
+      // deselect-one gesture over "all matching"); otherwise it flips plain
+      // membership. Read `allMatching` as a dependency rather than through a
+      // setter: an updater that writes other state runs twice under
+      // StrictMode, which flips the id and flips it straight back.
+      const flip = (prev: ReadonlySet<string>) => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      };
+      if (allMatching) setExcludeIds(flip);
+      else setSelectedIds(flip);
+    },
+    [allMatching]
+  );
 
   const selectRange = useCallback(
     (anchorId: string | null, targetId: string, additive: boolean) => {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -34,8 +34,10 @@
   --color-muted: var(--muted);
   --color-secondary-foreground: var(--secondary-foreground);
   --color-secondary: var(--secondary);
+  --color-primary-hover: var(--primary-hover);
   --color-primary-foreground: var(--primary-foreground);
   --color-primary: var(--primary);
+  --color-foreground-bright: var(--foreground-bright);
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
@@ -64,10 +66,15 @@
   --card: #073642;
   /* Solarized base1 */
   --card-foreground: #93a1a1;
+  /* Solarized base2 — the hover target for neutral text actions. */
+  --foreground-bright: #eee8d5;
   --popover: #073642;
   --popover-foreground: #93a1a1;
   /* Solarized cyan */
   --primary: #2aa198;
+  /* Solarized cyan lifted to 50% lightness. On a dark theme hover means
+     brighter, so primary-toned actions lift here rather than dim. */
+  --primary-hover: #35cabf;
   --primary-foreground: #002b36;
   /* Solarized base02 */
   --secondary: #073642;
@@ -105,9 +112,11 @@
   --foreground: #839496;
   --card: #073642;
   --card-foreground: #93a1a1;
+  --foreground-bright: #eee8d5;
   --popover: #073642;
   --popover-foreground: #93a1a1;
   --primary: #2aa198;
+  --primary-hover: #35cabf;
   --primary-foreground: #002b36;
   --secondary: #073642;
   --secondary-foreground: #839496;

--- a/web/src/shared/Toast.tsx
+++ b/web/src/shared/Toast.tsx
@@ -25,7 +25,7 @@ export function Toast({ toast, onDismiss }: ToastProps) {
           <button
             type="button"
             onClick={handleAction}
-            className="text-xs font-semibold uppercase tracking-wide text-primary transition-colors hover:text-primary/80"
+            className="text-xs font-semibold uppercase tracking-wide text-primary transition-colors hover:text-primary-hover"
           >
             {toast.actionLabel}
           </button>

--- a/web/src/tags/BatchTagButton.tsx
+++ b/web/src/tags/BatchTagButton.tsx
@@ -2,8 +2,10 @@ import { useState } from "react";
 import { Tag as TagIcon } from "lucide-react";
 import type { Tag } from "@/types";
 import type { ColorToken } from "@/tags/palette";
+import type { BatchTarget } from "@/chat/batchTarget";
 import { TagPickerDialog, type TagState } from "@/tags/TagPickerDialog";
 import { deriveBatchTagStates } from "@/tags/batchTagState";
+import { selectAllTagStates } from "@/tags/selectAllTagState";
 import {
   batchTagDiff,
   displayStateFor,
@@ -16,8 +18,18 @@ interface BatchTagButtonProps {
   selectedIds: ReadonlySet<string>;
   allTags: Tag[];
   fetchTagsByChat: (chatIds: string[]) => Promise<Record<string, Tag[]>>;
+  // Select-all-matching (#164): when active, the tri-state is derived from
+  // server-computed filtered per-Tag counts minus the excluded Chats' Tags,
+  // and the batch applies over the filter branch rather than the checked ids.
+  allMatching: boolean;
+  selectedCount: number;
+  batchTarget: BatchTarget;
+  fetchFilteredTagCounts: () => Promise<
+    Array<{ tagId: string; count: number }>
+  >;
+  excludedChatTags: string[][];
   onApply: (
-    chatIds: string[],
+    target: BatchTarget,
     diff: { add: string[]; remove: string[] }
   ) => void;
   onCreate: (name: string, color: ColorToken) => Promise<Tag | null>;
@@ -33,6 +45,11 @@ export function BatchTagButton({
   selectedIds,
   allTags,
   fetchTagsByChat,
+  allMatching,
+  selectedCount,
+  batchTarget,
+  fetchFilteredTagCounts,
+  excludedChatTags,
   onApply,
   onCreate,
 }: BatchTagButtonProps) {
@@ -44,9 +61,25 @@ export function BatchTagButton({
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
     if (!next) return;
-    // Fresh staging each open; pull the tri-state from one grouped query.
+    // Fresh staging each open.
     setStaged(new Map());
     setInitialStates(EMPTY_STATES);
+    if (allMatching) {
+      // Under select-all the Selection can't be enumerated (ADR-0021); derive
+      // each Tag's tri-state from the filtered per-Tag counts, subtracting the
+      // excluded Chats' own Tags.
+      void fetchFilteredTagCounts().then((counts) => {
+        setInitialStates(
+          selectAllTagStates({
+            selectedCount,
+            tagCounts: new Map(counts.map((c) => [c.tagId, c.count])),
+            excludedTags: excludedChatTags,
+          })
+        );
+      });
+      return;
+    }
+    // Explicit ids: pull the tri-state from one grouped query.
     const ids = [...selectedIds];
     void fetchTagsByChat(ids).then((byChat) => {
       setInitialStates(deriveBatchTagStates(ids.length, byChat));
@@ -74,14 +107,19 @@ export function BatchTagButton({
   };
 
   // The dialog closes itself on `Done` (via its imperative `close()`); this
-  // onDone side effect only applies the staged diff in one batch call.
+  // onDone side effect only applies the staged diff in one batch call over the
+  // current target (explicit ids or the filter branch).
   const handleDone = () => {
-    onApply([...selectedIds], batchTagDiff(staged, initialStates));
+    onApply(batchTarget, batchTagDiff(staged, initialStates));
   };
 
   return (
     <TagPickerDialog
-      title="Tag selected chats"
+      title={
+        allMatching
+          ? `Tag ${selectedCount.toLocaleString()} chats`
+          : "Tag selected chats"
+      }
       tags={allTags}
       open={open}
       onOpenChange={handleOpenChange}

--- a/web/src/tags/selectAllTagState.test.ts
+++ b/web/src/tags/selectAllTagState.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { selectAllTagStates } from "@/tags/selectAllTagState";
+
+describe("selectAllTagStates — tri-state under select-all-matching (#164)", () => {
+  it("marks a tag 'all' when every selected chat holds it", () => {
+    const states = selectAllTagStates({
+      selectedCount: 8,
+      tagCounts: new Map([["bug", 8]]),
+      excludedTags: [],
+    });
+    expect(states.get("bug")).toBe("all");
+  });
+
+  it("marks a tag 'some' when only part of the selection holds it", () => {
+    const states = selectAllTagStates({
+      selectedCount: 8,
+      tagCounts: new Map([["bug", 3]]),
+      excludedTags: [],
+    });
+    expect(states.get("bug")).toBe("some");
+  });
+
+  it("marks a tag 'none' when no selected chat holds it", () => {
+    const states = selectAllTagStates({
+      selectedCount: 8,
+      tagCounts: new Map([["bug", 0]]),
+      excludedTags: [],
+    });
+    expect(states.get("bug")).toBe("none");
+  });
+
+  it("subtracts the excluded chats' tags from the facet count", () => {
+    // 8 matching chats hold bug; the 2 excluded chats both held bug, so only 6
+    // of the 6 remaining selected chats hold it → still 'all'.
+    const states = selectAllTagStates({
+      selectedCount: 6, // filteredTotal 8 minus 2 excluded
+      tagCounts: new Map([["bug", 8]]),
+      excludedTags: [["bug"], ["bug"]],
+    });
+    expect(states.get("bug")).toBe("all");
+  });
+
+  it("drops to 'some' when excluding chats leaves a partial hold", () => {
+    // 8 hold bug; exclude 1 that held bug → 7 of 7 selected hold it → 'all'...
+    // but here 8 hold bug out of total, exclude 1 non-bug chat: 8 of 7? clamp.
+    const states = selectAllTagStates({
+      selectedCount: 7,
+      tagCounts: new Map([["bug", 5]]),
+      excludedTags: [["idea"]], // the excluded chat did not hold bug
+    });
+    // 5 of 7 selected hold bug → 'some'.
+    expect(states.get("bug")).toBe("some");
+  });
+
+  it("reports 'none' for every tag when the selection is empty", () => {
+    const states = selectAllTagStates({
+      selectedCount: 0,
+      tagCounts: new Map([["bug", 4]]),
+      excludedTags: [],
+    });
+    expect(states.get("bug")).toBe("none");
+  });
+});

--- a/web/src/tags/selectAllTagState.ts
+++ b/web/src/tags/selectAllTagState.ts
@@ -1,0 +1,59 @@
+/**
+ * Tri-state derivation for the batch TagPickerDialog under select-all-matching
+ * (#164). The dialog cannot enumerate every matching Chat — the Selection is
+ * "all matching minus `excludeIds`", a set the client never holds (ADR-0021).
+ * So each Tag row's all/some/none is computed from counts instead of a per-Chat
+ * scan: the facet count of matching Chats holding the Tag, minus the excluded
+ * Chats that held it, compared against the selected total.
+ */
+
+/** A Tag row's state across the Selection, matching the dialog's own vocabulary. */
+export type TagState = "all" | "some" | "none";
+
+export interface SelectAllTagStateInput {
+  /** Chats currently selected: the filtered total minus the excluded rows. */
+  selectedCount: number;
+  /**
+   * How many Chats matching the filter hold each Tag — the per-view facet count
+   * (#131), keyed by Tag id. A Tag absent from the map counts as zero.
+   */
+  tagCounts: ReadonlyMap<string, number>;
+  /**
+   * The Tag ids held by each excluded Chat (the rows the user unchecked after
+   * selecting all). Subtracted from the facet counts so an excluded Chat's Tags
+   * don't count toward the Selection.
+   */
+  excludedTags: ReadonlyArray<ReadonlyArray<string>>;
+}
+
+/**
+ * Derive each Tag's tri-state across the select-all-matching Selection. Returns
+ * a state for every Tag in `tagCounts`; a Tag no matching Chat holds is `none`.
+ */
+export function selectAllTagStates({
+  selectedCount,
+  tagCounts,
+  excludedTags,
+}: SelectAllTagStateInput): Map<string, TagState> {
+  // How many excluded Chats held each Tag — the amount to subtract from its
+  // facet count so it reflects the remaining Selection.
+  const excludedHolding = new Map<string, number>();
+  for (const tags of excludedTags) {
+    for (const tagId of tags) {
+      excludedHolding.set(tagId, (excludedHolding.get(tagId) ?? 0) + 1);
+    }
+  }
+
+  const states = new Map<string, TagState>();
+  for (const [tagId, facetCount] of tagCounts) {
+    const holding = Math.max(0, facetCount - (excludedHolding.get(tagId) ?? 0));
+    if (selectedCount <= 0 || holding <= 0) {
+      states.set(tagId, "none");
+    } else if (holding >= selectedCount) {
+      states.set(tagId, "all");
+    } else {
+      states.set(tagId, "some");
+    }
+  }
+  return states;
+}

--- a/web/src/tags/useTags.ts
+++ b/web/src/tags/useTags.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import type { Tag } from "@/types";
 import type { ColorToken } from "@/tags/palette";
+import type { BatchTarget } from "@/chat/batchTarget";
 
 interface UseTagsOptions {
   // Called after an assignment changes which tags a chat carries, so the chat
@@ -18,10 +19,10 @@ export interface UseTagsResult {
   deleteTag: (id: string) => Promise<void>;
   assignTag: (chatId: string, tagId: string) => Promise<void>;
   removeTag: (chatId: string, tagId: string) => Promise<void>;
-  /** Apply a staged add/remove Tag diff across a set of Chats in one batch call
-   * (#163, ADR-0021 explicit-ids branch). */
+  /** Apply a staged add/remove Tag diff across a batch target in one call — the
+   * checked ids (#163) or the live filter minus exclusions (#164, ADR-0021). */
   assignTagsBatch: (
-    chatIds: string[],
+    target: BatchTarget,
     diff: { add: string[]; remove: string[] }
   ) => Promise<void>;
   /** Tags grouped across a set of Chats in one query, keyed by chat id — feeds
@@ -132,15 +133,16 @@ export function useTags({ onAssignmentChange }: UseTagsOptions): UseTagsResult {
   );
 
   const assignTagsBatch = useCallback(
-    async (chatIds: string[], diff: { add: string[]; remove: string[] }) => {
+    async (target: BatchTarget, diff: { add: string[]; remove: string[] }) => {
       // POST only: the batch caller (App) orchestrates the follow-up itself —
       // the drop-reconcile reload (#176), facet counts, and pruning the
       // Selection by the exact ids that left the list — so it needs the reload's
-      // dropped-id result, which the shared onAssignmentChange discards.
+      // dropped-id result, which the shared onAssignmentChange discards. The
+      // target doubles as the request body (explicit ids or filter branch).
       await fetch("/api/chats/batch/tags", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ chatIds, add: diff.add, remove: diff.remove }),
+        body: JSON.stringify({ ...target, add: diff.add, remove: diff.remove }),
       });
     },
     []

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -141,6 +141,68 @@ function tagsForChat(chatId: string): FakeTag[] {
     .filter((t): t is FakeTag => t !== undefined);
 }
 
+type FakeFilter = {
+  projects?: string[];
+  tags?: string[];
+  tagMode?: "all" | "any";
+  includeTrashed?: boolean;
+};
+
+/**
+ * Mirrors the server's `buildFilterClauses` (ADR-0021) so a filter-targeted
+ * batch resolves to the same set the list shows. Kept in one place because the
+ * batch write and the filtered tag counts must agree with each other.
+ */
+function chatsMatchingFilter(filter: FakeFilter): FakeChat[] {
+  const inView = filter.includeTrashed
+    ? fakeChats.filter((c) => c.isDeleted)
+    : fakeChats.filter((c) => !c.isDeleted);
+  return inView.filter((c) => {
+    const projects = filter.projects ?? [];
+    if (projects.length > 0 && !projects.includes(c.project)) return false;
+    const tags = filter.tags;
+    if (tags && tags.length > 0) {
+      const ids = new Set(fakeChatTags[c.id] ?? []);
+      const wantUntagged = tags.includes("");
+      const real = tags.filter((t) => t !== "");
+      if (filter.tagMode === "any") {
+        const hitsUntagged = wantUntagged && ids.size === 0;
+        if (!hitsUntagged && !real.some((t) => ids.has(t))) return false;
+      } else {
+        if (wantUntagged && ids.size > 0) return false;
+        if (!real.every((t) => ids.has(t))) return false;
+      }
+    }
+    return true;
+  });
+}
+
+/**
+ * The ids a batch targets: the explicit branch as sent (#161), or every Chat
+ * matching the filter minus the exclusions the user unchecked (#164).
+ */
+function resolveBatchIds(body: unknown): string[] {
+  const b = body as {
+    chatIds?: unknown;
+    filter?: FakeFilter;
+    excludeIds?: unknown;
+  };
+  if (Array.isArray(b?.chatIds)) {
+    return b.chatIds.filter((x): x is string => typeof x === "string");
+  }
+  if (b?.filter && typeof b.filter === "object") {
+    const excluded = new Set(
+      Array.isArray(b.excludeIds)
+        ? b.excludeIds.filter((x): x is string => typeof x === "string")
+        : []
+    );
+    return chatsMatchingFilter(b.filter)
+      .map((c) => c.id)
+      .filter((id) => !excluded.has(id));
+  }
+  return [];
+}
+
 export const fakeMessages = {
   "chat-1": [
     {
@@ -403,6 +465,27 @@ export const handlers = [
 
     return HttpResponse.json({ total });
   }),
+  // Per-Tag counts over the filtered set (#164), the tri-state source under
+  // select-all-matching where the client never holds the ids.
+  http.get("/api/chats/filtered-tag-counts", ({ request }) => {
+    const url = new URL(request.url);
+    const tagsParam = url.searchParams.get("tags");
+    const matching = chatsMatchingFilter({
+      includeTrashed: url.searchParams.get("includeTrashed") === "true",
+      projects: url.searchParams.getAll("project"),
+      tags: tagsParam === null ? undefined : tagsParam.split(","),
+      tagMode: url.searchParams.get("tagMode") === "any" ? "any" : "all",
+    });
+    const counts = new Map<string, number>();
+    for (const chat of matching) {
+      for (const tagId of fakeChatTags[chat.id] ?? []) {
+        counts.set(tagId, (counts.get(tagId) ?? 0) + 1);
+      }
+    }
+    return HttpResponse.json({
+      tags: [...counts].map(([tagId, count]) => ({ tagId, count })),
+    });
+  }),
   http.patch("/api/chats/:id/title", async ({ params, request }) => {
     const id = params.id as string;
     const chat = fakeChats.find((c) => c.id === id);
@@ -430,8 +513,7 @@ export const handlers = [
   }),
   // Registered before `/api/chats/:id` so `batch` is not captured as an id.
   http.post("/api/chats/batch/trash", async ({ request }) => {
-    const body = (await request.json()) as { chatIds?: unknown };
-    const chatIds = Array.isArray(body?.chatIds) ? body.chatIds : [];
+    const chatIds = resolveBatchIds(await request.json());
     let count = 0;
     for (const id of chatIds) {
       const chat = fakeChats.find((c) => c.id === id);
@@ -443,8 +525,7 @@ export const handlers = [
     return HttpResponse.json({ count });
   }),
   http.post("/api/chats/batch/restore", async ({ request }) => {
-    const body = (await request.json()) as { chatIds?: unknown };
-    const chatIds = Array.isArray(body?.chatIds) ? body.chatIds : [];
+    const chatIds = resolveBatchIds(await request.json());
     let count = 0;
     for (const id of chatIds) {
       const chat = fakeChats.find((c) => c.id === id);
@@ -462,11 +543,12 @@ export const handlers = [
   http.post("/api/chats/batch/tags", async ({ request }) => {
     const body = (await request.json()) as {
       chatIds?: unknown;
+      filter?: unknown;
       add?: unknown;
       remove?: unknown;
     };
-    if (!Array.isArray(body?.chatIds)) {
-      return HttpResponse.json({ error: "Invalid chatIds" }, { status: 400 });
+    if (!Array.isArray(body?.chatIds) && !body?.filter) {
+      return HttpResponse.json({ error: "Invalid target" }, { status: 400 });
     }
     const asIds = (v: unknown): string[] =>
       Array.isArray(v)
@@ -475,8 +557,7 @@ export const handlers = [
     const add = asIds(body.add);
     const remove = asIds(body.remove);
     let count = 0;
-    for (const id of body.chatIds) {
-      if (typeof id !== "string") continue;
+    for (const id of resolveBatchIds(body)) {
       if (!fakeChats.some((c) => c.id === id)) continue;
       count++;
       const removeSet = new Set(remove);


### PR DESCRIPTION
## Background (Why)

Batch Tag (#163) and batch Move to Trash (#161) can only act on Chats the client has actually loaded. The list is a bounded window, so "select everything matching this filter" was impossible to express — you could check the rows in front of you and nothing more. Acting on 3,000 matching Chats meant scrolling until all 3,000 were materialised, which is exactly what the windowed list exists to avoid.

This adds a **select-all-matching** mode: the Selection can stand for every Chat matching the live filter, and the batch endpoints resolve that filter server-side instead of receiving an id list.

## Approach (How)

The Selection never materialises ids it cannot see. Select-all-matching is a boolean plus a small `excludeIds` set — the "all matching except these" model — so deselecting a row records an exclusion rather than removing one id from a list of thousands.

Batch endpoints gain a filter branch per ADR-0021: `{ filter, excludeIds }` resolves to `id IN (SELECT ... buildFilterClauses) AND id NOT IN (excludeIds)` inside the same transaction. No id list ships. Both branches share `buildViewAndFilter` with the filtered total, so a batch write can never disagree with the count the list showed.

Because the client holds no ids under select-all, the tag dialog's tri-state cannot be computed locally. Per-Tag counts are computed server-side scoped to the same filter, then compared against the filtered total minus the excluded Chats' tags — so a narrowing Project/Tag filter stays accurate.

## Changes (What)

- [x] `feat(api)`: batch reads and writes resolve against `{ filter, excludeIds }`; per-Tag counts can be scoped to the filtered set
- [x] `feat(web)`: Selection gains select-all-matching as a boolean + exclusion set
- [x] `feat(web)`: `Select all N` escalation in the batch bar, plus a centered banner stating the mode with its own way out; Esc leaves the mode
- [x] `feat(web)`: batch Tag and Move to Trash target the filter; tag dialog tri-state derives from server-side filtered tag counts
- [x] `style(web)` + `docs`: text actions unified under an emphasis hierarchy (ADR-0024, DESIGN.md)
- [x] `fix(web)`: Cmd/Ctrl+click toggle works under StrictMode

### Test Verification

- [x] Filter-branch resolution: batch trash and batch tag both mutate exactly the filtered set (`api/src/app.test.ts`)
- [x] Exclusions: `excludeIds` are held back from the filtered mutation
- [x] Filtered per-Tag counts stay scoped to a narrowing Project/Tag filter (`api/src/list-counts.test.ts`)
- [x] Tri-state under select-all, including the excluded Chats' tags subtracted from the filtered total (`web/src/tags/selectAllTagState.test.ts`)
- [x] Selection model: entering the mode, accumulating exclusions, live counts (`web/src/chat/useSelection.test.tsx`)
- [x] End to end, asserting the **request body** rather than the rows (`web/src/App.test.tsx`) — the batch write's UI is optimistic and the list never reloads after it, so row assertions pass even when the filter branch is dead
- [x] Cmd/Ctrl+click toggle renders under StrictMode, as the app does

## Additional Notes

The action emphasis hierarchy (ADR-0024 + DESIGN.md) is scope this PR picked up rather than issue work: the banner needed a `Clear selection` exit, and placing it exposed that exit actions and primary actions had no agreed weighting. ADR-0024 keeps the rejected color-encodes-direction framing so the next action is a lookup rather than a debate.

The StrictMode fix is worth a reviewer's eye: the toggle read `allMatching` through `setAllMatching` and wrote other state from inside that updater. StrictMode double-invokes updaters to surface exactly this, so every toggle ran twice and left no visible change. The hook's other tests render bare and never caught it.

Under select-all-matching the optimistic pass only covers the loaded window — the server acts on the whole matching set. That is intended, not a gap: the window refresh only grows and never drops.

## Related Links

- Closes #164