### PR TITLE
feat: render harness noise as collapsed system rows

### DIFF
--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -1162,6 +1162,41 @@ describe("ChatReader.getMessages", () => {
       { type: "command", name: "/tdd", args: "issue 191" },
     ]);
   });
+
+  it("serves a system block unchanged", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    const systemBlock = {
+      type: "system",
+      kind: "task-notification",
+      summary: 'Agent "Run tests" finished',
+      detail: "<task-notification>…</task-notification>",
+    };
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-sys",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: 'Agent "Run tests" finished',
+      blocks: [systemBlock],
+    });
+
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
+      includeTrashed: false,
+    });
+    expect(messages![0].content).toEqual([systemBlock]);
+  });
 });
 
 describe("ChatReader is agent-agnostic", () => {

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -56,7 +56,10 @@ export type ApiContentBlock =
     }
   // A slash-command invocation, served as-is from Normalized (ADR-0023). No
   // field remap: the frontend renders it as a chip.
-  | { type: "command"; name: string; args: string };
+  | { type: "command"; name: string; args: string }
+  // Harness noise, served as-is from Normalized (ADR-0023). No field remap: the
+  // frontend renders a collapsed system row and needs no per-agent knowledge.
+  | { type: "system"; kind: string; summary: string; detail: string };
 
 export interface MessageResponse {
   /**

--- a/api/src/ingestion/renormalize.ts
+++ b/api/src/ingestion/renormalize.ts
@@ -67,9 +67,10 @@ export function renormalizeFromRaw({
  * The current normalize-output version. Bump this whenever a plugin's normalize
  * output changes (a new block kind, a translated markup) so startup re-normalizes
  * archived chats up to the new shape. #191 introduces the `command` block, so the
- * first version that needs a re-normalize pass is 1.
+ * first version that needs a re-normalize pass is 1. #194 adds the `system`
+ * block, turning archived harness noise into collapsed rows: version 2.
  */
-export const NORMALIZE_VERSION = 1;
+export const NORMALIZE_VERSION = 2;
 
 export interface RunRenormalizeIfStaleOptions {
   plugins: readonly AgentPlugin[];

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -441,3 +441,114 @@ describe("ClaudeCodePlugin.normalize → slash commands", () => {
     expect(noArgs?.text).toBe("/commit");
   });
 });
+
+const TASK_NOTIFICATION = [
+  "<task-notification>",
+  "<task-id>a09d714025def2e83</task-id>",
+  "<tool-use-id>toolu_01SCVdD2uM7eki7WUj6siHyS</tool-use-id>",
+  "<status>completed</status>",
+  '<summary>Agent "Run App test (batch trash)" finished</summary>',
+  "<result>Total tests: 85. Passed: 83. Failed: 2.</result>",
+  "</task-notification>",
+].join("\n");
+
+describe("ClaudeCodePlugin.normalize → system rows", () => {
+  it("translates a task-notification into a single system block", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: { role: "user", content: TASK_NOTIFICATION },
+        uuid: "msg-sys-1",
+        timestamp: "2024-01-01T00:00:08Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "system",
+        kind: "task-notification",
+        summary: 'Agent "Run App test (batch trash)" finished',
+        detail: TASK_NOTIFICATION,
+      },
+    ]);
+  });
+
+  it("falls back to a generic summary when the notification carries none", () => {
+    const noSummary =
+      "<task-notification>\n<task-id>abc</task-id>\n<status>stopped</status>\n</task-notification>";
+
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: { role: "user", content: noSummary },
+        uuid: "msg-sys-2",
+        timestamp: "2024-01-01T00:00:09Z",
+        sessionId: "session-1",
+      })
+    );
+
+    // Still a system row, never a text block: the point is that no raw markup
+    // reaches the reader, summary or not.
+    expect(result?.blocks).toEqual([
+      {
+        type: "system",
+        kind: "task-notification",
+        summary: "Task notification",
+        detail: noSummary,
+      },
+    ]);
+  });
+
+  it("translates a local command echo into its own system kind", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content:
+            "<local-command-stdout>Set model to claude-opus-4-8</local-command-stdout>",
+        },
+        uuid: "msg-sys-3",
+        timestamp: "2024-01-01T00:00:10Z",
+        sessionId: "session-1",
+      })
+    );
+
+    // The echo is already one line, so it is wholly the summary — there is no
+    // detail worth expanding into.
+    expect(result?.blocks).toEqual([
+      {
+        type: "system",
+        kind: "local-command-stdout",
+        summary: "Set model to claude-opus-4-8",
+        detail: "",
+      },
+    ]);
+  });
+
+  it("strips terminal styling codes out of a local command echo", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content:
+            "<local-command-stdout>Set model to \u001b[1mOpus 4.6\u001b[22m with \u001b[1mhigh\u001b[22m effort</local-command-stdout>",
+        },
+        uuid: "msg-sys-4",
+        timestamp: "2024-01-01T00:00:11Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "system",
+        kind: "local-command-stdout",
+        summary: "Set model to Opus 4.6 with high effort",
+        detail: "",
+      },
+    ]);
+  });
+});

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -89,6 +89,19 @@ export class ClaudeCodePlugin implements AgentPlugin {
           blocks: [{ type: "command", name: command.name, args: command.args }],
         };
       }
+      const system = parseSystemNoise(message.content);
+      if (system) {
+        // The searchable text is the summary, not the markup: harness noise
+        // should stay findable without a wall of XML becoming a chat's title.
+        return {
+          messageId,
+          role,
+          ts,
+          text: system.summary,
+          blocks: [system],
+        };
+      }
+
       const text = message.content;
       return {
         messageId,
@@ -164,6 +177,52 @@ function parseCommandMarkup(
   const argsMatch = COMMAND_ARGS_RE.exec(content);
   const args = argsMatch ? argsMatch[1].trim() : "";
   return { name, args };
+}
+
+// Claude Code injects harness noise as fake user turns. Most of it is flagged
+// `isMeta` and already dropped above; what survives is translated here so the
+// frontend renders a system row and never sees the markup (ADR-0023).
+const TASK_NOTIFICATION_RE = /<task-notification>[\s\S]*<\/task-notification>/;
+const TASK_SUMMARY_RE = /<summary>([\s\S]*?)<\/summary>/;
+const LOCAL_COMMAND_STDOUT_RE =
+  /<local-command-stdout>([\s\S]*?)<\/local-command-stdout>/;
+
+// The echo is captured off a terminal, so it still carries SGR styling codes.
+// They would render as mojibake in a browser.
+// eslint-disable-next-line no-control-regex
+const ANSI_SGR_RE = /\u001b\[[0-9;]*m/g;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_SGR_RE, "");
+}
+
+function parseSystemNoise(
+  content: string
+): { type: "system"; kind: string; summary: string; detail: string } | null {
+  const notification = TASK_NOTIFICATION_RE.exec(content);
+  if (notification) {
+    const summaryMatch = TASK_SUMMARY_RE.exec(notification[0]);
+    return {
+      type: "system",
+      kind: "task-notification",
+      summary: summaryMatch?.[1].trim() || "Task notification",
+      detail: notification[0],
+    };
+  }
+
+  const stdout = LOCAL_COMMAND_STDOUT_RE.exec(content);
+  if (stdout) {
+    // A local command echo is already one line, so it is wholly the summary and
+    // there is nothing left to expand into.
+    return {
+      type: "system",
+      kind: "local-command-stdout",
+      summary: stripAnsi(stdout[1]).trim(),
+      detail: "",
+    };
+  }
+
+  return null;
 }
 
 function normalizeBlock(raw: unknown): NormalizedBlock | null {

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -33,7 +33,12 @@ export type NormalizedBlock =
     }
   // A slash-command invocation, translated from the Agent's private markup at
   // normalize time so the frontend never parses it (ADR-0023). Renders as a chip.
-  | { type: "command"; name: string; args: string };
+  | { type: "command"; name: string; args: string }
+  // Harness noise addressed to the Agent rather than written by the reader —
+  // task notifications, local command echoes. `kind` is an open string so a new
+  // noise type widens the data, not the type union (ADR-0023). `summary` is the
+  // collapsed one-liner; `detail` is the original content, kept for expansion.
+  | { type: "system"; kind: string; summary: string; detail: string };
 
 export interface NormalizedMessage {
   messageId: string;

--- a/web/src/conversation/CollapsibleRow.tsx
+++ b/web/src/conversation/CollapsibleRow.tsx
@@ -8,8 +8,12 @@ interface CollapsibleRowProps {
   summary: string;
   /** Marks the row as reporting a failure. */
   hasError?: boolean;
-  /** The detail revealed when expanded. */
-  children: ReactNode;
+  /**
+   * The detail revealed when expanded. Omit it when the summary is already the
+   * whole row — it then renders as a plain line, with no control that would
+   * open onto nothing.
+   */
+  children?: ReactNode;
 }
 
 /**
@@ -26,6 +30,20 @@ export function CollapsibleRow({
   children,
 }: CollapsibleRowProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+
+  if (!children) {
+    return (
+      <div className="my-1">
+        <div className="flex w-full items-center gap-1.5 px-1.5 py-1 text-xs text-muted-foreground">
+          {/* Stands in for the chevron so this row's icon still lines up with
+              the expandable rows around it. */}
+          <span aria-hidden="true" className="size-3 shrink-0" />
+          <Icon size={12} aria-hidden="true" className="shrink-0" />
+          <span className="truncate font-mono">{summary}</span>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="my-1">

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -318,6 +318,91 @@ describe("Conversation empty-turn suppression", () => {
   });
 });
 
+describe("Conversation system rows", () => {
+  const NOTIFICATION_DETAIL =
+    "<task-notification><status>completed</status></task-notification>";
+  const notificationTurn: Message = {
+    id: "m-sys",
+    role: "user",
+    content: [
+      {
+        type: "system",
+        kind: "task-notification",
+        summary: 'Agent "Run App test" finished',
+        detail: NOTIFICATION_DETAIL,
+      },
+    ],
+    timestamp: "2024-01-01T00:00:00Z",
+  };
+
+  it("renders harness noise as a collapsed row showing only its summary", async () => {
+    const { container } = render(
+      <ConversationView chat={chat} messages={[notificationTurn]} />
+    );
+
+    await screen.findByText('Agent "Run App test" finished');
+    // Collapsed by default: the detail is what the reader opts into.
+    expect(screen.queryByTestId("unit-detail")).toBeNull();
+    // The harness markup must never reach the screen unbidden (ADR-0023).
+    expect(container.textContent).not.toContain("<task-notification>");
+  });
+
+  it("reveals the full notification when the row is expanded", async () => {
+    render(<ConversationView chat={chat} messages={[notificationTurn]} />);
+
+    const row = await screen.findByRole("button", {
+      name: /Run App test/,
+    });
+    await userEvent.click(row);
+
+    const detail = await screen.findByTestId("unit-detail");
+    expect(detail.textContent).toContain(NOTIFICATION_DETAIL);
+  });
+
+  it("offers no expand affordance when the summary is the whole of it", async () => {
+    // A local command echo is one line. Opening it would reveal nothing, so the
+    // row stays a plain line rather than a control that does nothing.
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-echo",
+            role: "user",
+            content: [
+              {
+                type: "system",
+                kind: "local-command-stdout",
+                summary: "Set model to claude-opus-4-8",
+                detail: "",
+              },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    await screen.findByText("Set model to claude-opus-4-8");
+    expect(screen.queryByRole("button", { name: /Set model/ })).toBeNull();
+    expect(screen.queryByTestId("row-chevron")).toBeNull();
+  });
+
+  it("gives a system row no You header, since nobody wrote it", async () => {
+    // The Agent logs harness noise as a user turn, but it is machinery talking
+    // to the Agent — attributing it to the reader is the bug (ADR-0023).
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[assistant("Kicking that off."), notificationTurn]}
+      />
+    );
+
+    await screen.findByText('Agent "Run App test" finished');
+    expect(screen.queryByText("You")).toBeNull();
+  });
+});
+
 describe("Conversation command lines", () => {
   const commandTurn: Message = {
     id: "m-cmd",

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -6,6 +6,7 @@ import { MarkdownText } from "@/conversation/MarkdownText";
 import { CollapsibleThinking } from "@/conversation/CollapsibleThinking";
 import { CollapsibleToolCall } from "@/conversation/CollapsibleToolCall";
 import { CommandLine } from "@/conversation/CommandLine";
+import { SystemRow } from "@/conversation/SystemRow";
 import { ScrollPill } from "@/conversation/ScrollPill";
 import { NewMessagesPill } from "@/conversation/NewMessagesPill";
 import { UnreadDivider } from "@/conversation/UnreadDivider";
@@ -171,6 +172,10 @@ function renderContentBlock(
       return null;
     case "command":
       return <CommandLine key={index} name={block.name} args={block.args} />;
+    case "system":
+      return (
+        <SystemRow key={index} summary={block.summary} detail={block.detail} />
+      );
   }
 }
 

--- a/web/src/conversation/SystemRow.tsx
+++ b/web/src/conversation/SystemRow.tsx
@@ -1,0 +1,28 @@
+import { Cog } from "lucide-react";
+import { CollapsibleRow } from "@/conversation/CollapsibleRow";
+
+interface SystemRowProps {
+  /** The one-line collapsed summary the plugin extracted. */
+  summary: string;
+  /** The original content, revealed on expand. Empty when there is no more. */
+  detail: string;
+}
+
+/**
+ * Harness noise — a task notification, a local command echo — as one muted row.
+ *
+ * The plugin already classified it and pulled out the summary at normalize time,
+ * so this only renders it and knows nothing about which Agent produced it
+ * (ADR-0023). A gear marks it as machinery rather than something anyone wrote.
+ */
+export function SystemRow({ summary, detail }: SystemRowProps) {
+  return (
+    <CollapsibleRow icon={Cog} summary={summary}>
+      {detail ? (
+        <pre className="whitespace-pre-wrap break-words font-mono text-xs text-muted-foreground">
+          {detail}
+        </pre>
+      ) : null}
+    </CollapsibleRow>
+  );
+}

--- a/web/src/conversation/messageVisibility.ts
+++ b/web/src/conversation/messageVisibility.ts
@@ -20,6 +20,9 @@ function rendersSomething(block: ContentBlock): boolean {
     case "command":
       // The reader's own slash-command action, shown as a chip.
       return true;
+    case "system":
+      // Harness noise, shown as a collapsed row the reader skims past.
+      return true;
   }
 }
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -38,7 +38,10 @@ export type ContentBlock =
     }
   // A slash-command invocation the plugin translated from the Agent's private
   // markup (ADR-0023). Renders as a chip; the frontend never parses markup.
-  | { type: "command"; name: string; args: string };
+  | { type: "command"; name: string; args: string }
+  // Harness noise the plugin classified at normalize time (ADR-0023). Renders as
+  // a collapsed system row; `detail` is empty when the summary is the whole of it.
+  | { type: "system"; kind: string; summary: string; detail: string };
 
 export interface Message {
   /** The Normalized `message_id`, unique within a Chat — the Message's stable handle. */


### PR DESCRIPTION
## Background (Why)

Claude Code injects harness noise into a session as fake user turns. The most visible case is a task notification — a background agent's completion report — which reached the reader as raw XML, wearing a **You** header as if they had written it.

## Approach (How)

Classification happens at normalize time, inside the Agent's plugin, per ADR-0023. The plugin translates private markup into a `system { kind, summary, detail }` block; the API serves it unchanged; the frontend renders block kinds and keeps no per-agent knowledge.

Surveying every archived session first changed the scope. Three of the four noise types — `system-reminder` (147), `local-command-caveat` (57), `autonomous-loop-dynamic` (10) — already carry `isMeta: true` and are dropped before normalize, so they needed no work. Only `local-command-stdout` (45) was leaking alongside task notifications, so it ships here too as a second `kind`. Since `kind` is an open string, a future noise type widens the data rather than the type union.

The harness already writes a readable one-liner in `<summary>` (`Agent "Run tests" finished`), so that becomes the row summary. Parsing PASS/FAIL out of each agent's `<result>` would mean encoding per-agent output formats — exactly what the ADR pushes against.

## Changes (What)

- [ ] `parseSystemNoise()` in the Claude Code plugin translates `task-notification` and `local-command-stdout` into `system` blocks, stripping ANSI SGR codes from terminal echoes
- [ ] Searchable text is the summary, not the markup, so noise stays findable without a wall of XML becoming a chat's title
- [ ] `system` added to `NormalizedBlock`, `ApiContentBlock`, and the web `ContentBlock`; served with no field remap
- [ ] `SystemRow` renders a gear-marked collapsed row, expanding to the original content — kept, not dropped, since an agent's result has archival value
- [ ] `CollapsibleRow` gains an optional detail: a one-line echo renders as a plain line instead of a control that opens onto nothing
- [ ] A system-only turn renders without a **You** header
- [ ] `NORMALIZE_VERSION` 1 → 2, so archived chats re-normalize onto the new shape

### Test Verification

- [ ] Plugin: a task notification becomes a single `system` block with kind, summary, and full detail
- [ ] Plugin: a notification with no `<summary>` falls back to a generic one and still never returns raw text
- [ ] Plugin: a local command echo becomes its own kind, with empty detail
- [ ] Plugin: ANSI styling codes are stripped from an echo's summary
- [ ] API: a `system` block is served unchanged (shape guarded by typecheck)
- [ ] Web: a notification renders collapsed, showing only its summary, with no markup on screen
- [ ] Web: expanding the row reveals the full notification
- [ ] Web: a one-line echo offers no expand affordance — no button, no chevron
- [ ] Web: a system-only turn gets no **You** header
- [ ] Full suite green: 345 api + 333 web = 678 tests; `pnpm typecheck` and `pnpm build` pass
- [ ] Real data: running the plugin over all 54,462 archived messages converts 141 task notifications and 45 echoes, with zero markup leaking into any visible block. The session named in #194 (`c12c2083`) shows 8 notifications across 710 messages, all converted

## Additional Notes

`status: failed` notifications get no error dot. The ADR's `system` block has no error field, and the harness summary already reads `failed with exit code 143`. Adding one would mean widening a cross-layer contract for a cosmetic gain.

## Related Links

- Closes #194