### PR TITLE
feat(web): note-style conversation layout with message headers

### DIFF
--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -920,6 +920,47 @@ describe("ChatReader.getMessages", () => {
     expect(messages![1].role).toBe("assistant");
   });
 
+  it("exposes each message's Normalized message id", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-user",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "Build a login page",
+      blocks: [{ type: "text", text: "Build a login page" }],
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-assistant",
+      role: "assistant",
+      ts: new Date(1700000200000),
+      text: "Sure",
+      blocks: [{ type: "text", text: "Sure" }],
+    });
+
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
+      includeTrashed: false,
+    });
+
+    // The id travels from the Archive verbatim: it is the anchor the
+    // conversation pane keys a Message's DOM node by (#192), so it must be the
+    // Normalized message_id and never a positional index.
+    expect(messages!.map((m) => m.id)).toEqual(["m-user", "m-assistant"]);
+  });
+
   it("returns null for a trashed chat by default", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -50,6 +50,13 @@ export type ApiContentBlock =
   | { type: "tool_result"; tool_use_id: string; content: unknown };
 
 export interface MessageResponse {
+  /**
+   * The Normalized `message_id`, unique within a Chat. Served as the Message's
+   * stable handle: the conversation pane anchors a Message's DOM node to it
+   * (#192) so Spotlight can scroll to an exact Message (#25) without depending
+   * on a positional index.
+   */
+  id: string;
   role: "user" | "assistant";
   content: ApiContentBlock[];
   timestamp: string;
@@ -367,6 +374,7 @@ export function createChatReader({
     const rows = archive.read.listMessagesByChat(row.agent, row.sourceId);
 
     return rows.map((m) => ({
+      id: m.messageId,
       role: m.role as "user" | "assistant",
       content: (m.blocks as StoredBlock[]).map(toApiBlock),
       timestamp: m.ts.toISOString(),

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -16,7 +16,10 @@ export function CollapsibleToolCall({ block }: CollapsibleToolCallProps) {
       <button
         type="button"
         onClick={() => setIsExpanded((prev) => !prev)}
-        className="inline-block cursor-pointer rounded bg-card px-2 py-1 font-mono text-xs text-chart-3 hover:bg-card/80"
+        // text-left overrides the browser's default centring for buttons: a
+        // long command or path wraps to a second line, and centred code is
+        // unreadable.
+        className="inline-block cursor-pointer rounded bg-card px-2 py-1 text-left font-mono text-xs text-chart-3 hover:bg-card/80"
       >
         {generateToolSummary(block)}
       </button>

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { ConversationView } from "@/conversation/ConversationView";
+import { messageAnchorId } from "@/conversation/messageAnchor";
 import type { Chat, Message } from "@/types";
 
 const chat: Chat = {
@@ -20,8 +21,11 @@ function renderMessages(messages: Message[]) {
   return render(<ConversationView chat={chat} messages={messages} />);
 }
 
+let nextMessageId = 0;
+
 function assistant(text: string): Message {
   return {
+    id: `m-${(nextMessageId += 1)}`,
     role: "assistant",
     content: text,
     timestamp: "2024-01-01T00:00:00Z",
@@ -159,6 +163,195 @@ describe("Conversation live arrival", () => {
   });
 });
 
+describe("Conversation note-style headers", () => {
+  it("names the assistant by its agent display name, never ASSISTANT", async () => {
+    render(
+      <ConversationView
+        chat={{ ...chat, agent: "claude-code" }}
+        messages={[assistant("Sure, here goes.")]}
+      />
+    );
+
+    expect(await screen.findByText("Claude Code")).not.toBeNull();
+    // The literal role name is the thing this layout replaces: an archive
+    // header should read like a person's name, not a wire-protocol value.
+    expect(screen.queryByText(/^assistant$/i)).toBeNull();
+  });
+
+  it("stamps every header with an absolute date and time", async () => {
+    // A single-day session still carries the date (#192): the header is read as
+    // a record of when something happened, not only where it sits in the day.
+    // Asserted by shape, not a literal — the value renders in the reader's
+    // local timezone, and the suite pins no TZ.
+    renderMessages([assistant("one")]);
+
+    expect(
+      await screen.findByText(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/)
+    ).not.toBeNull();
+  });
+
+  it("names the reader's own turns You", async () => {
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-ask",
+            role: "user",
+            content: "Build a login page",
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    expect(await screen.findByText("You")).not.toBeNull();
+  });
+});
+
+describe("Conversation note-style layout", () => {
+  async function renderBothRoles() {
+    const { container } = render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-ask",
+            role: "user",
+            content: "Build a login page",
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+          assistant("Sure, here goes."),
+        ]}
+      />
+    );
+    await screen.findByText("Sure, here goes.");
+    return {
+      user: container.querySelector('[data-role="user"]')!,
+      assistant: container.querySelector('[data-role="assistant"]')!,
+    };
+  }
+
+  it("gives user turns a background block and assistant turns none", async () => {
+    // The reader's own turns are the scanning anchors in a long session; the
+    // Agent's prose sits directly on the pane (#192).
+    const { user, assistant: agent } = await renderBothRoles();
+
+    expect(user.className).toContain("bg-card");
+    expect(agent.className).not.toContain("bg-");
+  });
+
+  it("lays both roles out full-width, with no bubbles or side alignment", async () => {
+    const { user, assistant: agent } = await renderBothRoles();
+
+    // A document flow, not a chat transcript: nothing is pushed to a side or
+    // capped to a bubble's width.
+    for (const el of [user, agent]) {
+      expect(el.className).not.toContain("self-end");
+      expect(el.className).not.toContain("self-start");
+      expect(el.className).not.toContain("max-w-[85%]");
+    }
+  });
+});
+
+describe("Conversation message anchors", () => {
+  it("anchors each message to its message id, not its position", async () => {
+    // The anchor is this layout's public contract (#192): Spotlight (#25)
+    // scrolls to an exact Message through it, so it must survive turns being
+    // dropped, reordered, or arriving live — which a positional index does not.
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-user",
+            role: "user",
+            content: [
+              { type: "tool_result", tool_use_id: "t1", content: "ok" },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "m-assistant",
+            role: "assistant",
+            content: "Sure, here goes.",
+            timestamp: "2024-01-01T00:01:00Z",
+          },
+        ]}
+      />
+    );
+
+    await screen.findByText("Sure, here goes.");
+    // The empty first turn is dropped, so the surviving message sits at index
+    // 0 — its anchor must still name the message, not that position.
+    const anchored = document.getElementById(messageAnchorId("m-assistant"));
+    expect(anchored).not.toBeNull();
+    expect(anchored!.textContent).toContain("Sure, here goes.");
+  });
+});
+
+describe("Conversation empty-turn suppression", () => {
+  it("drops a turn whose content renders nothing at all", async () => {
+    // A user turn carrying only tool results is a harness artifact, not
+    // something the reader wrote. It has nothing to show, so it contributes no
+    // header and no block — rather than an empty "You" box (#192).
+    const { container } = render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          assistant("Sure, running that now."),
+          {
+            id: "m-tool-result",
+            role: "user",
+            content: [
+              { type: "tool_result", tool_use_id: "t1", content: "ok" },
+            ],
+            timestamp: "2024-01-01T00:01:00Z",
+          },
+        ]}
+      />
+    );
+
+    await screen.findByText("Sure, running that now.");
+    expect(screen.queryByText("You")).toBeNull();
+    expect(container.querySelector('[data-role="user"]')).toBeNull();
+  });
+});
+
+describe("Conversation collapsed units", () => {
+  it("gives a tool-only turn its collapsed row but no header of its own", async () => {
+    // Tool calls nest under the message that prompted them (#192). The Agent
+    // records them as separate turns, but the reader sees one authored moment,
+    // so the run of tool calls must not repeat the author header.
+    render(
+      <ConversationView
+        chat={{ ...chat, agent: "claude-code" }}
+        messages={[
+          assistant("Let me check that file."),
+          {
+            id: "m-tool-use",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Read",
+                input: { file_path: "/tmp/a.ts" },
+              },
+            ],
+            timestamp: "2024-01-01T00:01:00Z",
+          },
+        ]}
+      />
+    );
+
+    // The collapsed row is still rendered — it is content, just not authored.
+    expect(await screen.findByText("Read: /tmp/a.ts")).not.toBeNull();
+    // ...but the header belongs to the text turn alone.
+    expect(screen.getAllByText("Claude Code")).toHaveLength(1);
+  });
+});
+
 describe("Conversation markdown typography", () => {
   it("renders markdown links that open in a new tab", async () => {
     renderMessages([assistant("See the [docs](https://example.com) page.")]);
@@ -185,6 +378,7 @@ describe("Conversation markdown typography", () => {
         chat={chat}
         messages={[
           {
+            id: "m-thinking",
             role: "assistant",
             content: [{ type: "thinking", thinking: "- first\n- second\n" }],
             timestamp: "2024-01-01T00:00:00Z",

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { RotateCcw } from "lucide-react";
 import type { Message, ContentBlock, Chat, Tag } from "@/types";
@@ -12,9 +12,16 @@ import {
   getScrollPillTarget,
   type ScrollPillTarget,
 } from "@/conversation/scrollPillVisibility";
+import { formatMessageTimestamp } from "@/conversation/formatMessageTimestamp";
+import { messageAnchorId } from "@/conversation/messageAnchor";
 import { deriveArrivalAction } from "@/conversation/liveArrival";
 import { deriveFirstUnseenIndex } from "@/conversation/firstUnseenIndex";
+import {
+  hasAuthorHeader,
+  hasRenderableContent,
+} from "@/conversation/messageVisibility";
 import { useScrollShortcuts } from "@/conversation/useScrollShortcuts";
+import { getAgentDisplayName } from "@/agent/agentDisplayName";
 import { ChatMetadataPopover } from "@/metadata/ChatMetadataPopover";
 import { EditableTitle } from "@/metadata/EditableTitle";
 import { TagStrip } from "@/tags/TagStrip";
@@ -155,23 +162,41 @@ function renderContent(content: Message["content"]) {
   return content.map((block, i) => renderContentBlock(block, i));
 }
 
-function MessageBubble({ message }: { message: Message }) {
+function MessageItem({
+  message,
+  agentName,
+}: {
+  message: Message;
+  agentName: string;
+}) {
   return (
     <div
+      id={messageAnchorId(message.id)}
       data-role={message.role}
-      className={`max-w-[85%] rounded-lg px-4 py-3 text-sm leading-relaxed ${
+      // A note-style document flow: every turn spans the pane's column, and
+      // only the reader's own turns take a background block, as scanning
+      // anchors. Both roles keep the same horizontal padding so their text
+      // aligns down a single edge (#192).
+      className={`w-full px-4 py-3 text-sm leading-relaxed ${
         message.role === "user"
-          ? "self-end bg-card text-accent-foreground"
-          : "self-start bg-primary/10 text-foreground"
+          ? "rounded-md bg-card text-accent-foreground"
+          : "text-foreground"
       }`}
     >
-      <div
-        className={`mb-1 text-xs font-semibold uppercase tracking-wide ${
-          message.role === "user" ? "text-chart-2" : "text-primary"
-        }`}
-      >
-        {message.role === "user" ? "You" : "Assistant"}
-      </div>
+      {hasAuthorHeader(message) && (
+        // Set as a name, not a label: the old all-caps role tag belonged to the
+        // bubble layout, and an agent's display name is written "Claude Code".
+        <div
+          className={`mb-1 text-xs font-semibold ${
+            message.role === "user" ? "text-chart-2" : "text-primary"
+          }`}
+        >
+          {message.role === "user" ? "You" : agentName}
+          <span className="ml-2 font-normal text-muted-foreground">
+            {formatMessageTimestamp(message.timestamp)}
+          </span>
+        </div>
+      )}
       {renderContent(message.content)}
     </div>
   );
@@ -179,7 +204,7 @@ function MessageBubble({ message }: { message: Message }) {
 
 export function ConversationView({
   chat,
-  messages,
+  messages: allMessages,
   error,
   onRestore,
   onRenameTitle,
@@ -190,6 +215,14 @@ export function ConversationView({
   onRemoveTag,
   onCreateTag,
 }: ConversationViewProps) {
+  // Turns that render nothing are dropped once, here, so everything downstream
+  // — virtualizer indices, the unread divider, the live-arrival trackers —
+  // counts only Messages the reader can actually see. A turn with nothing to
+  // show is not something to be told is new (#192).
+  const messages = useMemo(
+    () => allMessages.filter(hasRenderableContent),
+    [allMessages]
+  );
   const tagControls: TagControls | undefined =
     allTags && onAssignTag && onRemoveTag && onCreateTag
       ? { allTags, onAssignTag, onRemoveTag, onCreateTag }
@@ -202,6 +235,9 @@ export function ConversationView({
     onEditingTitleChange?.(next);
   };
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Assistant turns are authored by the Agent that recorded the Chat, so the
+  // header names it ("Claude Code") rather than the wire-form role.
+  const agentName = getAgentDisplayName(chat?.agent ?? "");
 
   // TanStack Virtual's useVirtualizer returns functions (e.g. measureElement)
   // that the React Compiler cannot memoize without risking stale UI, so the
@@ -396,7 +432,10 @@ export function ConversationView({
                       <UnreadDivider />
                     </div>
                   )}
-                  <MessageBubble message={messages[virtualItem.index]} />
+                  <MessageItem
+                    message={messages[virtualItem.index]}
+                    agentName={agentName}
+                  />
                 </div>
               ))}
             </div>

--- a/web/src/conversation/formatMessageTimestamp.ts
+++ b/web/src/conversation/formatMessageTimestamp.ts
@@ -1,0 +1,20 @@
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+/**
+ * A Message header's absolute stamp: `2026-07-17 14:32`, in the reader's local
+ * timezone.
+ *
+ * Always both date and time, never relative ("2h ago") and never time-only
+ * (#192). An archive is read long after the fact, so "14:32" alone is not a
+ * fact the reader can place, and the date cannot depend on whether the Chat
+ * happens to span midnight — that would make the same Message render
+ * differently depending on its neighbours.
+ */
+export function formatMessageTimestamp(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "";
+  const day = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+  return `${day} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}

--- a/web/src/conversation/messageAnchor.ts
+++ b/web/src/conversation/messageAnchor.ts
@@ -1,0 +1,18 @@
+/**
+ * The DOM id anchoring a rendered Message, derived from its Normalized
+ * `message_id`.
+ *
+ * This is the conversation layout's public contract (#192): Spotlight (#25)
+ * scrolls to and highlights an exact Message by resolving this id, without
+ * knowing anything about how the pane lays messages out. It is a function, not
+ * a documented string format, so both sides can never drift apart.
+ *
+ * Keyed by message id rather than list position on purpose — positions shift
+ * when empty turns are dropped or live messages arrive, and an anchor that
+ * moves under a link is not an anchor.
+ */
+export function messageAnchorId(messageId: string): string {
+  // Prefixed so the value is always a valid DOM id, whatever an Agent's
+  // message ids look like.
+  return `message-${messageId}`;
+}

--- a/web/src/conversation/messageVisibility.ts
+++ b/web/src/conversation/messageVisibility.ts
@@ -1,0 +1,50 @@
+import type { ContentBlock, Message } from "@/types";
+
+function hasText(text: string): boolean {
+  return text.trim().length > 0;
+}
+
+function rendersSomething(block: ContentBlock): boolean {
+  switch (block.type) {
+    case "text":
+      return hasText(block.text);
+    case "thinking":
+      return hasText(block.thinking);
+    case "tool_use":
+      // Renders as a collapsed row — visible, though it carries no header.
+      return true;
+    case "tool_result":
+      // Never rendered on its own: a result belongs to the tool call that
+      // produced it, not to the turn the Agent happened to record it under.
+      return false;
+  }
+}
+
+/**
+ * Whether a Message puts anything on screen at all.
+ *
+ * A turn that renders nothing — most often a user turn carrying only tool
+ * results — is dropped before layout, so it can never surface as an empty
+ * authored block (#192). Suppressing it at render time would still leave the
+ * turn occupying a row in the virtualized list.
+ */
+export function hasRenderableContent(message: Message): boolean {
+  if (typeof message.content === "string") return hasText(message.content);
+  return message.content.some(rendersSomething);
+}
+
+/**
+ * Whether a Message is authored prose, and so earns a `You` / agent-name
+ * header.
+ *
+ * Only text counts. Tool calls and thinking are collapsed units: the Agent logs
+ * them as turns of their own, but the reader sees them as part of the moment
+ * that prompted them, so they nest under the preceding header instead of
+ * repeating it (#192).
+ */
+export function hasAuthorHeader(message: Message): boolean {
+  if (typeof message.content === "string") return hasText(message.content);
+  return message.content.some(
+    (block) => block.type === "text" && hasText(block.text)
+  );
+}

--- a/web/src/conversation/useMessages.test.tsx
+++ b/web/src/conversation/useMessages.test.tsx
@@ -6,8 +6,15 @@ import type { ConversationStreamConnector } from "@/conversation/useConversation
 import { server } from "@/test/server";
 import type { Message } from "@/types";
 
+let nextMessageId = 0;
+
 function message(role: Message["role"], text: string): Message {
-  return { role, content: text, timestamp: "2024-01-01T00:00:00Z" };
+  return {
+    id: `m-${(nextMessageId += 1)}`,
+    role,
+    content: text,
+    timestamp: "2024-01-01T00:00:00Z",
+  };
 }
 
 // A connector double that lets the test push a `changed` event for given ids.

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { MAX_PAGE_LIMIT } from "@contract";
+import type { Message } from "@/types";
 
 type FakeChat = {
   id: string;
@@ -203,14 +204,19 @@ function resolveBatchIds(body: unknown): string[] {
   return [];
 }
 
-export const fakeMessages = {
+// Typed against the wire shape so a change to the served Message contract (a
+// new required field, say) fails here rather than silently letting the double
+// drift from the real API.
+export const fakeMessages: Record<string, Message[]> = {
   "chat-1": [
     {
+      id: "chat-1-m1",
       role: "user",
       content: "Help me build a login page",
       timestamp: "2024-01-01T00:00:02Z",
     },
     {
+      id: "chat-1-m2",
       role: "assistant",
       content: [{ type: "text", text: "Sure, I'll create a login page." }],
       timestamp: "2024-01-01T00:00:03Z",
@@ -218,11 +224,13 @@ export const fakeMessages = {
   ],
   "chat-2": [
     {
+      id: "chat-2-m1",
       role: "user",
       content: "Show me a **bold** example with a [link](https://example.com)",
       timestamp: "2024-01-01T00:00:04Z",
     },
     {
+      id: "chat-2-m2",
       role: "assistant",
       content: [
         {
@@ -235,6 +243,7 @@ export const fakeMessages = {
   ],
   "chat-deleted-1": [
     {
+      id: "chat-deleted-1-m1",
       role: "user",
       content: "Quick prototype experiment",
       timestamp: "2024-01-01T00:00:08Z",
@@ -242,11 +251,13 @@ export const fakeMessages = {
   ],
   "chat-3": [
     {
+      id: "chat-3-m1",
       role: "user",
       content: "Refactor the utils module",
       timestamp: "2024-01-01T00:00:06Z",
     },
     {
+      id: "chat-3-m2",
       role: "assistant",
       content: [
         {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -32,6 +32,8 @@ export type ContentBlock =
   | { type: "tool_result"; tool_use_id: string; content: unknown };
 
 export interface Message {
+  /** The Normalized `message_id`, unique within a Chat — the Message's stable handle. */
+  id: string;
   role: "user" | "assistant";
   content: string | ContentBlock[];
   timestamp: string;


### PR DESCRIPTION
## Background (Why)

The conversation pane rendered an archive as if it were a live chat: bubbles, left/right alignment, and a hardcoded `ASSISTANT` label. An archive is read long after the fact, and the design session concluded a note-style document is the better reading model for that.

The bubble layout also had a structural defect. Every turn the Agent recorded became a block, whether or not it had anything to show — so a user turn carrying only tool results rendered an empty `YOU` box, and an assistant turn whose thinking was empty rendered an empty `ASSISTANT` box. In the session this was designed against (`c12c2083`), that is **338 empty blocks in a single conversation**: 200 empty `YOU`, 138 empty `ASSISTANT`.

## Approach (How)

**Empty turns are dropped, not hidden.** Two pure predicates in `messageVisibility.ts` split what was one unconditional block:

- `hasRenderableContent` — does this turn put anything on screen? If not it is dropped **before** layout. Suppressing it at render time would still leave it occupying a row in the virtualized list.
- `hasAuthorHeader` — is this authored prose? Only text earns a `You` / agent-name header. Tool calls and thinking are collapsed units: the Agent logs them as turns of their own, but the reader sees them as part of the moment that prompted them, so they nest under the preceding header instead of repeating it.

**Filtering happens once, at the top of `ConversationView`.** Everything downstream — virtualizer indices, the unread divider, the live-arrival trackers — then counts only Messages the reader can see. This is a deliberate semantic change to the live-arrival path: a turn with nothing to show is not something to be told is new.

**The anchor is a function, not a string format.** `messageAnchorId(messageId)` is exported so #25 resolves it without knowing layout internals, and the two sides cannot drift. Keyed by message id rather than position, because positions shift when empty turns are dropped or live messages arrive — an anchor that moves under a link is not an anchor.

**The API already had the id.** `message_id` sits in the Archive with a uniqueness index on `(agent, source_id, message_id)`; the read path simply dropped it when mapping to `MessageResponse`. No schema change was needed.

## Changes (What)

- [x] `feat(api)`: serve each Message's Normalized `message_id` as `id`
- [x] `feat(web)`: note-style layout — full-width turns, no bubbles, no side alignment; user turns take a background block, assistant prose sits on the pane
- [x] `feat(web)`: author headers naming `You` / the agent display name (never the literal `ASSISTANT`), with an absolute date **and** time on every header
- [x] `feat(web)`: empty-turn suppression and header-less collapsed units (`messageVisibility.ts`)
- [x] `feat(web)`: stable per-Message DOM anchors keyed by `message_id` (`messageAnchor.ts`)
- [x] `fix(web)`: left-align tool call summaries — see Additional Notes

### Test Verification

Full suite green: 643 tests (api 327, web 316), typecheck, and build.

- [x] Assistant header shows the agent display name; the literal `ASSISTANT` never appears
- [x] User turns are headed `You`
- [x] Every header carries an absolute date and time (asserted by shape — the suite pins no `TZ`, so a literal would break outside the author's timezone)
- [x] A turn of only `tool_result` renders no header **and** no block
- [x] A turn of only `tool_use` renders its collapsed row but no header
- [x] User turns carry a background; assistant turns do not
- [x] Neither role carries side-alignment or bubble-width classes
- [x] Anchors survive an empty turn being dropped ahead of them (asserted against the shifted index)
- [x] Virtualized scrolling and the live-arrival/unread-divider tests still pass
- [x] Verified against real data: 710 messages → 372 kept, 338 dropped, 0 empty blocks remaining

## Additional Notes

**`fix(web)`: left-aligned tool summaries.** Buttons centre their text by default, so a tool summary long enough to wrap rendered its command or path centred across two lines. Full-width rows made the wrap routine rather than rare, so it went from unnoticeable to glaring. It is arguably #193's territory, but shipping a visibly centred code path into the integration branch to wait for the next PR helps nobody.

**Two judgment calls worth a reviewer's eye:**

1. `MessageBubble` → `MessageItem`. There are no bubbles now; the old name would misdirect the next reader.
2. Dropped `uppercase` from the header. It rendered the display name as `CLAUDE CODE`, which contradicts the point of a display name, and an all-caps role tag is exactly the bubble-era visual language this replaces.

**One gap the type system did not catch.** `fakeMessages` in `web/src/test/handlers.ts` was untyped, so making `Message.id` required did **not** fail typecheck there — the mock API would have kept serving Messages with no `id`, rendering `message-undefined` anchors while every test passed. It is now typed `Record<string, Message[]>` so the next contract change fails loudly.

**Not in scope.** The collapsed rows still have the airy spacing inherited from the old per-message padding; #193 reworks tool units wholesale under a unified collapsible-row language.

## Related Links

- Closes #192