### PR TITLE
feat: command blocks end-to-end with a re-normalize-from-Raw mechanism

### DIFF
--- a/api/drizzle/archive/0011_add_normalize_version.sql
+++ b/api/drizzle/archive/0011_add_normalize_version.sql
@@ -1,0 +1,7 @@
+-- The normalize-output version this archive's Normalized layer was last rebuilt
+-- at. Startup compares it to the code's NORMALIZE_VERSION and re-normalizes from
+-- Raw once per bump, so a new block kind (e.g. `command`, ADR-0023) reaches
+-- already-archived dormant chats without re-reading Source. Additive, NOT NULL
+-- with a 0 default so every existing archive reads as "behind" and gets the
+-- first re-normalize pass.
+ALTER TABLE `archive_meta` ADD COLUMN `normalize_version` integer DEFAULT 0 NOT NULL;

--- a/api/drizzle/archive/meta/_journal.json
+++ b/api/drizzle/archive/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1779500000000,
       "tag": "0010_add_chats_created_at",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1779600000000,
+      "tag": "0011_add_normalize_version",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/archive/read-seam.ts
+++ b/api/src/archive/read-seam.ts
@@ -36,6 +36,15 @@ export interface FirstUserText {
   text: string;
 }
 
+/** A raw message row, the input the re-normalize pass rebuilds Normalized from. */
+export interface RawMessageRow {
+  id: number;
+  agent: string;
+  sourceId: string;
+  sourcePath: string;
+  rawPayload: string;
+}
+
 export interface ArchiveReadSeam {
   /**
    * Chat rows in insertion order. With `projects`, filters server-side to rows
@@ -79,6 +88,12 @@ export interface ArchiveReadSeam {
   listFirstUserTexts(opts?: { sourceIds?: string[] }): FirstUserText[];
   /** Every ingestion-event audit row, in insertion order. */
   listIngestionEvents(): IngestionEventRow[];
+  /**
+   * Every raw message row, in insertion (id) order. The re-normalize pass reads
+   * these to rebuild the Normalized layer without touching Source (ADR-0004);
+   * `rawPayload` is the verbatim per-agent JSON the plugin re-parses.
+   */
+  listRawMessages(): RawMessageRow[];
 }
 
 export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
@@ -195,6 +210,19 @@ export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
     },
     listIngestionEvents() {
       return db.select().from(ingestionEvents).all();
+    },
+    listRawMessages() {
+      return db
+        .select({
+          id: rawMessages.id,
+          agent: rawMessages.agent,
+          sourceId: rawMessages.sourceId,
+          sourcePath: rawMessages.sourcePath,
+          rawPayload: rawMessages.rawPayload,
+        })
+        .from(rawMessages)
+        .orderBy(asc(rawMessages.id))
+        .all();
     },
   };
 }

--- a/api/src/archive/repository.ts
+++ b/api/src/archive/repository.ts
@@ -74,6 +74,14 @@ export interface ArchiveRepository {
    */
   readonly read: ArchiveReadSeam;
   getArchiveUuid(): string;
+  /**
+   * The normalize-output version the Normalized layer was last rebuilt at. 0 on
+   * a fresh or pre-#191 archive. Startup uses it to run re-normalize once per
+   * NORMALIZE_VERSION bump (ADR-0023).
+   */
+  getNormalizeVersion(): number;
+  /** Stamp the archive as rebuilt at `version` after a re-normalize pass. */
+  setNormalizeVersion(version: number): void;
   getAppliedMigrations(): AppliedMigration[];
   generateChatId(): string;
   /**
@@ -176,6 +184,19 @@ export function createArchiveRepository({
         throw new Error("archive_meta row missing after initialization");
       }
       return row.archiveUuid;
+    },
+    getNormalizeVersion() {
+      const row = db.select().from(archiveMeta).get();
+      if (!row) {
+        throw new Error("archive_meta row missing after initialization");
+      }
+      return row.normalizeVersion;
+    },
+    setNormalizeVersion(version) {
+      db.update(archiveMeta)
+        .set({ normalizeVersion: version })
+        .where(eq(archiveMeta.id, 1))
+        .run();
     },
     getAppliedMigrations() {
       return db

--- a/api/src/archive/schema.ts
+++ b/api/src/archive/schema.ts
@@ -10,6 +10,11 @@ export const archiveMeta = sqliteTable("archive_meta", {
   id: integer("id").primaryKey(),
   archiveUuid: text("archive_uuid").notNull(),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  // The normalize-output version this archive's Normalized layer was last built
+  // at. Startup compares it to the code's NORMALIZE_VERSION and re-normalizes
+  // from Raw once per bump, so a new block kind reaches dormant chats without
+  // re-reading Source (ADR-0023). Additive, default 0 for existing archives.
+  normalizeVersion: integer("normalize_version").notNull().default(0),
 });
 
 export const schemaVersion = sqliteTable("schema_version", {

--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -1131,6 +1131,37 @@ describe("ChatReader.getMessages", () => {
       },
     ]);
   });
+
+  it("serves a command block unchanged", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-cmd",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "/tdd issue 191",
+      blocks: [{ type: "command", name: "/tdd", args: "issue 191" }],
+    });
+
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
+      includeTrashed: false,
+    });
+    expect(messages![0].content).toEqual([
+      { type: "command", name: "/tdd", args: "issue 191" },
+    ]);
+  });
 });
 
 describe("ChatReader is agent-agnostic", () => {

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -53,7 +53,10 @@ export type ApiContentBlock =
       content: unknown;
       /** Set when the tool reported a failure. Absent on success. */
       is_error?: boolean;
-    };
+    }
+  // A slash-command invocation, served as-is from Normalized (ADR-0023). No
+  // field remap: the frontend renders it as a chip.
+  | { type: "command"; name: string; args: string };
 
 export interface MessageResponse {
   /**

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -11,6 +11,7 @@ import { createCheckpointRepository } from "./checkpoint/repository.js";
 import { createMetadataRepository } from "./metadata/repository.js";
 import { createTagRepository } from "./metadata/tags.js";
 import { startIngestionInBackground } from "./ingestion/background.js";
+import { runRenormalizeIfStale } from "./ingestion/renormalize.js";
 import { startWatcher } from "./ingestion/watcher.js";
 import { plugins } from "./plugins/registry.js";
 import { parseCliArgs } from "./cli/argv.js";
@@ -54,6 +55,16 @@ const webDistDir = path.join(__dirname, "../../web/dist");
 const port = action.port;
 
 const archive = createArchiveRepository({ dataDir });
+// Rebuild the Normalized layer from Raw when the archive is behind the current
+// normalize-output version, so a new block kind reaches already-archived,
+// dormant chats without re-reading Source (ADR-0023). Runs once per bump; an
+// up-to-date archive is a no-op. A failure here must not stop the server — the
+// existing normalized rows still serve.
+try {
+  runRenormalizeIfStale({ plugins, archive });
+} catch (err) {
+  console.error("[renormalize] startup pass failed:", err);
+}
 const checkpoint = createCheckpointRepository({ dataDir });
 const metadata = createMetadataRepository({ dataDir });
 const tags = createTagRepository({ dataDir });

--- a/api/src/ingestion/renormalize.test.ts
+++ b/api/src/ingestion/renormalize.test.ts
@@ -1,0 +1,204 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createArchiveRepository } from "../archive/repository.js";
+import { ClaudeCodePlugin } from "../plugins/claude-code/plugin.js";
+import { renormalizeFromRaw, runRenormalizeIfStale } from "./renormalize.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "chat-logbook-renorm-"));
+  dataDir = path.join(tmp, "data");
+  fs.mkdirSync(dataDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(path.dirname(dataDir), { recursive: true, force: true });
+});
+
+const COMMAND_MARKUP =
+  "<command-message>tdd</command-message>\n<command-name>/tdd</command-name>\n<command-args>issue 191</command-args>";
+
+/**
+ * Seed one raw slash-command row plus the *stale* normalized row a pre-command
+ * plugin would have produced (the raw markup as a text block). Re-normalize
+ * should rebuild it into a command block from the Raw layer alone.
+ */
+function seedStaleCommand(
+  archive: ReturnType<typeof createArchiveRepository>
+): { rawId: number } {
+  archive.ensureChat("claude-code", "session-1", new Date(1700000000000));
+  const payload = {
+    type: "user",
+    message: { role: "user", content: COMMAND_MARKUP },
+    uuid: "m-cmd",
+    timestamp: "2024-01-01T00:00:00Z",
+    sessionId: "session-1",
+  };
+  const { id: rawId } = archive.insertRawMessage({
+    agent: "claude-code",
+    sourceId: "session-1",
+    sourcePath: "/fake/session-1.jsonl",
+    sourceLocator: "L1",
+    payload,
+    ingestedAt: new Date(1700000000000),
+  });
+  archive.upsertNormalizedMessage({
+    agent: "claude-code",
+    sourceId: "session-1",
+    rawId,
+    message: {
+      messageId: "m-cmd",
+      role: "user",
+      ts: "2024-01-01T00:00:00Z",
+      text: COMMAND_MARKUP,
+      blocks: [{ type: "text", text: COMMAND_MARKUP }],
+    },
+  });
+  return { rawId };
+}
+
+describe("renormalizeFromRaw", () => {
+  it("rebuilds a stale normalized row from Raw so it gains the command block", () => {
+    const archive = createArchiveRepository({ dataDir });
+    seedStaleCommand(archive);
+
+    renormalizeFromRaw({ plugins: [new ClaudeCodePlugin()], archive });
+
+    const messages = archive.read.listMessagesByChat(
+      "claude-code",
+      "session-1"
+    );
+    expect(messages[0].blocks).toEqual([
+      { type: "command", name: "/tdd", args: "issue 191" },
+    ]);
+
+    archive.close();
+  });
+
+  it("leaves the Raw layer byte-identical", () => {
+    const archive = createArchiveRepository({ dataDir });
+    seedStaleCommand(archive);
+
+    const rawBefore = archive.read.listRawMessages();
+    renormalizeFromRaw({ plugins: [new ClaudeCodePlugin()], archive });
+    const rawAfter = archive.read.listRawMessages();
+
+    expect(rawAfter).toEqual(rawBefore);
+
+    archive.close();
+  });
+
+  it("is idempotent: a second pass yields the same normalized content", () => {
+    const archive = createArchiveRepository({ dataDir });
+    seedStaleCommand(archive);
+    const plugins = [new ClaudeCodePlugin()];
+
+    renormalizeFromRaw({ plugins, archive });
+    const first = archive.read.listMessagesByChat("claude-code", "session-1");
+    renormalizeFromRaw({ plugins, archive });
+    const second = archive.read.listMessagesByChat("claude-code", "session-1");
+
+    expect(second).toEqual(first);
+    expect(second[0].blocks).toEqual([
+      { type: "command", name: "/tdd", args: "issue 191" },
+    ]);
+
+    archive.close();
+  });
+
+  it("backfills a tool_result's is_error flag onto a pre-ADR-0023 normalized row", () => {
+    const archive = createArchiveRepository({ dataDir });
+    archive.ensureChat("claude-code", "session-1", new Date(1700000000000));
+    const payload = {
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t1",
+            content: "boom",
+            is_error: true,
+          },
+        ],
+      },
+      uuid: "m-tr",
+      timestamp: "2024-01-01T00:00:00Z",
+      sessionId: "session-1",
+    };
+    const { id: rawId } = archive.insertRawMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/fake/session-1.jsonl",
+      sourceLocator: "L1",
+      payload,
+      ingestedAt: new Date(1700000000000),
+    });
+    // The stale row a pre-ADR-0023 plugin wrote: no isError flag.
+    archive.upsertNormalizedMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      rawId,
+      message: {
+        messageId: "m-tr",
+        role: "user",
+        ts: "2024-01-01T00:00:00Z",
+        text: "",
+        blocks: [{ type: "tool_result", toolUseId: "t1", content: "boom" }],
+      },
+    });
+
+    renormalizeFromRaw({ plugins: [new ClaudeCodePlugin()], archive });
+
+    const messages = archive.read.listMessagesByChat(
+      "claude-code",
+      "session-1"
+    );
+    expect(messages[0].blocks).toEqual([
+      { type: "tool_result", toolUseId: "t1", content: "boom", isError: true },
+    ]);
+
+    archive.close();
+  });
+});
+
+describe("runRenormalizeIfStale", () => {
+  it("runs once when the stored version is behind the target, then stamps it", () => {
+    const archive = createArchiveRepository({ dataDir });
+    seedStaleCommand(archive);
+    const plugins = [new ClaudeCodePlugin()];
+
+    // A fresh archive starts below any target, so the first pass runs.
+    expect(archive.getNormalizeVersion()).toBe(0);
+    const first = runRenormalizeIfStale({ archive, plugins, targetVersion: 1 });
+
+    expect(first).toBe(true);
+    expect(archive.getNormalizeVersion()).toBe(1);
+    expect(
+      archive.read.listMessagesByChat("claude-code", "session-1")[0].blocks
+    ).toEqual([{ type: "command", name: "/tdd", args: "issue 191" }]);
+
+    archive.close();
+  });
+
+  it("is a no-op when the stored version already meets the target", () => {
+    const archive = createArchiveRepository({ dataDir });
+    seedStaleCommand(archive);
+    const plugins = [new ClaudeCodePlugin()];
+
+    runRenormalizeIfStale({ archive, plugins, targetVersion: 1 });
+    const second = runRenormalizeIfStale({
+      archive,
+      plugins,
+      targetVersion: 1,
+    });
+
+    expect(second).toBe(false);
+    expect(archive.getNormalizeVersion()).toBe(1);
+
+    archive.close();
+  });
+});

--- a/api/src/ingestion/renormalize.ts
+++ b/api/src/ingestion/renormalize.ts
@@ -1,0 +1,96 @@
+import type { ArchiveRepository } from "../archive/repository.js";
+import type { AgentPlugin, RawRecord } from "../plugins/types.js";
+
+export interface RenormalizeOptions {
+  plugins: readonly AgentPlugin[];
+  archive: ArchiveRepository;
+}
+
+export interface RenormalizeResult {
+  /** Raw rows read. */
+  scanned: number;
+  /** Normalized rows (re)written. */
+  normalizedUpserted: number;
+}
+
+/**
+ * Rebuild the Normalized layer from the Raw layer, in place. Every raw row is
+ * re-parsed by its Agent's plugin and upserted over the existing normalized row
+ * (last-write-wins by ts, so re-running is idempotent). Source is never read and
+ * the Raw rows are never written — this is the contract's "parser fixes are a
+ * re-ingest, not a migration" (ADR-0004/0023). It is how a normalize-output
+ * change (a new block kind) reaches already-archived, dormant chats.
+ */
+export function renormalizeFromRaw({
+  plugins,
+  archive,
+}: RenormalizeOptions): RenormalizeResult {
+  const pluginById = new Map(plugins.map((p) => [p.id, p]));
+  const result: RenormalizeResult = { scanned: 0, normalizedUpserted: 0 };
+
+  for (const raw of archive.read.listRawMessages()) {
+    result.scanned += 1;
+    const plugin = pluginById.get(raw.agent);
+    if (!plugin) continue;
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(raw.rawPayload);
+    } catch {
+      continue; // A raw row that no longer parses is left as-is.
+    }
+
+    const record: RawRecord = {
+      sourceId: raw.sourceId,
+      sourcePath: raw.sourcePath,
+      // Re-normalize works entirely off the stored payload; the plugin does not
+      // read the file, so a synthetic locator is enough.
+      sourceLocator: "renormalize",
+      payload,
+    };
+    const normalized = plugin.normalize(record);
+    if (!normalized) continue;
+
+    const upserted = archive.upsertNormalizedMessage({
+      agent: raw.agent,
+      sourceId: raw.sourceId,
+      message: normalized,
+      rawId: raw.id,
+    });
+    if (upserted) result.normalizedUpserted += 1;
+  }
+
+  return result;
+}
+
+/**
+ * The current normalize-output version. Bump this whenever a plugin's normalize
+ * output changes (a new block kind, a translated markup) so startup re-normalizes
+ * archived chats up to the new shape. #191 introduces the `command` block, so the
+ * first version that needs a re-normalize pass is 1.
+ */
+export const NORMALIZE_VERSION = 1;
+
+export interface RunRenormalizeIfStaleOptions {
+  plugins: readonly AgentPlugin[];
+  archive: ArchiveRepository;
+  /** Defaults to NORMALIZE_VERSION; overridable in tests. */
+  targetVersion?: number;
+}
+
+/**
+ * Re-normalize from Raw only when the archive is behind `targetVersion`, then
+ * stamp it forward. Runs once per version bump — a boot on an up-to-date archive
+ * is a no-op — so the whole archive is not re-normalized on every start. Returns
+ * whether a pass ran.
+ */
+export function runRenormalizeIfStale({
+  plugins,
+  archive,
+  targetVersion = NORMALIZE_VERSION,
+}: RunRenormalizeIfStaleOptions): boolean {
+  if (archive.getNormalizeVersion() >= targetVersion) return false;
+  renormalizeFromRaw({ plugins, archive });
+  archive.setNormalizeVersion(targetVersion);
+  return true;
+}

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -347,3 +347,97 @@ describe("ClaudeCodePlugin.normalize", () => {
     });
   });
 });
+
+describe("ClaudeCodePlugin.normalize → slash commands", () => {
+  it("translates command markup into a single command block", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content:
+            "<command-message>tdd</command-message>\n<command-name>/tdd</command-name>\n<command-args>issue 191</command-args>",
+        },
+        uuid: "msg-cmd",
+        timestamp: "2024-01-01T00:00:03Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      { type: "command", name: "/tdd", args: "issue 191" },
+    ]);
+  });
+
+  it("gives an empty args string when the invocation carries no arguments", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content:
+            "<command-message>commit</command-message>\n<command-name>/commit</command-name>",
+        },
+        uuid: "msg-cmd-2",
+        timestamp: "2024-01-01T00:00:04Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      { type: "command", name: "/commit", args: "" },
+    ]);
+  });
+
+  it("preserves multi-line arguments verbatim", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content:
+            "<command-message>grill-me</command-message>\n<command-name>/grill-me</command-name>\n<command-args>first line\nsecond line</command-args>",
+        },
+        uuid: "msg-cmd-3",
+        timestamp: "2024-01-01T00:00:05Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      { type: "command", name: "/grill-me", args: "first line\nsecond line" },
+    ]);
+  });
+
+  it("sets the searchable text to the command line so titles read `/tdd issue 191`", () => {
+    const withArgs = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content:
+            "<command-message>tdd</command-message>\n<command-name>/tdd</command-name>\n<command-args>issue 191</command-args>",
+        },
+        uuid: "msg-cmd-4",
+        timestamp: "2024-01-01T00:00:06Z",
+        sessionId: "session-1",
+      })
+    );
+    expect(withArgs?.text).toBe("/tdd issue 191");
+
+    const noArgs = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content:
+            "<command-message>commit</command-message>\n<command-name>/commit</command-name>",
+        },
+        uuid: "msg-cmd-5",
+        timestamp: "2024-01-01T00:00:07Z",
+        sessionId: "session-1",
+      })
+    );
+    expect(noArgs?.text).toBe("/commit");
+  });
+});

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -75,6 +75,20 @@ export class ClaudeCodePlugin implements AgentPlugin {
     const ts = String(payload.timestamp ?? "");
 
     if (typeof message.content === "string") {
+      const command = parseCommandMarkup(message.content);
+      if (command) {
+        // The searchable text is the command line (`/tdd issue 191`), so FTS
+        // finds it and a chat whose first turn is a slash command derives that
+        // as its title instead of the raw markup.
+        const commandLine = `${command.name} ${command.args}`.trim();
+        return {
+          messageId,
+          role,
+          ts,
+          text: commandLine,
+          blocks: [{ type: "command", name: command.name, args: command.args }],
+        };
+      }
       const text = message.content;
       return {
         messageId,
@@ -132,6 +146,24 @@ async function readCwdFromJsonl(
     // Ignore I/O errors; fall back to undefined project.
   }
   return undefined;
+}
+
+// Claude Code records a slash-command invocation as a user message whose text
+// is `<command-message>…</command-message>\n<command-name>/tdd</command-name>`
+// with an optional `<command-args>…</command-args>`. Translate it here so the
+// frontend renders a chip and never sees the markup (ADR-0023).
+const COMMAND_NAME_RE = /<command-name>([\s\S]*?)<\/command-name>/;
+const COMMAND_ARGS_RE = /<command-args>([\s\S]*?)<\/command-args>/;
+
+function parseCommandMarkup(
+  content: string
+): { name: string; args: string } | null {
+  const nameMatch = COMMAND_NAME_RE.exec(content);
+  if (!nameMatch) return null;
+  const name = nameMatch[1].trim();
+  const argsMatch = COMMAND_ARGS_RE.exec(content);
+  const args = argsMatch ? argsMatch[1].trim() : "";
+  return { name, args };
 }
 
 function normalizeBlock(raw: unknown): NormalizedBlock | null {

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -30,7 +30,10 @@ export type NormalizedBlock =
        * only ever widens a stored block (ADR-0023).
        */
       isError?: boolean;
-    };
+    }
+  // A slash-command invocation, translated from the Agent's private markup at
+  // normalize time so the frontend never parses it (ADR-0023). Renders as a chip.
+  | { type: "command"; name: string; args: string };
 
 export interface NormalizedMessage {
   messageId: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       rehype-highlight:
         specifier: ^7.0.2
         version: 7.0.2
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -5196,6 +5199,12 @@ packages:
         integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==,
       }
 
+  mdast-util-newline-to-break@2.0.0:
+    resolution:
+      {
+        integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==,
+      }
+
   mdast-util-phrasing@4.1.0:
     resolution:
       {
@@ -6177,6 +6186,12 @@ packages:
     resolution:
       {
         integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==,
+      }
+
+  remark-breaks@4.0.0:
+    resolution:
+      {
+        integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==,
       }
 
   remark-gfm@4.0.1:
@@ -10468,6 +10483,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      "@types/mdast": 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       "@types/mdast": 4.0.4
@@ -11198,6 +11218,12 @@ snapshots:
       lowlight: 3.3.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+
+  remark-breaks@4.0.0:
+    dependencies:
+      "@types/mdast": 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
 
   remark-gfm@4.0.1:
     dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.7.6",
     "rehype-highlight": "^7.0.2",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.0",
     "tailwind-merge": "^3.5.0",

--- a/web/src/conversation/CommandLine.tsx
+++ b/web/src/conversation/CommandLine.tsx
@@ -1,0 +1,26 @@
+interface CommandLineProps {
+  /** The command name, including the leading slash (e.g. `/tdd`). */
+  name: string;
+  /** The arguments typed after the command; empty when none. */
+  args: string;
+}
+
+/**
+ * A slash-command invocation, read as the reader's own message: the command
+ * name in the interactive accent, its args following as plain prose. The plugin
+ * already translated the Agent's markup into a command block at normalize time,
+ * so this only renders it (ADR-0023). Matches Claude Code desktop — no chip, no
+ * icon; args wrap in full, preserving blank lines, since a command can carry a
+ * whole multi-line prompt.
+ */
+export function CommandLine({ name, args }: CommandLineProps) {
+  return (
+    <div
+      data-testid="command-line"
+      className="whitespace-pre-wrap break-words leading-relaxed"
+    >
+      <span className="font-medium text-primary">{name}</span>
+      {args ? ` ${args}` : ""}
+    </div>
+  );
+}

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -318,6 +318,65 @@ describe("Conversation empty-turn suppression", () => {
   });
 });
 
+describe("Conversation command lines", () => {
+  const commandTurn: Message = {
+    id: "m-cmd",
+    role: "user",
+    content: [{ type: "command", name: "/tdd", args: "issue 191" }],
+    timestamp: "2024-01-01T00:00:00Z",
+  };
+
+  it("renders a command invocation as a command line, with no raw markup", async () => {
+    const { container } = render(
+      <ConversationView chat={chat} messages={[commandTurn]} />
+    );
+
+    const line = await screen.findByTestId("command-line");
+    expect(line.textContent).toContain("/tdd issue 191");
+    // The Agent's private markup must never reach the screen (ADR-0023).
+    expect(container.textContent).not.toContain("<command-name>");
+  });
+
+  it("shows multi-line args in full, without truncating", async () => {
+    // A slash command can carry a whole prompt as its args, including blank
+    // lines. It reads like the reader's own message, so every line stays.
+    const { container } = render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-cmd-multiline",
+            role: "user",
+            content: [
+              {
+                type: "command",
+                name: "/tdd",
+                args: "issue 191\n\np.s. see PR #225.",
+              },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    const line = await screen.findByTestId("command-line");
+    // The blank line between the args and the p.s. survives to the DOM — the
+    // component neither collapses nor truncates it (the CSS then renders it).
+    expect(line.textContent).toContain("issue 191\n\np.s. see PR #225.");
+    expect(container.textContent).not.toContain("<command-args>");
+  });
+
+  it("keeps the reader's authored turn: a You header and a background block", async () => {
+    const { container } = render(
+      <ConversationView chat={chat} messages={[commandTurn]} />
+    );
+
+    expect(await screen.findByText("You")).not.toBeNull();
+    expect(container.querySelector('[data-role="user"]')).not.toBeNull();
+  });
+});
+
 describe("Conversation collapsed units", () => {
   it("gives a tool-only turn its collapsed row but no header of its own", async () => {
     // Tool calls nest under the message that prompted them (#192). The Agent

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -5,6 +5,7 @@ import type { Message, ContentBlock, Chat, Tag } from "@/types";
 import { MarkdownText } from "@/conversation/MarkdownText";
 import { CollapsibleThinking } from "@/conversation/CollapsibleThinking";
 import { CollapsibleToolCall } from "@/conversation/CollapsibleToolCall";
+import { CommandLine } from "@/conversation/CommandLine";
 import { ScrollPill } from "@/conversation/ScrollPill";
 import { NewMessagesPill } from "@/conversation/NewMessagesPill";
 import { UnreadDivider } from "@/conversation/UnreadDivider";
@@ -168,6 +169,8 @@ function renderContentBlock(
       );
     case "tool_result":
       return null;
+    case "command":
+      return <CommandLine key={index} name={block.name} args={block.args} />;
   }
 }
 

--- a/web/src/conversation/MarkdownText.test.tsx
+++ b/web/src/conversation/MarkdownText.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MarkdownText } from "@/conversation/MarkdownText";
+
+describe("MarkdownText line breaks", () => {
+  it("keeps a single newline as a visible line break", () => {
+    // People write chat messages with Enter, not with markdown's blank-line
+    // paragraph rule. Plain markdown folds a single newline into a space, which
+    // silently reflows what the reader actually wrote.
+    const { container } = render(
+      <MarkdownText>{"first line\nsecond line"}</MarkdownText>
+    );
+
+    expect(container.querySelectorAll("br")).toHaveLength(1);
+    expect(container.textContent).toContain("first line");
+    expect(container.textContent).toContain("second line");
+  });
+
+  it("still separates blank-line-delimited paragraphs", () => {
+    const { container } = render(
+      <MarkdownText>{"first para\n\nsecond para"}</MarkdownText>
+    );
+
+    expect(container.querySelectorAll("p")).toHaveLength(2);
+  });
+
+  it("leaves markdown structure intact", () => {
+    const { container } = render(
+      <MarkdownText>{"- one\n- two\n\n**bold** and `code`"}</MarkdownText>
+    );
+
+    // A list's own newlines are structure, not prose breaks: two items, and no
+    // stray <br> injected between them.
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+    expect(container.querySelector("li br")).toBeNull();
+    expect(screen.getByText("bold").tagName).toBe("STRONG");
+    expect(screen.getByText("code").tagName).toBe("CODE");
+  });
+});

--- a/web/src/conversation/MarkdownText.tsx
+++ b/web/src/conversation/MarkdownText.tsx
@@ -1,5 +1,6 @@
 import Markdown, { type Components } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
 const markdownComponents: Components = {
@@ -37,7 +38,12 @@ export function MarkdownText({ children }: { children: string }) {
   return (
     <div className={PROSE_CLASS}>
       <Markdown
-        remarkPlugins={[remarkGfm]}
+        // remark-breaks renders a single newline as a line break. A logged turn
+        // is something a person typed with Enter, not an article written to
+        // markdown's blank-line paragraph rule — folding those newlines into
+        // spaces silently reflows what they actually wrote. Structure (lists,
+        // tables, code) still parses normally.
+        remarkPlugins={[remarkGfm, remarkBreaks]}
         rehypePlugins={[rehypeHighlight]}
         components={markdownComponents}
       >

--- a/web/src/conversation/messageVisibility.ts
+++ b/web/src/conversation/messageVisibility.ts
@@ -17,6 +17,9 @@ function rendersSomething(block: ContentBlock): boolean {
       // Never rendered on its own: a result belongs to the tool call that
       // produced it, not to the turn the Agent happened to record it under.
       return false;
+    case "command":
+      // The reader's own slash-command action, shown as a chip.
+      return true;
   }
 }
 
@@ -37,14 +40,16 @@ export function hasRenderableContent(message: Message): boolean {
  * Whether a Message is authored prose, and so earns a `You` / agent-name
  * header.
  *
- * Only text counts. Tool calls and thinking are collapsed units: the Agent logs
- * them as turns of their own, but the reader sees them as part of the moment
- * that prompted them, so they nest under the preceding header instead of
+ * Text and a slash-command invocation count: both are things the reader wrote,
+ * so they earn a `You` header. Tool calls and thinking are collapsed units: the
+ * Agent logs them as turns of their own, but the reader sees them as part of the
+ * moment that prompted them, so they nest under the preceding header instead of
  * repeating it (#192).
  */
 export function hasAuthorHeader(message: Message): boolean {
   if (typeof message.content === "string") return hasText(message.content);
   return message.content.some(
-    (block) => block.type === "text" && hasText(block.text)
+    (block) =>
+      (block.type === "text" && hasText(block.text)) || block.type === "command"
   );
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -35,7 +35,10 @@ export type ContentBlock =
       content: unknown;
       /** Set when the tool reported a failure. Absent on success. */
       is_error?: boolean;
-    };
+    }
+  // A slash-command invocation the plugin translated from the Agent's private
+  // markup (ADR-0023). Renders as a chip; the frontend never parses markup.
+  | { type: "command"; name: string; args: string };
 
 export interface Message {
   /** The Normalized `message_id`, unique within a Chat — the Message's stable handle. */


### PR DESCRIPTION
## Background (Why)

Slash-command invocations rendered as raw markup — `<command-message>tdd</command-message><command-name>/tdd</command-name>…` — straight into the conversation pane. The reader saw the Agent's private wire format instead of the action they took.

Fixing that means changing what normalize writes, and that raises the harder problem this PR also solves: a normalize-output change only reaches chats that get re-ingested. Chats whose source file never changes again — the dormant majority — would keep the old shape forever. ADR-0023 named the answer (rebuild from Raw, never re-read Source) and left it to the first consumer slice to build. This is that slice.

## Approach (How)

**Command block (#191).** The Claude Code plugin translates its own markup into the vocabulary's `command` block at normalize time, so the frontend contains no per-agent parsing (ADR-0023). The block travels the whole line — plugin → Archive → API → frontend — with no field remap. A command message's searchable `text` becomes the command line (`/tdd issue 191`), so FTS finds it and a chat opening with a slash command derives a readable title instead of raw markup.

**Re-normalize from Raw.** `renormalizeFromRaw` reads each raw row back through its agent's plugin and upserts the result. Raw is never written; Source is never read. Upsert is last-write-wins by `ts`, so a second pass is a no-op in content — parser fixes become a re-ingest, not a migration (ADR-0004/0023).

The trigger is a stamp, not a migration: `archive_meta.normalize_version` (additive column, default 0) against a `NORMALIZE_VERSION` constant. Startup runs the pass once per bump and stamps forward, so an up-to-date archive pays nothing at boot. Every later vocabulary slice reuses this by bumping the constant.

**Rendering.** Rather than the "compact chip" the issue described, the command renders the way Claude Code desktop actually shows it: the reader's own message, command name in the interactive accent (Solarized cyan — the colour this product already uses for actions), args following as prose. It keeps its `You` header and background block, because a slash command is something the reader wrote.

## Changes (What)

- [x] Claude Code plugin translates slash-command markup into a `command` block; `text` becomes the command line (#191)
- [x] `command` added to the block vocabulary across plugin, API, and frontend types — additive, no field remap (ADR-0023)
- [x] `renormalizeFromRaw` rebuilds the Normalized layer from `raw_messages` without touching Raw or Source
- [x] Archive read seam gains `listRawMessages()`
- [x] `archive_meta.normalize_version` stamp (migration 0011) + `runRenormalizeIfStale` startup guard, running once per `NORMALIZE_VERSION` bump
- [x] `CommandLine` renders the invocation as the reader's own message; args wrap in full, keeping blank lines
- [x] A command turn counts as renderable and as authored, so it keeps its `You` header and background block
- [x] Incidental fix: `remark-breaks` so single newlines render as written, across text blocks, string content, and thinking

### Screenshots or Recordings

Command name uses `text-primary` (Solarized cyan `#2aa198`) at weight 500; args inherit the turn's prose colour and wrap in full. A multi-line invocation keeps its blank lines rather than collapsing to one line.

### Test Verification

- [x] Markup with args, without args, and with multi-line args each normalize to one `command` block
- [x] A command message's `text` is `/tdd issue 191`; plain user text is untouched
- [x] The API serves a `command` block unchanged
- [x] A stale normalized row (raw markup as a text block) gains the `command` block after a re-normalize pass
- [x] Raw rows are byte-identical before and after the pass
- [x] A second pass yields identical normalized content (idempotent)
- [x] A pre-ADR-0023 `tool_result` gains its `is_error` flag — the same mechanism backfills any vocabulary change, closing the gap PR #225 deferred
- [x] The version guard runs once when behind the target and stamps it; a second call is a no-op
- [x] The command renders as a command line with no raw markup on screen; multi-line args survive to the DOM intact
- [x] A command turn keeps its `You` header and background block
- [x] A single newline renders as a line break; blank-line paragraphs and markdown structure (lists, bold, inline code) still parse
- [x] Full suite green: api 340, web 329 (669 total); typecheck, lint, and build clean

## Additional Notes

**Deliberate deviation from the issue.** #191 specifies a "compact chip". The same sentence asks it to match Claude Code desktop, and desktop renders the invocation as message text, not a pill. Chip styling also truncated multi-line args to a single line, which hides real content — a slash command routinely carries a whole prompt. The desktop behaviour won.

**The line-break fix is incidental, not in scope for #191.** It surfaced while reviewing the command rendering: all prose rendering shared the same flaw, since plain markdown folds single newlines into spaces. It is one plugin on a shared component, it is pure rendering, and it needs no re-normalize — so it rides along here rather than as its own PR.

**Bump `NORMALIZE_VERSION` in future vocabulary slices.** It lives in `api/src/ingestion/renormalize.ts` and is the only thing standing between a normalize change and the archived chats that need it. This PR sets it to 1.

The startup pass is synchronous and scans every raw row once per bump. On a large archive that adds measurable boot time the first time after an upgrade — acceptable for a one-off, but worth revisiting if the vocabulary starts changing often.

## Related Links

- Closes #191
- Depends on ADR-0023 (normalized block vocabulary), introduced in #186
- Finishes the `is_error` backfill deferred in #225
