### PR TITLE
feat(web): note-style conversation with paired tool units

### DIFF
--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -920,6 +920,47 @@ describe("ChatReader.getMessages", () => {
     expect(messages![1].role).toBe("assistant");
   });
 
+  it("exposes each message's Normalized message id", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-user",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "Build a login page",
+      blocks: [{ type: "text", text: "Build a login page" }],
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-assistant",
+      role: "assistant",
+      ts: new Date(1700000200000),
+      text: "Sure",
+      blocks: [{ type: "text", text: "Sure" }],
+    });
+
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
+      includeTrashed: false,
+    });
+
+    // The id travels from the Archive verbatim: it is the anchor the
+    // conversation pane keys a Message's DOM node by (#192), so it must be the
+    // Normalized message_id and never a positional index.
+    expect(messages!.map((m) => m.id)).toEqual(["m-user", "m-assistant"]);
+  });
+
   it("returns null for a trashed chat by default", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });

--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -1088,6 +1088,49 @@ describe("ChatReader.getMessages", () => {
       { type: "tool_result", tool_use_id: "tool-1", content: "result" },
     ]);
   });
+
+  it("serves a failed tool_result's error flag as is_error", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-tool",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "",
+      blocks: [
+        {
+          type: "tool_result",
+          toolUseId: "tool-1",
+          content: "command not found",
+          isError: true,
+        },
+      ],
+    });
+
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
+      includeTrashed: false,
+    });
+    expect(messages![0].content).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: "tool-1",
+        content: "command not found",
+        is_error: true,
+      },
+    ]);
+  });
 });
 
 describe("ChatReader is agent-agnostic", () => {

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -50,6 +50,13 @@ export type ApiContentBlock =
   | { type: "tool_result"; tool_use_id: string; content: unknown };
 
 export interface MessageResponse {
+  /**
+   * The Normalized `message_id`, unique within a Chat. Served as the Message's
+   * stable handle: the conversation pane anchors a Message's DOM node to it
+   * (#192) so Spotlight can scroll to an exact Message (#25) without depending
+   * on a positional index.
+   */
+  id: string;
   role: "user" | "assistant";
   content: ApiContentBlock[];
   timestamp: string;
@@ -367,6 +374,7 @@ export function createChatReader({
     const rows = archive.read.listMessagesByChat(row.agent, row.sourceId);
 
     return rows.map((m) => ({
+      id: m.messageId,
       role: m.role as "user" | "assistant",
       content: (m.blocks as StoredBlock[]).map(toApiBlock),
       timestamp: m.ts.toISOString(),

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -47,7 +47,13 @@ export type ApiContentBlock =
   | { type: "text"; text: string }
   | { type: "thinking"; thinking: string }
   | { type: "tool_use"; id: string; name: string; input: unknown }
-  | { type: "tool_result"; tool_use_id: string; content: unknown };
+  | {
+      type: "tool_result";
+      tool_use_id: string;
+      content: unknown;
+      /** Set when the tool reported a failure. Absent on success. */
+      is_error?: boolean;
+    };
 
 export interface MessageResponse {
   /**
@@ -73,6 +79,7 @@ function toApiBlock(block: StoredBlock): ApiContentBlock {
       type: "tool_result",
       tool_use_id: String(block.toolUseId ?? ""),
       content: block.content,
+      ...(block.isError === true ? { is_error: true } : {}),
     };
   }
   return block as ApiContentBlock;

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -293,6 +293,38 @@ describe("ClaudeCodePlugin.normalize", () => {
     ]);
   });
 
+  it("carries a tool_result's error flag through as isError", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-1",
+              content: "command not found",
+              is_error: true,
+            },
+          ],
+        },
+        isMeta: false,
+        isSidechain: false,
+        uuid: "msg-8",
+        timestamp: "2024-01-01T00:00:08Z",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "tool_result",
+        toolUseId: "tool-1",
+        content: "command not found",
+        isError: true,
+      },
+    ]);
+  });
+
   it("normalizes a user text message", () => {
     const result = plugin.normalize(
       rawRecord({

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -154,6 +154,9 @@ function normalizeBlock(raw: unknown): NormalizedBlock | null {
         type: "tool_result",
         toolUseId: String(b.tool_use_id ?? ""),
         content: b.content,
+        // Only carried when the tool actually failed: a `false` on every
+        // successful result would grow the stored block for nothing.
+        ...(b.is_error === true ? { isError: true } : {}),
       };
     default:
       return null;

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -21,7 +21,16 @@ export type NormalizedBlock =
   | { type: "text"; text: string }
   | { type: "thinking"; thinking: string }
   | { type: "tool_use"; id: string; name: string; input: unknown }
-  | { type: "tool_result"; toolUseId: string; content: unknown };
+  | {
+      type: "tool_result";
+      toolUseId: string;
+      content: unknown;
+      /**
+       * Set when the tool reported a failure. Omitted on success, so the flag
+       * only ever widens a stored block (ADR-0023).
+       */
+      isError?: boolean;
+    };
 
 export interface NormalizedMessage {
   messageId: string;

--- a/web/src/conversation/CollapsibleRow.tsx
+++ b/web/src/conversation/CollapsibleRow.tsx
@@ -1,0 +1,70 @@
+import { useState, type ReactNode } from "react";
+import { ChevronDown, type LucideIcon } from "lucide-react";
+
+interface CollapsibleRowProps {
+  /** The kind marker — a terminal for tool units, a brain for thinking. */
+  icon: LucideIcon;
+  /** The one-line collapsed summary. */
+  summary: string;
+  /** Marks the row as reporting a failure. */
+  hasError?: boolean;
+  /** The detail revealed when expanded. */
+  children: ReactNode;
+}
+
+/**
+ * One collapsed line that opens into its detail.
+ *
+ * The shared visual language for everything the reader skims past by default —
+ * tool units, thinking, and later system rows (#193). Kept as one component so
+ * those kinds cannot drift apart: they differ only by icon and summary.
+ */
+export function CollapsibleRow({
+  icon: Icon,
+  summary,
+  hasError,
+  children,
+}: CollapsibleRowProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div className="my-1">
+      <button
+        type="button"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        aria-expanded={isExpanded}
+        // Muted and a size down from body text: these rows are the parts of a
+        // session the reader scans past, not the prose they came to read.
+        className="flex w-full cursor-pointer items-center gap-1.5 rounded px-1.5 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-white/[0.04] hover:text-foreground"
+      >
+        <ChevronDown
+          data-testid="row-chevron"
+          size={12}
+          aria-hidden="true"
+          className={`shrink-0 transition-transform ${
+            isExpanded ? "" : "-rotate-90"
+          }`}
+        />
+        <Icon size={12} aria-hidden="true" className="shrink-0" />
+        <span className="truncate font-mono">{summary}</span>
+        {hasError && (
+          <span
+            data-testid="row-error"
+            aria-label="Failed"
+            className="ml-1 size-1.5 shrink-0 rounded-full bg-destructive"
+          />
+        )}
+      </button>
+      {isExpanded && (
+        <div
+          data-testid="unit-detail"
+          // The rule marks the detail's extent, so an expanded unit reads as a
+          // nested aside rather than more prose.
+          className="mt-1 ml-2 flex flex-col gap-1 border-l border-border pl-3"
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/conversation/CollapsibleThinking.tsx
+++ b/web/src/conversation/CollapsibleThinking.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { Brain } from "lucide-react";
+import { CollapsibleRow } from "@/conversation/CollapsibleRow";
 import { MarkdownText } from "@/conversation/MarkdownText";
 
 interface CollapsibleThinkingProps {
@@ -6,22 +7,11 @@ interface CollapsibleThinkingProps {
 }
 
 export function CollapsibleThinking({ thinking }: CollapsibleThinkingProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-
   return (
-    <div className="my-1">
-      <button
-        type="button"
-        onClick={() => setIsExpanded((prev) => !prev)}
-        className="cursor-pointer text-xs italic text-muted-foreground hover:text-muted-foreground/80"
-      >
-        Thinking...
-      </button>
-      {isExpanded && (
-        <div className="mt-1 rounded bg-card p-2 text-xs italic text-muted-foreground">
-          <MarkdownText>{thinking}</MarkdownText>
-        </div>
-      )}
-    </div>
+    <CollapsibleRow icon={Brain} summary="Thinking...">
+      <div className="overflow-x-auto rounded bg-card p-2 text-xs italic text-muted-foreground">
+        <MarkdownText>{thinking}</MarkdownText>
+      </div>
+    </CollapsibleRow>
   );
 }

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -1,33 +1,45 @@
-import { useState } from "react";
+import { Terminal } from "lucide-react";
 import type { ContentBlock } from "@/types";
+import { CollapsibleRow } from "@/conversation/CollapsibleRow";
 import { generateToolSummary } from "@/conversation/generateToolSummary";
+import type { ToolResultBlock } from "@/conversation/toolUnits";
 
 type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
 
 interface CollapsibleToolCallProps {
   block: ToolUseBlock;
+  result?: ToolResultBlock;
 }
 
-export function CollapsibleToolCall({ block }: CollapsibleToolCallProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
+function formatResultContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  return JSON.stringify(content, null, 2);
+}
 
+/**
+ * A tool call and the result it produced, as one unit.
+ *
+ * The result is passed in rather than read from the call's own turn: an Agent
+ * commonly records it in the next turn (#193).
+ */
+export function CollapsibleToolCall({
+  block,
+  result,
+}: CollapsibleToolCallProps) {
   return (
-    <div className="my-1">
-      <button
-        type="button"
-        onClick={() => setIsExpanded((prev) => !prev)}
-        // text-left overrides the browser's default centring for buttons: a
-        // long command or path wraps to a second line, and centred code is
-        // unreadable.
-        className="inline-block cursor-pointer rounded bg-card px-2 py-1 text-left font-mono text-xs text-chart-3 hover:bg-card/80"
-      >
-        {generateToolSummary(block)}
-      </button>
-      {isExpanded && (
-        <pre className="mt-1 overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
-          {JSON.stringify(block.input, null, 2)}
+    <CollapsibleRow
+      icon={Terminal}
+      summary={generateToolSummary(block)}
+      hasError={result?.is_error}
+    >
+      <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
+        {JSON.stringify(block.input, null, 2)}
+      </pre>
+      {result && (
+        <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
+          {formatResultContent(result.content)}
         </pre>
       )}
-    </div>
+    </CollapsibleRow>
   );
 }

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -16,7 +16,10 @@ export function CollapsibleToolCall({ block }: CollapsibleToolCallProps) {
       <button
         type="button"
         onClick={() => setIsExpanded((prev) => !prev)}
-        className="inline-block cursor-pointer rounded bg-card px-2 py-1 font-mono text-xs text-chart-3 hover:bg-card/80"
+        // text-left overrides the browser's default centring for buttons: a
+        // long command or path wraps to a second line, and centred code is
+        // unreadable.
+        className="inline-block cursor-pointer rounded bg-card px-2 py-1 text-left font-mono text-xs text-chart-3 hover:bg-card/80"
       >
         {generateToolSummary(block)}
       </button>

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -352,6 +352,256 @@ describe("Conversation collapsed units", () => {
   });
 });
 
+describe("Conversation tool units", () => {
+  it("shows the tool's result when the unit is expanded", async () => {
+    // A call and its result are one unit: the reader asks "what did Read
+    // return?", not "which turn was the result recorded under" (#193).
+    const user = userEvent.setup();
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-tool",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Read",
+                input: { file_path: "/tmp/a.ts" },
+              },
+              {
+                type: "tool_result",
+                tool_use_id: "t1",
+                content: "export const answer = 42;",
+              },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    await user.click(await screen.findByText("Read: /tmp/a.ts"));
+
+    expect(await screen.findByText(/export const answer = 42;/)).not.toBeNull();
+  });
+
+  it("pairs a call with a result recorded in the next turn", async () => {
+    // The common shape in a real log: the Agent calls a tool, and the harness
+    // records the result as a user turn of its own. That turn renders nothing
+    // and is dropped before layout (#192), so pairing must read the unfiltered
+    // list — otherwise the result vanishes with the turn that carried it.
+    const user = userEvent.setup();
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-call",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Bash",
+                input: { command: "pnpm test" },
+              },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "m-result",
+            role: "user",
+            content: [
+              { type: "tool_result", tool_use_id: "t1", content: "17 passed" },
+            ],
+            timestamp: "2024-01-01T00:01:00Z",
+          },
+        ]}
+      />
+    );
+
+    await user.click(await screen.findByText("Bash: pnpm test"));
+
+    expect(await screen.findByText(/17 passed/)).not.toBeNull();
+  });
+
+  it("shows input and output under one left rule marking the unit's extent", async () => {
+    // The rule is what makes an expanded unit read as a nested aside rather
+    // than more prose: it marks where the unit's detail starts and ends (#193).
+    const user = userEvent.setup();
+    const { container } = render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-tool",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Bash",
+                input: { command: "pnpm test" },
+              },
+              { type: "tool_result", tool_use_id: "t1", content: "17 passed" },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    await user.click(await screen.findByText("Bash: pnpm test"));
+
+    const detail = container.querySelector('[data-testid="unit-detail"]')!;
+    expect(detail).not.toBeNull();
+    expect(detail.className).toContain("border-l");
+    // Both halves of the unit live inside that extent.
+    expect(detail.textContent).toContain("pnpm test");
+    expect(detail.textContent).toContain("17 passed");
+  });
+
+  it("makes the collapsed row obviously toggleable", async () => {
+    // A row that toggles must look like it toggles: a leading chevron, a
+    // pointer cursor, and a hover background. Without them the reader has no
+    // reason to try clicking, and the result stays hidden (#193).
+    const user = userEvent.setup();
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-tool",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Read",
+                input: { file_path: "/tmp/a.ts" },
+              },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    const row = await screen.findByRole("button", {
+      name: /Read: \/tmp\/a\.ts/,
+    });
+    expect(row).toHaveAttribute("aria-expanded", "false");
+    expect(row.querySelector('[data-testid="row-chevron"]')).not.toBeNull();
+    expect(row.className).toContain("cursor-pointer");
+    expect(row.className).toContain("hover:bg-");
+
+    await user.click(row);
+
+    expect(row).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("renders thinking with the same collapsible row as tool units", async () => {
+    // Thinking and tool units are the same kind of thing to a reader — skimmed
+    // past by default, opened on demand — so they share one row rather than
+    // each inventing their own affordance (#193).
+    const user = userEvent.setup();
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-thinking",
+            role: "assistant",
+            content: [{ type: "thinking", thinking: "weighing the options" }],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    const row = await screen.findByRole("button", { name: /Thinking/ });
+    expect(row).toHaveAttribute("aria-expanded", "false");
+    expect(row.querySelector('[data-testid="row-chevron"]')).not.toBeNull();
+    expect(row.className).toContain("cursor-pointer");
+
+    await user.click(row);
+
+    expect(row).toHaveAttribute("aria-expanded", "true");
+    expect(await screen.findByText("weighing the options")).not.toBeNull();
+  });
+
+  it("marks a failed result on the collapsed row", async () => {
+    // A failure is the thing a reader scans a session for. It has to show
+    // without expanding, or every row must be opened to find it (#193).
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-call",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Bash",
+                input: { command: "pnpm test" },
+              },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "m-result",
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "t1",
+                content: "1 failed",
+                is_error: true,
+              },
+            ],
+            timestamp: "2024-01-01T00:01:00Z",
+          },
+        ]}
+      />
+    );
+
+    const row = await screen.findByRole("button", { name: /Bash: pnpm test/ });
+    expect(row.querySelector('[data-testid="row-error"]')).not.toBeNull();
+  });
+
+  it("leaves a successful result unmarked", async () => {
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-tool",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Bash",
+                input: { command: "pnpm test" },
+              },
+              { type: "tool_result", tool_use_id: "t1", content: "17 passed" },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    const row = await screen.findByRole("button", { name: /Bash: pnpm test/ });
+    expect(row.querySelector('[data-testid="row-error"]')).toBeNull();
+  });
+});
+
 describe("Conversation markdown typography", () => {
   it("renders markdown links that open in a new tab", async () => {
     renderMessages([assistant("See the [docs](https://example.com) page.")]);

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { ConversationView } from "@/conversation/ConversationView";
+import { messageAnchorId } from "@/conversation/messageAnchor";
 import type { Chat, Message } from "@/types";
 
 const chat: Chat = {
@@ -20,8 +21,11 @@ function renderMessages(messages: Message[]) {
   return render(<ConversationView chat={chat} messages={messages} />);
 }
 
+let nextMessageId = 0;
+
 function assistant(text: string): Message {
   return {
+    id: `m-${(nextMessageId += 1)}`,
     role: "assistant",
     content: text,
     timestamp: "2024-01-01T00:00:00Z",
@@ -159,6 +163,195 @@ describe("Conversation live arrival", () => {
   });
 });
 
+describe("Conversation note-style headers", () => {
+  it("names the assistant by its agent display name, never ASSISTANT", async () => {
+    render(
+      <ConversationView
+        chat={{ ...chat, agent: "claude-code" }}
+        messages={[assistant("Sure, here goes.")]}
+      />
+    );
+
+    expect(await screen.findByText("Claude Code")).not.toBeNull();
+    // The literal role name is the thing this layout replaces: an archive
+    // header should read like a person's name, not a wire-protocol value.
+    expect(screen.queryByText(/^assistant$/i)).toBeNull();
+  });
+
+  it("stamps every header with an absolute date and time", async () => {
+    // A single-day session still carries the date (#192): the header is read as
+    // a record of when something happened, not only where it sits in the day.
+    // Asserted by shape, not a literal — the value renders in the reader's
+    // local timezone, and the suite pins no TZ.
+    renderMessages([assistant("one")]);
+
+    expect(
+      await screen.findByText(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/)
+    ).not.toBeNull();
+  });
+
+  it("names the reader's own turns You", async () => {
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-ask",
+            role: "user",
+            content: "Build a login page",
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    expect(await screen.findByText("You")).not.toBeNull();
+  });
+});
+
+describe("Conversation note-style layout", () => {
+  async function renderBothRoles() {
+    const { container } = render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-ask",
+            role: "user",
+            content: "Build a login page",
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+          assistant("Sure, here goes."),
+        ]}
+      />
+    );
+    await screen.findByText("Sure, here goes.");
+    return {
+      user: container.querySelector('[data-role="user"]')!,
+      assistant: container.querySelector('[data-role="assistant"]')!,
+    };
+  }
+
+  it("gives user turns a background block and assistant turns none", async () => {
+    // The reader's own turns are the scanning anchors in a long session; the
+    // Agent's prose sits directly on the pane (#192).
+    const { user, assistant: agent } = await renderBothRoles();
+
+    expect(user.className).toContain("bg-card");
+    expect(agent.className).not.toContain("bg-");
+  });
+
+  it("lays both roles out full-width, with no bubbles or side alignment", async () => {
+    const { user, assistant: agent } = await renderBothRoles();
+
+    // A document flow, not a chat transcript: nothing is pushed to a side or
+    // capped to a bubble's width.
+    for (const el of [user, agent]) {
+      expect(el.className).not.toContain("self-end");
+      expect(el.className).not.toContain("self-start");
+      expect(el.className).not.toContain("max-w-[85%]");
+    }
+  });
+});
+
+describe("Conversation message anchors", () => {
+  it("anchors each message to its message id, not its position", async () => {
+    // The anchor is this layout's public contract (#192): Spotlight (#25)
+    // scrolls to an exact Message through it, so it must survive turns being
+    // dropped, reordered, or arriving live — which a positional index does not.
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-user",
+            role: "user",
+            content: [
+              { type: "tool_result", tool_use_id: "t1", content: "ok" },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "m-assistant",
+            role: "assistant",
+            content: "Sure, here goes.",
+            timestamp: "2024-01-01T00:01:00Z",
+          },
+        ]}
+      />
+    );
+
+    await screen.findByText("Sure, here goes.");
+    // The empty first turn is dropped, so the surviving message sits at index
+    // 0 — its anchor must still name the message, not that position.
+    const anchored = document.getElementById(messageAnchorId("m-assistant"));
+    expect(anchored).not.toBeNull();
+    expect(anchored!.textContent).toContain("Sure, here goes.");
+  });
+});
+
+describe("Conversation empty-turn suppression", () => {
+  it("drops a turn whose content renders nothing at all", async () => {
+    // A user turn carrying only tool results is a harness artifact, not
+    // something the reader wrote. It has nothing to show, so it contributes no
+    // header and no block — rather than an empty "You" box (#192).
+    const { container } = render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          assistant("Sure, running that now."),
+          {
+            id: "m-tool-result",
+            role: "user",
+            content: [
+              { type: "tool_result", tool_use_id: "t1", content: "ok" },
+            ],
+            timestamp: "2024-01-01T00:01:00Z",
+          },
+        ]}
+      />
+    );
+
+    await screen.findByText("Sure, running that now.");
+    expect(screen.queryByText("You")).toBeNull();
+    expect(container.querySelector('[data-role="user"]')).toBeNull();
+  });
+});
+
+describe("Conversation collapsed units", () => {
+  it("gives a tool-only turn its collapsed row but no header of its own", async () => {
+    // Tool calls nest under the message that prompted them (#192). The Agent
+    // records them as separate turns, but the reader sees one authored moment,
+    // so the run of tool calls must not repeat the author header.
+    render(
+      <ConversationView
+        chat={{ ...chat, agent: "claude-code" }}
+        messages={[
+          assistant("Let me check that file."),
+          {
+            id: "m-tool-use",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Read",
+                input: { file_path: "/tmp/a.ts" },
+              },
+            ],
+            timestamp: "2024-01-01T00:01:00Z",
+          },
+        ]}
+      />
+    );
+
+    // The collapsed row is still rendered — it is content, just not authored.
+    expect(await screen.findByText("Read: /tmp/a.ts")).not.toBeNull();
+    // ...but the header belongs to the text turn alone.
+    expect(screen.getAllByText("Claude Code")).toHaveLength(1);
+  });
+});
+
 describe("Conversation markdown typography", () => {
   it("renders markdown links that open in a new tab", async () => {
     renderMessages([assistant("See the [docs](https://example.com) page.")]);
@@ -185,6 +378,7 @@ describe("Conversation markdown typography", () => {
         chat={chat}
         messages={[
           {
+            id: "m-thinking",
             role: "assistant",
             content: [{ type: "thinking", thinking: "- first\n- second\n" }],
             timestamp: "2024-01-01T00:00:00Z",

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -20,6 +20,10 @@ import {
   hasAuthorHeader,
   hasRenderableContent,
 } from "@/conversation/messageVisibility";
+import {
+  collectToolResults,
+  type ToolResultBlock,
+} from "@/conversation/toolUnits";
 import { useScrollShortcuts } from "@/conversation/useScrollShortcuts";
 import { getAgentDisplayName } from "@/agent/agentDisplayName";
 import { ChatMetadataPopover } from "@/metadata/ChatMetadataPopover";
@@ -141,7 +145,13 @@ function ConversationHeader({
   );
 }
 
-function renderContentBlock(block: ContentBlock, index: number) {
+type ToolResults = Map<string, ToolResultBlock>;
+
+function renderContentBlock(
+  block: ContentBlock,
+  index: number,
+  toolResults: ToolResults
+) {
   switch (block.type) {
     case "text":
       return <MarkdownText key={index}>{block.text}</MarkdownText>;
@@ -149,25 +159,33 @@ function renderContentBlock(block: ContentBlock, index: number) {
       if (!block.thinking) return null;
       return <CollapsibleThinking key={index} thinking={block.thinking} />;
     case "tool_use":
-      return <CollapsibleToolCall key={index} block={block} />;
+      return (
+        <CollapsibleToolCall
+          key={index}
+          block={block}
+          result={toolResults.get(block.id)}
+        />
+      );
     case "tool_result":
       return null;
   }
 }
 
-function renderContent(content: Message["content"]) {
+function renderContent(content: Message["content"], toolResults: ToolResults) {
   if (typeof content === "string") {
     return <MarkdownText>{content}</MarkdownText>;
   }
-  return content.map((block, i) => renderContentBlock(block, i));
+  return content.map((block, i) => renderContentBlock(block, i, toolResults));
 }
 
 function MessageItem({
   message,
   agentName,
+  toolResults,
 }: {
   message: Message;
   agentName: string;
+  toolResults: ToolResults;
 }) {
   return (
     <div
@@ -197,7 +215,7 @@ function MessageItem({
           </span>
         </div>
       )}
-      {renderContent(message.content)}
+      {renderContent(message.content, toolResults)}
     </div>
   );
 }
@@ -221,6 +239,12 @@ export function ConversationView({
   // show is not something to be told is new (#192).
   const messages = useMemo(
     () => allMessages.filter(hasRenderableContent),
+    [allMessages]
+  );
+  // Collected from the unfiltered list, since the turn carrying a result is
+  // itself one of the turns dropped above (#193).
+  const toolResults = useMemo(
+    () => collectToolResults(allMessages),
     [allMessages]
   );
   const tagControls: TagControls | undefined =
@@ -435,6 +459,7 @@ export function ConversationView({
                   <MessageItem
                     message={messages[virtualItem.index]}
                     agentName={agentName}
+                    toolResults={toolResults}
                   />
                 </div>
               ))}

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { RotateCcw } from "lucide-react";
 import type { Message, ContentBlock, Chat, Tag } from "@/types";
@@ -12,9 +12,16 @@ import {
   getScrollPillTarget,
   type ScrollPillTarget,
 } from "@/conversation/scrollPillVisibility";
+import { formatMessageTimestamp } from "@/conversation/formatMessageTimestamp";
+import { messageAnchorId } from "@/conversation/messageAnchor";
 import { deriveArrivalAction } from "@/conversation/liveArrival";
 import { deriveFirstUnseenIndex } from "@/conversation/firstUnseenIndex";
+import {
+  hasAuthorHeader,
+  hasRenderableContent,
+} from "@/conversation/messageVisibility";
 import { useScrollShortcuts } from "@/conversation/useScrollShortcuts";
+import { getAgentDisplayName } from "@/agent/agentDisplayName";
 import { ChatMetadataPopover } from "@/metadata/ChatMetadataPopover";
 import { EditableTitle } from "@/metadata/EditableTitle";
 import { TagStrip } from "@/tags/TagStrip";
@@ -155,23 +162,41 @@ function renderContent(content: Message["content"]) {
   return content.map((block, i) => renderContentBlock(block, i));
 }
 
-function MessageBubble({ message }: { message: Message }) {
+function MessageItem({
+  message,
+  agentName,
+}: {
+  message: Message;
+  agentName: string;
+}) {
   return (
     <div
+      id={messageAnchorId(message.id)}
       data-role={message.role}
-      className={`max-w-[85%] rounded-lg px-4 py-3 text-sm leading-relaxed ${
+      // A note-style document flow: every turn spans the pane's column, and
+      // only the reader's own turns take a background block, as scanning
+      // anchors. Both roles keep the same horizontal padding so their text
+      // aligns down a single edge (#192).
+      className={`w-full px-4 py-3 text-sm leading-relaxed ${
         message.role === "user"
-          ? "self-end bg-card text-accent-foreground"
-          : "self-start bg-primary/10 text-foreground"
+          ? "rounded-md bg-card text-accent-foreground"
+          : "text-foreground"
       }`}
     >
-      <div
-        className={`mb-1 text-xs font-semibold uppercase tracking-wide ${
-          message.role === "user" ? "text-chart-2" : "text-primary"
-        }`}
-      >
-        {message.role === "user" ? "You" : "Assistant"}
-      </div>
+      {hasAuthorHeader(message) && (
+        // Set as a name, not a label: the old all-caps role tag belonged to the
+        // bubble layout, and an agent's display name is written "Claude Code".
+        <div
+          className={`mb-1 text-xs font-semibold ${
+            message.role === "user" ? "text-chart-2" : "text-primary"
+          }`}
+        >
+          {message.role === "user" ? "You" : agentName}
+          <span className="ml-2 font-normal text-muted-foreground">
+            {formatMessageTimestamp(message.timestamp)}
+          </span>
+        </div>
+      )}
       {renderContent(message.content)}
     </div>
   );
@@ -179,7 +204,7 @@ function MessageBubble({ message }: { message: Message }) {
 
 export function ConversationView({
   chat,
-  messages,
+  messages: allMessages,
   error,
   onRestore,
   onRenameTitle,
@@ -190,6 +215,14 @@ export function ConversationView({
   onRemoveTag,
   onCreateTag,
 }: ConversationViewProps) {
+  // Turns that render nothing are dropped once, here, so everything downstream
+  // — virtualizer indices, the unread divider, the live-arrival trackers —
+  // counts only Messages the reader can actually see. A turn with nothing to
+  // show is not something to be told is new (#192).
+  const messages = useMemo(
+    () => allMessages.filter(hasRenderableContent),
+    [allMessages]
+  );
   const tagControls: TagControls | undefined =
     allTags && onAssignTag && onRemoveTag && onCreateTag
       ? { allTags, onAssignTag, onRemoveTag, onCreateTag }
@@ -202,6 +235,9 @@ export function ConversationView({
     onEditingTitleChange?.(next);
   };
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Assistant turns are authored by the Agent that recorded the Chat, so the
+  // header names it ("Claude Code") rather than the wire-form role.
+  const agentName = getAgentDisplayName(chat?.agent ?? "");
 
   // TanStack Virtual's useVirtualizer returns functions (e.g. measureElement)
   // that the React Compiler cannot memoize without risking stale UI, so the
@@ -396,7 +432,10 @@ export function ConversationView({
                       <UnreadDivider />
                     </div>
                   )}
-                  <MessageBubble message={messages[virtualItem.index]} />
+                  <MessageItem
+                    message={messages[virtualItem.index]}
+                    agentName={agentName}
+                  />
                 </div>
               ))}
             </div>

--- a/web/src/conversation/formatMessageTimestamp.ts
+++ b/web/src/conversation/formatMessageTimestamp.ts
@@ -1,0 +1,20 @@
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+/**
+ * A Message header's absolute stamp: `2026-07-17 14:32`, in the reader's local
+ * timezone.
+ *
+ * Always both date and time, never relative ("2h ago") and never time-only
+ * (#192). An archive is read long after the fact, so "14:32" alone is not a
+ * fact the reader can place, and the date cannot depend on whether the Chat
+ * happens to span midnight — that would make the same Message render
+ * differently depending on its neighbours.
+ */
+export function formatMessageTimestamp(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "";
+  const day = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+  return `${day} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}

--- a/web/src/conversation/messageAnchor.ts
+++ b/web/src/conversation/messageAnchor.ts
@@ -1,0 +1,18 @@
+/**
+ * The DOM id anchoring a rendered Message, derived from its Normalized
+ * `message_id`.
+ *
+ * This is the conversation layout's public contract (#192): Spotlight (#25)
+ * scrolls to and highlights an exact Message by resolving this id, without
+ * knowing anything about how the pane lays messages out. It is a function, not
+ * a documented string format, so both sides can never drift apart.
+ *
+ * Keyed by message id rather than list position on purpose — positions shift
+ * when empty turns are dropped or live messages arrive, and an anchor that
+ * moves under a link is not an anchor.
+ */
+export function messageAnchorId(messageId: string): string {
+  // Prefixed so the value is always a valid DOM id, whatever an Agent's
+  // message ids look like.
+  return `message-${messageId}`;
+}

--- a/web/src/conversation/messageVisibility.ts
+++ b/web/src/conversation/messageVisibility.ts
@@ -1,0 +1,50 @@
+import type { ContentBlock, Message } from "@/types";
+
+function hasText(text: string): boolean {
+  return text.trim().length > 0;
+}
+
+function rendersSomething(block: ContentBlock): boolean {
+  switch (block.type) {
+    case "text":
+      return hasText(block.text);
+    case "thinking":
+      return hasText(block.thinking);
+    case "tool_use":
+      // Renders as a collapsed row — visible, though it carries no header.
+      return true;
+    case "tool_result":
+      // Never rendered on its own: a result belongs to the tool call that
+      // produced it, not to the turn the Agent happened to record it under.
+      return false;
+  }
+}
+
+/**
+ * Whether a Message puts anything on screen at all.
+ *
+ * A turn that renders nothing — most often a user turn carrying only tool
+ * results — is dropped before layout, so it can never surface as an empty
+ * authored block (#192). Suppressing it at render time would still leave the
+ * turn occupying a row in the virtualized list.
+ */
+export function hasRenderableContent(message: Message): boolean {
+  if (typeof message.content === "string") return hasText(message.content);
+  return message.content.some(rendersSomething);
+}
+
+/**
+ * Whether a Message is authored prose, and so earns a `You` / agent-name
+ * header.
+ *
+ * Only text counts. Tool calls and thinking are collapsed units: the Agent logs
+ * them as turns of their own, but the reader sees them as part of the moment
+ * that prompted them, so they nest under the preceding header instead of
+ * repeating it (#192).
+ */
+export function hasAuthorHeader(message: Message): boolean {
+  if (typeof message.content === "string") return hasText(message.content);
+  return message.content.some(
+    (block) => block.type === "text" && hasText(block.text)
+  );
+}

--- a/web/src/conversation/toolUnits.ts
+++ b/web/src/conversation/toolUnits.ts
@@ -1,0 +1,24 @@
+import type { ContentBlock, Message } from "@/types";
+
+export type ToolResultBlock = Extract<ContentBlock, { type: "tool_result" }>;
+
+/**
+ * Every tool result in the Chat, keyed by the `tool_use` id it answers.
+ *
+ * Built from the *unfiltered* Message list. An Agent usually records a result
+ * in the turn after the call, and such a turn renders nothing of its own, so it
+ * is dropped before layout (#192). Collecting before that drop is what lets a
+ * call find its result whichever turn carried it (#193).
+ */
+export function collectToolResults(
+  messages: Message[]
+): Map<string, ToolResultBlock> {
+  const results = new Map<string, ToolResultBlock>();
+  for (const message of messages) {
+    if (typeof message.content === "string") continue;
+    for (const block of message.content) {
+      if (block.type === "tool_result") results.set(block.tool_use_id, block);
+    }
+  }
+  return results;
+}

--- a/web/src/conversation/useMessages.test.tsx
+++ b/web/src/conversation/useMessages.test.tsx
@@ -6,8 +6,15 @@ import type { ConversationStreamConnector } from "@/conversation/useConversation
 import { server } from "@/test/server";
 import type { Message } from "@/types";
 
+let nextMessageId = 0;
+
 function message(role: Message["role"], text: string): Message {
-  return { role, content: text, timestamp: "2024-01-01T00:00:00Z" };
+  return {
+    id: `m-${(nextMessageId += 1)}`,
+    role,
+    content: text,
+    timestamp: "2024-01-01T00:00:00Z",
+  };
 }
 
 // A connector double that lets the test push a `changed` event for given ids.

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { MAX_PAGE_LIMIT } from "@contract";
+import type { Message } from "@/types";
 
 type FakeChat = {
   id: string;
@@ -203,14 +204,19 @@ function resolveBatchIds(body: unknown): string[] {
   return [];
 }
 
-export const fakeMessages = {
+// Typed against the wire shape so a change to the served Message contract (a
+// new required field, say) fails here rather than silently letting the double
+// drift from the real API.
+export const fakeMessages: Record<string, Message[]> = {
   "chat-1": [
     {
+      id: "chat-1-m1",
       role: "user",
       content: "Help me build a login page",
       timestamp: "2024-01-01T00:00:02Z",
     },
     {
+      id: "chat-1-m2",
       role: "assistant",
       content: [{ type: "text", text: "Sure, I'll create a login page." }],
       timestamp: "2024-01-01T00:00:03Z",
@@ -218,11 +224,13 @@ export const fakeMessages = {
   ],
   "chat-2": [
     {
+      id: "chat-2-m1",
       role: "user",
       content: "Show me a **bold** example with a [link](https://example.com)",
       timestamp: "2024-01-01T00:00:04Z",
     },
     {
+      id: "chat-2-m2",
       role: "assistant",
       content: [
         {
@@ -235,6 +243,7 @@ export const fakeMessages = {
   ],
   "chat-deleted-1": [
     {
+      id: "chat-deleted-1-m1",
       role: "user",
       content: "Quick prototype experiment",
       timestamp: "2024-01-01T00:00:08Z",
@@ -242,11 +251,13 @@ export const fakeMessages = {
   ],
   "chat-3": [
     {
+      id: "chat-3-m1",
       role: "user",
       content: "Refactor the utils module",
       timestamp: "2024-01-01T00:00:06Z",
     },
     {
+      id: "chat-3-m2",
       role: "assistant",
       content: [
         {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -29,7 +29,13 @@ export type ContentBlock =
   | { type: "text"; text: string }
   | { type: "thinking"; thinking: string }
   | { type: "tool_use"; id: string; name: string; input: unknown }
-  | { type: "tool_result"; tool_use_id: string; content: unknown };
+  | {
+      type: "tool_result";
+      tool_use_id: string;
+      content: unknown;
+      /** Set when the tool reported a failure. Absent on success. */
+      is_error?: boolean;
+    };
 
 export interface Message {
   /** The Normalized `message_id`, unique within a Chat — the Message's stable handle. */

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -32,6 +32,8 @@ export type ContentBlock =
   | { type: "tool_result"; tool_use_id: string; content: unknown };
 
 export interface Message {
+  /** The Normalized `message_id`, unique within a Chat — the Message's stable handle. */
+  id: string;
   role: "user" | "assistant";
   content: string | ContentBlock[];
   timestamp: string;


### PR DESCRIPTION
## Background (Why)

The conversation pane read like a chat transcript — role-labelled bubbles, tool calls stranded from their results, and turns the reader never wrote showing up as empty boxes. This integration branch reworks it into a note-style document that reads like a record of a session, and pairs each tool call with what it returned. It lands the note-style layout (#192) and paired tool units (#193) together.

## Approach (How)

**#192 — note-style layout.** Turns span the pane's full column; only the reader's own turns take a background block, as scanning anchors. Headers read like a name and a timestamp ("Claude Code · 2024-01-01 09:00"), not an all-caps wire role. A turn that renders nothing — most often a user turn carrying only tool results — is dropped once, before layout, so it never surfaces as an empty authored block, and the drop keeps virtualizer indices, the unread divider, and the live-arrival trackers counting only visible turns. Each message anchors its DOM node to its normalized message id, the public contract Spotlight (#25) will scroll through.

**#193 — paired tool units + shared row language.** A `tool_use` block pairs with its `tool_result` — commonly recorded in the next turn — into one collapsible unit. Pairing collects results from the unfiltered message list, before #192's empty-turn suppression drops the turn a result was recorded under. A shared `CollapsibleRow` owns the collapsed/expanded language (chevron + per-kind icon + one-line muted summary, hover feedback, `aria-expanded`); tool units and thinking now differ only by icon and summary. The `tool_result` error flag flows end-to-end per ADR-0023 — plugin normalizes wire `is_error` to `isError`, chat-reader serves it back as wire-form `is_error` — and shows as a red dot on the collapsed row.

## Changes (What)

- [x] Note-style document layout: full-width turns, background block on the reader's turns only, name + timestamp headers (#192)
- [x] Empty-turn suppression: a turn that renders nothing is dropped before layout, keeping downstream indices honest (#192)
- [x] Per-message DOM anchor keyed to the normalized message id; API serves that id (#192)
- [x] Paired tool units: call + result (including result-in-next-turn) render as one collapsible unit (#193)
- [x] Shared `CollapsibleRow`; tool units and thinking reuse it (#193)
- [x] Expanded detail shows input and output under a left rule, scrolling horizontally rather than widening the pane (#193)
- [x] `is_error` end-to-end with a red dot on errored results (#193, ADR-0023)

### Test Verification

- [x] Assistant named by agent display name, never "ASSISTANT"; reader's turns named "You"; every header carries an absolute date + time
- [x] Both roles full-width, no bubbles or side alignment; only the reader's turn takes a background
- [x] A turn rendering nothing is dropped — no empty "You" box, no stray virtualized row
- [x] Message anchor survives a turn being dropped (anchors by id, not position)
- [x] Tool call pairs with a result in the same turn and in the next turn
- [x] Collapsed row is obviously toggleable (chevron, pointer, hover, `aria-expanded`); expanding shows input + output under one rule
- [x] Failed result shows the red dot, successful one does not; plugin + API carry `is_error` through
- [x] Full suite green across the branch: api 329, web 323 (652 total), typecheck + lint clean

## Additional Notes

`is_error` does not reach **dormant** sessions (files that never change again) until the re-normalize-from-Raw mechanism ships in #191. Active sessions pick it up on their next append, since ingest re-reads the whole file and overwrites the normalized rows — additive per ADR-0023, so a re-normalize backfills it, not a migration.

## Related Links

- Closes #192, #193