### PR TITLE
feat(web): pair tool units with a shared collapsible-row language

### DIFF
--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -1088,6 +1088,49 @@ describe("ChatReader.getMessages", () => {
       { type: "tool_result", tool_use_id: "tool-1", content: "result" },
     ]);
   });
+
+  it("serves a failed tool_result's error flag as is_error", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-tool",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "",
+      blocks: [
+        {
+          type: "tool_result",
+          toolUseId: "tool-1",
+          content: "command not found",
+          isError: true,
+        },
+      ],
+    });
+
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
+      includeTrashed: false,
+    });
+    expect(messages![0].content).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: "tool-1",
+        content: "command not found",
+        is_error: true,
+      },
+    ]);
+  });
 });
 
 describe("ChatReader is agent-agnostic", () => {

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -47,7 +47,13 @@ export type ApiContentBlock =
   | { type: "text"; text: string }
   | { type: "thinking"; thinking: string }
   | { type: "tool_use"; id: string; name: string; input: unknown }
-  | { type: "tool_result"; tool_use_id: string; content: unknown };
+  | {
+      type: "tool_result";
+      tool_use_id: string;
+      content: unknown;
+      /** Set when the tool reported a failure. Absent on success. */
+      is_error?: boolean;
+    };
 
 export interface MessageResponse {
   /**
@@ -73,6 +79,7 @@ function toApiBlock(block: StoredBlock): ApiContentBlock {
       type: "tool_result",
       tool_use_id: String(block.toolUseId ?? ""),
       content: block.content,
+      ...(block.isError === true ? { is_error: true } : {}),
     };
   }
   return block as ApiContentBlock;

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -293,6 +293,38 @@ describe("ClaudeCodePlugin.normalize", () => {
     ]);
   });
 
+  it("carries a tool_result's error flag through as isError", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-1",
+              content: "command not found",
+              is_error: true,
+            },
+          ],
+        },
+        isMeta: false,
+        isSidechain: false,
+        uuid: "msg-8",
+        timestamp: "2024-01-01T00:00:08Z",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "tool_result",
+        toolUseId: "tool-1",
+        content: "command not found",
+        isError: true,
+      },
+    ]);
+  });
+
   it("normalizes a user text message", () => {
     const result = plugin.normalize(
       rawRecord({

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -154,6 +154,9 @@ function normalizeBlock(raw: unknown): NormalizedBlock | null {
         type: "tool_result",
         toolUseId: String(b.tool_use_id ?? ""),
         content: b.content,
+        // Only carried when the tool actually failed: a `false` on every
+        // successful result would grow the stored block for nothing.
+        ...(b.is_error === true ? { isError: true } : {}),
       };
     default:
       return null;

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -21,7 +21,16 @@ export type NormalizedBlock =
   | { type: "text"; text: string }
   | { type: "thinking"; thinking: string }
   | { type: "tool_use"; id: string; name: string; input: unknown }
-  | { type: "tool_result"; toolUseId: string; content: unknown };
+  | {
+      type: "tool_result";
+      toolUseId: string;
+      content: unknown;
+      /**
+       * Set when the tool reported a failure. Omitted on success, so the flag
+       * only ever widens a stored block (ADR-0023).
+       */
+      isError?: boolean;
+    };
 
 export interface NormalizedMessage {
   messageId: string;

--- a/web/src/conversation/CollapsibleRow.tsx
+++ b/web/src/conversation/CollapsibleRow.tsx
@@ -1,0 +1,70 @@
+import { useState, type ReactNode } from "react";
+import { ChevronDown, type LucideIcon } from "lucide-react";
+
+interface CollapsibleRowProps {
+  /** The kind marker — a terminal for tool units, a brain for thinking. */
+  icon: LucideIcon;
+  /** The one-line collapsed summary. */
+  summary: string;
+  /** Marks the row as reporting a failure. */
+  hasError?: boolean;
+  /** The detail revealed when expanded. */
+  children: ReactNode;
+}
+
+/**
+ * One collapsed line that opens into its detail.
+ *
+ * The shared visual language for everything the reader skims past by default —
+ * tool units, thinking, and later system rows (#193). Kept as one component so
+ * those kinds cannot drift apart: they differ only by icon and summary.
+ */
+export function CollapsibleRow({
+  icon: Icon,
+  summary,
+  hasError,
+  children,
+}: CollapsibleRowProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div className="my-1">
+      <button
+        type="button"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        aria-expanded={isExpanded}
+        // Muted and a size down from body text: these rows are the parts of a
+        // session the reader scans past, not the prose they came to read.
+        className="flex w-full cursor-pointer items-center gap-1.5 rounded px-1.5 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-white/[0.04] hover:text-foreground"
+      >
+        <ChevronDown
+          data-testid="row-chevron"
+          size={12}
+          aria-hidden="true"
+          className={`shrink-0 transition-transform ${
+            isExpanded ? "" : "-rotate-90"
+          }`}
+        />
+        <Icon size={12} aria-hidden="true" className="shrink-0" />
+        <span className="truncate font-mono">{summary}</span>
+        {hasError && (
+          <span
+            data-testid="row-error"
+            aria-label="Failed"
+            className="ml-1 size-1.5 shrink-0 rounded-full bg-destructive"
+          />
+        )}
+      </button>
+      {isExpanded && (
+        <div
+          data-testid="unit-detail"
+          // The rule marks the detail's extent, so an expanded unit reads as a
+          // nested aside rather than more prose.
+          className="mt-1 ml-2 flex flex-col gap-1 border-l border-border pl-3"
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/conversation/CollapsibleThinking.tsx
+++ b/web/src/conversation/CollapsibleThinking.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { Brain } from "lucide-react";
+import { CollapsibleRow } from "@/conversation/CollapsibleRow";
 import { MarkdownText } from "@/conversation/MarkdownText";
 
 interface CollapsibleThinkingProps {
@@ -6,22 +7,11 @@ interface CollapsibleThinkingProps {
 }
 
 export function CollapsibleThinking({ thinking }: CollapsibleThinkingProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-
   return (
-    <div className="my-1">
-      <button
-        type="button"
-        onClick={() => setIsExpanded((prev) => !prev)}
-        className="cursor-pointer text-xs italic text-muted-foreground hover:text-muted-foreground/80"
-      >
-        Thinking...
-      </button>
-      {isExpanded && (
-        <div className="mt-1 rounded bg-card p-2 text-xs italic text-muted-foreground">
-          <MarkdownText>{thinking}</MarkdownText>
-        </div>
-      )}
-    </div>
+    <CollapsibleRow icon={Brain} summary="Thinking...">
+      <div className="overflow-x-auto rounded bg-card p-2 text-xs italic text-muted-foreground">
+        <MarkdownText>{thinking}</MarkdownText>
+      </div>
+    </CollapsibleRow>
   );
 }

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -1,33 +1,45 @@
-import { useState } from "react";
+import { Terminal } from "lucide-react";
 import type { ContentBlock } from "@/types";
+import { CollapsibleRow } from "@/conversation/CollapsibleRow";
 import { generateToolSummary } from "@/conversation/generateToolSummary";
+import type { ToolResultBlock } from "@/conversation/toolUnits";
 
 type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
 
 interface CollapsibleToolCallProps {
   block: ToolUseBlock;
+  result?: ToolResultBlock;
 }
 
-export function CollapsibleToolCall({ block }: CollapsibleToolCallProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
+function formatResultContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  return JSON.stringify(content, null, 2);
+}
 
+/**
+ * A tool call and the result it produced, as one unit.
+ *
+ * The result is passed in rather than read from the call's own turn: an Agent
+ * commonly records it in the next turn (#193).
+ */
+export function CollapsibleToolCall({
+  block,
+  result,
+}: CollapsibleToolCallProps) {
   return (
-    <div className="my-1">
-      <button
-        type="button"
-        onClick={() => setIsExpanded((prev) => !prev)}
-        // text-left overrides the browser's default centring for buttons: a
-        // long command or path wraps to a second line, and centred code is
-        // unreadable.
-        className="inline-block cursor-pointer rounded bg-card px-2 py-1 text-left font-mono text-xs text-chart-3 hover:bg-card/80"
-      >
-        {generateToolSummary(block)}
-      </button>
-      {isExpanded && (
-        <pre className="mt-1 overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
-          {JSON.stringify(block.input, null, 2)}
+    <CollapsibleRow
+      icon={Terminal}
+      summary={generateToolSummary(block)}
+      hasError={result?.is_error}
+    >
+      <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
+        {JSON.stringify(block.input, null, 2)}
+      </pre>
+      {result && (
+        <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
+          {formatResultContent(result.content)}
         </pre>
       )}
-    </div>
+    </CollapsibleRow>
   );
 }

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -352,6 +352,256 @@ describe("Conversation collapsed units", () => {
   });
 });
 
+describe("Conversation tool units", () => {
+  it("shows the tool's result when the unit is expanded", async () => {
+    // A call and its result are one unit: the reader asks "what did Read
+    // return?", not "which turn was the result recorded under" (#193).
+    const user = userEvent.setup();
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-tool",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Read",
+                input: { file_path: "/tmp/a.ts" },
+              },
+              {
+                type: "tool_result",
+                tool_use_id: "t1",
+                content: "export const answer = 42;",
+              },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    await user.click(await screen.findByText("Read: /tmp/a.ts"));
+
+    expect(await screen.findByText(/export const answer = 42;/)).not.toBeNull();
+  });
+
+  it("pairs a call with a result recorded in the next turn", async () => {
+    // The common shape in a real log: the Agent calls a tool, and the harness
+    // records the result as a user turn of its own. That turn renders nothing
+    // and is dropped before layout (#192), so pairing must read the unfiltered
+    // list — otherwise the result vanishes with the turn that carried it.
+    const user = userEvent.setup();
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-call",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Bash",
+                input: { command: "pnpm test" },
+              },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "m-result",
+            role: "user",
+            content: [
+              { type: "tool_result", tool_use_id: "t1", content: "17 passed" },
+            ],
+            timestamp: "2024-01-01T00:01:00Z",
+          },
+        ]}
+      />
+    );
+
+    await user.click(await screen.findByText("Bash: pnpm test"));
+
+    expect(await screen.findByText(/17 passed/)).not.toBeNull();
+  });
+
+  it("shows input and output under one left rule marking the unit's extent", async () => {
+    // The rule is what makes an expanded unit read as a nested aside rather
+    // than more prose: it marks where the unit's detail starts and ends (#193).
+    const user = userEvent.setup();
+    const { container } = render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-tool",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Bash",
+                input: { command: "pnpm test" },
+              },
+              { type: "tool_result", tool_use_id: "t1", content: "17 passed" },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    await user.click(await screen.findByText("Bash: pnpm test"));
+
+    const detail = container.querySelector('[data-testid="unit-detail"]')!;
+    expect(detail).not.toBeNull();
+    expect(detail.className).toContain("border-l");
+    // Both halves of the unit live inside that extent.
+    expect(detail.textContent).toContain("pnpm test");
+    expect(detail.textContent).toContain("17 passed");
+  });
+
+  it("makes the collapsed row obviously toggleable", async () => {
+    // A row that toggles must look like it toggles: a leading chevron, a
+    // pointer cursor, and a hover background. Without them the reader has no
+    // reason to try clicking, and the result stays hidden (#193).
+    const user = userEvent.setup();
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-tool",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Read",
+                input: { file_path: "/tmp/a.ts" },
+              },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    const row = await screen.findByRole("button", {
+      name: /Read: \/tmp\/a\.ts/,
+    });
+    expect(row).toHaveAttribute("aria-expanded", "false");
+    expect(row.querySelector('[data-testid="row-chevron"]')).not.toBeNull();
+    expect(row.className).toContain("cursor-pointer");
+    expect(row.className).toContain("hover:bg-");
+
+    await user.click(row);
+
+    expect(row).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("renders thinking with the same collapsible row as tool units", async () => {
+    // Thinking and tool units are the same kind of thing to a reader — skimmed
+    // past by default, opened on demand — so they share one row rather than
+    // each inventing their own affordance (#193).
+    const user = userEvent.setup();
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-thinking",
+            role: "assistant",
+            content: [{ type: "thinking", thinking: "weighing the options" }],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    const row = await screen.findByRole("button", { name: /Thinking/ });
+    expect(row).toHaveAttribute("aria-expanded", "false");
+    expect(row.querySelector('[data-testid="row-chevron"]')).not.toBeNull();
+    expect(row.className).toContain("cursor-pointer");
+
+    await user.click(row);
+
+    expect(row).toHaveAttribute("aria-expanded", "true");
+    expect(await screen.findByText("weighing the options")).not.toBeNull();
+  });
+
+  it("marks a failed result on the collapsed row", async () => {
+    // A failure is the thing a reader scans a session for. It has to show
+    // without expanding, or every row must be opened to find it (#193).
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-call",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Bash",
+                input: { command: "pnpm test" },
+              },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "m-result",
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "t1",
+                content: "1 failed",
+                is_error: true,
+              },
+            ],
+            timestamp: "2024-01-01T00:01:00Z",
+          },
+        ]}
+      />
+    );
+
+    const row = await screen.findByRole("button", { name: /Bash: pnpm test/ });
+    expect(row.querySelector('[data-testid="row-error"]')).not.toBeNull();
+  });
+
+  it("leaves a successful result unmarked", async () => {
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-tool",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Bash",
+                input: { command: "pnpm test" },
+              },
+              { type: "tool_result", tool_use_id: "t1", content: "17 passed" },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    const row = await screen.findByRole("button", { name: /Bash: pnpm test/ });
+    expect(row.querySelector('[data-testid="row-error"]')).toBeNull();
+  });
+});
+
 describe("Conversation markdown typography", () => {
   it("renders markdown links that open in a new tab", async () => {
     renderMessages([assistant("See the [docs](https://example.com) page.")]);

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -20,6 +20,10 @@ import {
   hasAuthorHeader,
   hasRenderableContent,
 } from "@/conversation/messageVisibility";
+import {
+  collectToolResults,
+  type ToolResultBlock,
+} from "@/conversation/toolUnits";
 import { useScrollShortcuts } from "@/conversation/useScrollShortcuts";
 import { getAgentDisplayName } from "@/agent/agentDisplayName";
 import { ChatMetadataPopover } from "@/metadata/ChatMetadataPopover";
@@ -141,7 +145,13 @@ function ConversationHeader({
   );
 }
 
-function renderContentBlock(block: ContentBlock, index: number) {
+type ToolResults = Map<string, ToolResultBlock>;
+
+function renderContentBlock(
+  block: ContentBlock,
+  index: number,
+  toolResults: ToolResults
+) {
   switch (block.type) {
     case "text":
       return <MarkdownText key={index}>{block.text}</MarkdownText>;
@@ -149,25 +159,33 @@ function renderContentBlock(block: ContentBlock, index: number) {
       if (!block.thinking) return null;
       return <CollapsibleThinking key={index} thinking={block.thinking} />;
     case "tool_use":
-      return <CollapsibleToolCall key={index} block={block} />;
+      return (
+        <CollapsibleToolCall
+          key={index}
+          block={block}
+          result={toolResults.get(block.id)}
+        />
+      );
     case "tool_result":
       return null;
   }
 }
 
-function renderContent(content: Message["content"]) {
+function renderContent(content: Message["content"], toolResults: ToolResults) {
   if (typeof content === "string") {
     return <MarkdownText>{content}</MarkdownText>;
   }
-  return content.map((block, i) => renderContentBlock(block, i));
+  return content.map((block, i) => renderContentBlock(block, i, toolResults));
 }
 
 function MessageItem({
   message,
   agentName,
+  toolResults,
 }: {
   message: Message;
   agentName: string;
+  toolResults: ToolResults;
 }) {
   return (
     <div
@@ -197,7 +215,7 @@ function MessageItem({
           </span>
         </div>
       )}
-      {renderContent(message.content)}
+      {renderContent(message.content, toolResults)}
     </div>
   );
 }
@@ -221,6 +239,12 @@ export function ConversationView({
   // show is not something to be told is new (#192).
   const messages = useMemo(
     () => allMessages.filter(hasRenderableContent),
+    [allMessages]
+  );
+  // Collected from the unfiltered list, since the turn carrying a result is
+  // itself one of the turns dropped above (#193).
+  const toolResults = useMemo(
+    () => collectToolResults(allMessages),
     [allMessages]
   );
   const tagControls: TagControls | undefined =
@@ -435,6 +459,7 @@ export function ConversationView({
                   <MessageItem
                     message={messages[virtualItem.index]}
                     agentName={agentName}
+                    toolResults={toolResults}
                   />
                 </div>
               ))}

--- a/web/src/conversation/toolUnits.ts
+++ b/web/src/conversation/toolUnits.ts
@@ -1,0 +1,24 @@
+import type { ContentBlock, Message } from "@/types";
+
+export type ToolResultBlock = Extract<ContentBlock, { type: "tool_result" }>;
+
+/**
+ * Every tool result in the Chat, keyed by the `tool_use` id it answers.
+ *
+ * Built from the *unfiltered* Message list. An Agent usually records a result
+ * in the turn after the call, and such a turn renders nothing of its own, so it
+ * is dropped before layout (#192). Collecting before that drop is what lets a
+ * call find its result whichever turn carried it (#193).
+ */
+export function collectToolResults(
+  messages: Message[]
+): Map<string, ToolResultBlock> {
+  const results = new Map<string, ToolResultBlock>();
+  for (const message of messages) {
+    if (typeof message.content === "string") continue;
+    for (const block of message.content) {
+      if (block.type === "tool_result") results.set(block.tool_use_id, block);
+    }
+  }
+  return results;
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -29,7 +29,13 @@ export type ContentBlock =
   | { type: "text"; text: string }
   | { type: "thinking"; thinking: string }
   | { type: "tool_use"; id: string; name: string; input: unknown }
-  | { type: "tool_result"; tool_use_id: string; content: unknown };
+  | {
+      type: "tool_result";
+      tool_use_id: string;
+      content: unknown;
+      /** Set when the tool reported a failure. Absent on success. */
+      is_error?: boolean;
+    };
 
 export interface Message {
   /** The Normalized `message_id`, unique within a Chat — the Message's stable handle. */


### PR DESCRIPTION
## Background (Why)

Tool calls and their results were split across turns: a `tool_use` block rendered on its own, and the matching `tool_result` — which an Agent commonly records in the *next* turn — never surfaced at all. The reader could see that a tool ran, but not what it returned. This is the second slice of the third-pane redesign (#193), building on the note-style layout (#192).

It also introduces the shared collapsible-row visual language that thinking, and later system rows, reuse — so those kinds cannot drift apart into three different affordances.

## Approach (How)

Pairing is a pure function (`toolUnits.collectToolResults`) that builds a `Map<toolUseId, result>` from the **unfiltered** message list. This ordering matters: #192's empty-turn suppression drops the turn a result was recorded under (a user turn carrying only tool results renders nothing), so pairing has to run before that drop or the result vanishes with its turn.

A new shared `CollapsibleRow` owns the collapsed/expanded language — a leading chevron (the same `ChevronDown` + `-rotate-90` design as the filter-panel sections), a per-kind icon, a one-line muted summary, hover feedback, and `aria-expanded`. `CollapsibleToolCall` and `CollapsibleThinking` now differ only by icon and summary.

The `tool_result` error flag flows end-to-end per ADR-0023: the Claude Code plugin normalizes wire `is_error` to `isError`, and the chat-reader maps it back to wire-form `is_error` for the API. The flag only ever widens a block on failure — no `false` is stored on successful results.

## Changes (What)

- [x] Pair a `tool_use` with its `tool_result` (including result-in-next-turn) into one collapsible unit; standalone tool-result turns stay suppressed (#192)
- [x] New shared `CollapsibleRow`: chevron + per-kind icon + one-line muted summary, hover background, pointer cursor, `aria-expanded`
- [x] Expanding shows input and output under a left rule; content scrolls horizontally rather than widening the pane
- [x] Errored results show a red dot on the collapsed row
- [x] Thinking reuses the same row component and styling
- [x] `is_error` end-to-end: plugin `normalizeBlock`, `NormalizedBlock`, chat-reader `toApiBlock` (wire-form `is_error`)

### Test Verification

- [x] A call pairs with a result in the **same** turn (expanding shows the output)
- [x] A call pairs with a result recorded in the **next** turn — the regression guard for reading the unfiltered list
- [x] Expanded detail shows input and output under one `border-l` rule
- [x] Collapsed row is obviously toggleable: chevron present, `cursor-pointer`, `hover:bg-*`, `aria-expanded` flips on click
- [x] Thinking renders through the same row and expands its content
- [x] Failed result shows the red dot; successful result does not
- [x] Plugin carries `is_error` through as `isError`; API serves it as wire-form `is_error`
- [x] Full suite green: api 329, web 323 (652 total), typecheck + lint clean

## Additional Notes

`is_error` does not reach **dormant** sessions (files that never change again) until the re-normalize-from-Raw mechanism ships in #191. Active sessions pick it up on their next append, since ingest re-reads the whole file and overwrites the normalized rows. This is additive per ADR-0023, so it needs a re-normalize to backfill, not a migration.

## Related Links

- Closes #193