### PR TITLE
feat: show each message's model in the conversation header

### DIFF
--- a/api/drizzle/archive/0012_add_message_model.sql
+++ b/api/drizzle/archive/0012_add_message_model.sql
@@ -1,0 +1,6 @@
+-- The model id the Agent recorded on a message (e.g. `claude-opus-4-8`), so the
+-- conversation pane can name the model per message and show a mid-chat switch
+-- (ADR-0023, #195). Additive and nullable: reader turns record no model, and
+-- rows normalized before this column existed read as NULL until the
+-- NORMALIZE_VERSION bump re-normalizes them from Raw.
+ALTER TABLE `messages` ADD COLUMN `model` text;

--- a/api/drizzle/archive/meta/_journal.json
+++ b/api/drizzle/archive/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1779600000000,
       "tag": "0011_add_normalize_version",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1779700000000,
+      "tag": "0012_add_message_model",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/archive/repository-write.test.ts
+++ b/api/src/archive/repository-write.test.ts
@@ -289,3 +289,46 @@ describe("ArchiveRepository write seam", () => {
     repo.close();
   });
 });
+
+describe("ArchiveRepository model persistence", () => {
+  it("round-trips the message's model id, and reads back null when none was recorded", () => {
+    const repo = createArchiveRepository({ dataDir });
+    const raw = repo.insertRawMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/src/session-1.jsonl",
+      sourceLocator: "line:1",
+      payload: { role: "assistant", content: "hi" },
+      ingestedAt: new Date(),
+    });
+
+    const base = { agent: "claude-code", sourceId: "session-1", rawId: raw.id };
+
+    repo.upsertNormalizedMessage({
+      ...base,
+      message: {
+        messageId: "m1",
+        role: "assistant",
+        ts: "2024-01-01T00:00:00Z",
+        text: "hi",
+        blocks: [{ type: "text", text: "hi" }],
+        model: "claude-opus-4-8",
+      },
+    });
+    repo.upsertNormalizedMessage({
+      ...base,
+      message: {
+        messageId: "m2",
+        role: "user",
+        ts: "2024-01-01T00:00:01Z",
+        text: "ok",
+        blocks: [{ type: "text", text: "ok" }],
+      },
+    });
+
+    const rows = repo.read.listMessagesByChat("claude-code", "session-1");
+    expect(rows.map((r) => r.model)).toEqual(["claude-opus-4-8", null]);
+
+    repo.close();
+  });
+});

--- a/api/src/archive/repository.ts
+++ b/api/src/archive/repository.ts
@@ -42,6 +42,8 @@ export interface NormalizedMessageInput {
   ts: string;
   text: string;
   blocks: unknown;
+  /** The model id the Agent recorded, when it recorded one (ADR-0023). */
+  model?: string;
 }
 
 export interface UpsertNormalizedMessageInput {
@@ -324,6 +326,7 @@ export function createArchiveRepository({
             ts,
             text: message.text,
             blocks: message.blocks,
+            model: message.model ?? null,
             rawId,
           })
           .run();
@@ -337,6 +340,7 @@ export function createArchiveRepository({
             ts,
             text: message.text,
             blocks: message.blocks,
+            model: message.model ?? null,
             rawId,
           })
           .where(eq(messages.id, existing.id))

--- a/api/src/archive/schema.ts
+++ b/api/src/archive/schema.ts
@@ -87,6 +87,10 @@ export const messages = sqliteTable(
     ts: integer("ts", { mode: "timestamp_ms" }).notNull(),
     text: text("text").notNull(),
     blocks: text("blocks", { mode: "json" }).notNull(),
+    // The model id the Agent recorded on this message (ADR-0023). Nullable:
+    // reader turns record none, and neither do rows normalized before #195 —
+    // those get backfilled by the next re-normalize pass.
+    model: text("model"),
     rawId: integer("raw_id")
       .notNull()
       .references(() => rawMessages.id),

--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -74,6 +74,7 @@ function seedMessage(
     text: string;
     blocks: unknown[];
     agent?: string;
+    model?: string;
   }
 ): void {
   const agent = opts.agent ?? DEFAULT_AGENT;
@@ -96,6 +97,7 @@ function seedMessage(
       ts: opts.ts.toISOString(),
       text: opts.text,
       blocks: opts.blocks,
+      ...(opts.model === undefined ? {} : { model: opts.model }),
     },
   });
 }
@@ -918,6 +920,60 @@ describe("ChatReader.getMessages", () => {
     ]);
     expect(messages![0].timestamp).toBe("2023-11-14T22:15:00.000Z");
     expect(messages![1].role).toBe("assistant");
+  });
+
+  it("serves each message's own model, and omits it where none was recorded", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-user",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "Build a login page",
+      blocks: [{ type: "text", text: "Build a login page" }],
+    });
+    // A chat that switches models mid-way: each turn keeps the model it ran on.
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-opus",
+      role: "assistant",
+      ts: new Date(1700000200000),
+      text: "Sure",
+      blocks: [{ type: "text", text: "Sure" }],
+      model: "claude-opus-4-8",
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-haiku",
+      role: "assistant",
+      ts: new Date(1700000300000),
+      text: "Done",
+      blocks: [{ type: "text", text: "Done" }],
+      model: "claude-haiku-4-5-20251001",
+    });
+
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
+      includeTrashed: false,
+    });
+
+    expect(messages!.map((m) => m.model)).toEqual([
+      undefined,
+      "claude-opus-4-8",
+      "claude-haiku-4-5-20251001",
+    ]);
+    expect(messages![0]).not.toHaveProperty("model");
   });
 
   it("exposes each message's Normalized message id", () => {

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -72,6 +72,12 @@ export interface MessageResponse {
   role: "user" | "assistant";
   content: ApiContentBlock[];
   timestamp: string;
+  /**
+   * The model id the Agent recorded on this message (ADR-0023), served raw so
+   * the frontend owns the id→display-name mapping and an unrecognized id still
+   * renders. Absent when no model was recorded.
+   */
+  model?: string;
 }
 
 interface StoredBlock {
@@ -391,6 +397,7 @@ export function createChatReader({
       role: m.role as "user" | "assistant",
       content: (m.blocks as StoredBlock[]).map(toApiBlock),
       timestamp: m.ts.toISOString(),
+      ...(m.model === null ? {} : { model: m.model }),
     }));
   }
 

--- a/api/src/ingestion/renormalize.test.ts
+++ b/api/src/ingestion/renormalize.test.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createArchiveRepository } from "../archive/repository.js";
 import { ClaudeCodePlugin } from "../plugins/claude-code/plugin.js";
-import { renormalizeFromRaw, runRenormalizeIfStale } from "./renormalize.js";
+import {
+  NORMALIZE_VERSION,
+  renormalizeFromRaw,
+  runRenormalizeIfStale,
+} from "./renormalize.js";
 
 let dataDir: string;
 
@@ -200,5 +204,62 @@ describe("runRenormalizeIfStale", () => {
     expect(archive.getNormalizeVersion()).toBe(1);
 
     archive.close();
+  });
+});
+
+describe("renormalizeFromRaw → model backfill", () => {
+  it("backfills the model on a row normalized before the field existed", () => {
+    const archive = createArchiveRepository({ dataDir });
+    archive.ensureChat("claude-code", "session-1", new Date(1700000000000));
+    const { id: rawId } = archive.insertRawMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/fake/session-1.jsonl",
+      sourceLocator: "L1",
+      payload: {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-8",
+          content: [{ type: "text", text: "Done." }],
+        },
+        uuid: "m-model",
+        timestamp: "2024-01-01T00:00:00Z",
+        sessionId: "session-1",
+      },
+      ingestedAt: new Date(1700000000000),
+    });
+    // The pre-#195 normalized row: same content, no model.
+    archive.upsertNormalizedMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      rawId,
+      message: {
+        messageId: "m-model",
+        role: "assistant",
+        ts: "2024-01-01T00:00:00Z",
+        text: "Done.",
+        blocks: [{ type: "text", text: "Done." }],
+      },
+    });
+
+    renormalizeFromRaw({ plugins: [new ClaudeCodePlugin()], archive });
+
+    const messages = archive.read.listMessagesByChat(
+      "claude-code",
+      "session-1"
+    );
+    expect(messages[0].model).toBe("claude-opus-4-8");
+
+    archive.close();
+  });
+});
+
+describe("NORMALIZE_VERSION", () => {
+  it("is ahead of the version that shipped the system block, so #195 re-normalizes", () => {
+    // The backfill only reaches dormant chats when the archive reads as behind.
+    // Version 2 shipped the `system` block (#194); capturing the model (#195)
+    // is the next normalize-output change.
+    expect(NORMALIZE_VERSION).toBeGreaterThanOrEqual(3);
   });
 });

--- a/api/src/ingestion/renormalize.ts
+++ b/api/src/ingestion/renormalize.ts
@@ -68,9 +68,10 @@ export function renormalizeFromRaw({
  * output changes (a new block kind, a translated markup) so startup re-normalizes
  * archived chats up to the new shape. #191 introduces the `command` block, so the
  * first version that needs a re-normalize pass is 1. #194 adds the `system`
- * block, turning archived harness noise into collapsed rows: version 2.
+ * block, turning archived harness noise into collapsed rows: version 2. #195
+ * captures the per-message `model`, backfilling it onto archived rows: version 3.
  */
-export const NORMALIZE_VERSION = 2;
+export const NORMALIZE_VERSION = 3;
 
 export interface RunRenormalizeIfStaleOptions {
   plugins: readonly AgentPlugin[];

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -552,3 +552,37 @@ describe("ClaudeCodePlugin.normalize → system rows", () => {
     ]);
   });
 });
+
+describe("ClaudeCodePlugin.normalize → model capture", () => {
+  it("captures the model id the Agent recorded on an assistant message", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-8",
+          content: [{ type: "text", text: "Done." }],
+        },
+        uuid: "msg-model-1",
+        timestamp: "2024-01-01T00:00:20Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result?.model).toBe("claude-opus-4-8");
+  });
+
+  it("leaves model absent on a reader turn, which records none", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: { role: "user", content: "What changed?" },
+        uuid: "msg-model-2",
+        timestamp: "2024-01-01T00:00:21Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result).not.toHaveProperty("model");
+  });
+});

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -66,13 +66,19 @@ export class ClaudeCodePlugin implements AgentPlugin {
     if (payload.isSidechain === true) return null;
 
     const message = payload.message as
-      | { role: string; content: unknown }
+      | { role: string; content: unknown; model?: unknown }
       | undefined;
     if (!message) return null;
 
     const role = message.role === "assistant" ? "assistant" : "user";
     const messageId = String(payload.uuid ?? "");
     const ts = String(payload.timestamp ?? "");
+    // Claude Code records the model on each assistant message; reader turns
+    // carry none. Spread so the field is absent rather than undefined (ADR-0023).
+    const model =
+      typeof message.model === "string" && message.model !== ""
+        ? { model: message.model }
+        : {};
 
     if (typeof message.content === "string") {
       const command = parseCommandMarkup(message.content);
@@ -109,6 +115,7 @@ export class ClaudeCodePlugin implements AgentPlugin {
         ts,
         text,
         blocks: [{ type: "text", text }],
+        ...model,
       };
     }
 
@@ -122,7 +129,7 @@ export class ClaudeCodePlugin implements AgentPlugin {
         .filter((b): b is { type: "text"; text: string } => b.type === "text")
         .map((b) => b.text)
         .join("\n");
-      return { messageId, role, ts, text, blocks };
+      return { messageId, role, ts, text, blocks, ...model };
     }
 
     return null;

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -46,6 +46,13 @@ export interface NormalizedMessage {
   ts: string;
   text: string;
   blocks: NormalizedBlock[];
+  /**
+   * The model id the Agent recorded on this message (e.g. `claude-opus-4-8`),
+   * per ADR-0023. Absent when the Agent doesn't record one — reader turns never
+   * carry one, and a chat that switches models mid-way records the switch
+   * message by message.
+   */
+  model?: string;
 }
 
 export interface AgentPlugin {

--- a/web/src/agent/modelDisplayName.test.ts
+++ b/web/src/agent/modelDisplayName.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getModelDisplayName } from "./modelDisplayName";
+
+describe("getModelDisplayName", () => {
+  it("names a known model id the way the model is written", () => {
+    expect(getModelDisplayName("claude-opus-4-8")).toBe("Opus 4.8");
+  });
+
+  it("names an unmapped model that still follows the id convention", () => {
+    expect(getModelDisplayName("claude-something-9")).toBe("Something 9");
+  });
+
+  it("shows an id of no known shape as-is, rather than guessing at a name", () => {
+    // The honest floor: an id we cannot read stays readable as itself. Covers a
+    // different vendor and Anthropic's own older ordering, where the version
+    // came before the family.
+    expect(getModelDisplayName("gpt-4o")).toBe("gpt-4o");
+    expect(getModelDisplayName("claude-3-5-sonnet-20241022")).toBe(
+      "claude-3-5-sonnet-20241022"
+    );
+  });
+
+  it("derives a name for an unmapped snapshot of a familiar id shape", () => {
+    // A new dated snapshot of a model we already show should not regress to a
+    // raw id just because the date moved — the date is not part of the name.
+    expect(getModelDisplayName("claude-haiku-4-5-20251001")).toBe("Haiku 4.5");
+    expect(getModelDisplayName("claude-haiku-4-5-20260315")).toBe("Haiku 4.5");
+  });
+});

--- a/web/src/agent/modelDisplayName.ts
+++ b/web/src/agent/modelDisplayName.ts
@@ -1,0 +1,30 @@
+// Overrides for ids the convention below reads wrongly. Empty on purpose: every
+// model shipped so far derives correctly from its id, so listing them here would
+// be duplicate data that drifts. Add an entry only when a model's written name
+// genuinely departs from its id.
+const MODEL_DISPLAY_NAMES: Record<string, string> = {};
+
+// Anthropic's id convention: `claude-<family>-<major>[-<minor>][-<snapshot>]`,
+// where the snapshot is an 8-digit date. Reading the name out of the shape means
+// a new model — or a new dated snapshot of an old one — names itself with no
+// maintenance here at all.
+const CONVENTIONAL_ID = /^claude-([a-z]+)-(\d+)(?:-(\d+))?(?:-(\d{8}))?$/;
+
+function deriveModelDisplayName(model: string): string | null {
+  const match = CONVENTIONAL_ID.exec(model);
+  if (!match) return null;
+
+  const [, family, major, minor] = match;
+  const name = family.charAt(0).toUpperCase() + family.slice(1);
+  return minor === undefined ? `${name} ${major}` : `${name} ${major}.${minor}`;
+}
+
+/**
+ * The model's name as it is written, read from its id. Three layers, narrowest
+ * first: an explicit override, then a name derived from the id convention, and
+ * finally the raw id. The last layer is the honest one — an id that fits no
+ * known shape names itself rather than being guessed at.
+ */
+export function getModelDisplayName(model: string): string {
+  return MODEL_DISPLAY_NAMES[model] ?? deriveModelDisplayName(model) ?? model;
+}

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -207,6 +207,35 @@ describe("Conversation note-style headers", () => {
 
     expect(await screen.findByText("You")).not.toBeNull();
   });
+
+  it("names the model beside the agent, per message, so a mid-chat switch shows", async () => {
+    render(
+      <ConversationView
+        chat={{ ...chat, agent: "claude-code" }}
+        messages={[
+          { ...assistant("Sure, here goes."), model: "claude-opus-4-8" },
+          { ...assistant("Switched."), model: "claude-haiku-4-5-20251001" },
+          // An id of no readable shape still names itself, never blank.
+          { ...assistant("And again."), model: "some-other-model" },
+        ]}
+      />
+    );
+
+    expect(await screen.findByText("Claude Code · Opus 4.8")).not.toBeNull();
+    expect(screen.getByText("Claude Code · Haiku 4.5")).not.toBeNull();
+    expect(screen.getByText("Claude Code · some-other-model")).not.toBeNull();
+  });
+
+  it("names the agent alone when a message records no model", async () => {
+    render(
+      <ConversationView
+        chat={{ ...chat, agent: "claude-code" }}
+        messages={[assistant("No model recorded.")]}
+      />
+    );
+
+    expect(await screen.findByText("Claude Code")).not.toBeNull();
+  });
 });
 
 describe("Conversation note-style layout", () => {

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/conversation/toolUnits";
 import { useScrollShortcuts } from "@/conversation/useScrollShortcuts";
 import { getAgentDisplayName } from "@/agent/agentDisplayName";
+import { getModelDisplayName } from "@/agent/modelDisplayName";
 import { ChatMetadataPopover } from "@/metadata/ChatMetadataPopover";
 import { EditableTitle } from "@/metadata/EditableTitle";
 import { TagStrip } from "@/tags/TagStrip";
@@ -186,6 +187,14 @@ function renderContent(content: Message["content"], toolResults: ToolResults) {
   return content.map((block, i) => renderContentBlock(block, i, toolResults));
 }
 
+// The assistant's byline: the Agent, then the model that turn ran on. Read per
+// message, not per chat, so a chat that switched models mid-way shows where.
+// A message with no recorded model keeps the bare Agent name.
+function authorName(agentName: string, message: Message): string {
+  if (!message.model) return agentName;
+  return `${agentName} · ${getModelDisplayName(message.model)}`;
+}
+
 function MessageItem({
   message,
   agentName,
@@ -217,7 +226,7 @@ function MessageItem({
             message.role === "user" ? "text-chart-2" : "text-primary"
           }`}
         >
-          {message.role === "user" ? "You" : agentName}
+          {message.role === "user" ? "You" : authorName(agentName, message)}
           <span className="ml-2 font-normal text-muted-foreground">
             {formatMessageTimestamp(message.timestamp)}
           </span>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -49,4 +49,10 @@ export interface Message {
   role: "user" | "assistant";
   content: string | ContentBlock[];
   timestamp: string;
+  /**
+   * The model id the Agent recorded on this message, served raw by the API.
+   * Per message, not per chat: a chat that switches models mid-way shows the
+   * switch. Absent when the Agent recorded none.
+   */
+  model?: string;
 }


### PR DESCRIPTION
## Background (Why)

Claude Code records a model id on every assistant message, and normalize threw it away. Reading an archived chat, you could not tell which model wrote a given turn — and a chat that switched models mid-way looked uniform.

## Approach (How)

The id travels the whole line unchanged: plugin → Archive → API → frontend. Naming happens only at the last step, so the stored data stays raw and an id we have never seen still renders.

`NormalizedMessage.model` is optional per ADR-0023, the Archive column is additive and nullable, and the API omits the field rather than sending null. Reader turns record no model and carry none.

The display name is read from the id in three layers, narrowest first: an explicit override table, then a name derived from Anthropic's id convention (`claude-<family>-<major>[-<minor>][-<date>]`), then the raw id. Deriving is what keeps this maintenance-free — a new model, or a new dated snapshot of an old one, names itself. The raw-id floor is the honest one: an id of no known shape stays readable as itself rather than being guessed at.

The override table ships empty on purpose. Every model shipped so far derives correctly, so listing them would be duplicate data that drifts.

## Changes (What)

- [x] `NormalizedMessage.model` captured from the Claude Code payload, absent when none is recorded
- [x] Additive nullable `messages.model` column (migration `0012`), written on both insert and update paths
- [x] `MessageResponse.model` served raw, omitted where unset
- [x] `getModelDisplayName` — override → convention-derived → raw id
- [x] Assistant headers read `Claude Code · Opus 4.8`, per message
- [x] `NORMALIZE_VERSION` 2 → 3 so already-archived chats get backfilled from Raw

### Test Verification

- [x] Plugin captures the model id from an assistant payload
- [x] Field stays absent on a reader turn
- [x] Archive round-trips the value; reads back null when none was recorded
- [x] API serves each message's own model across a mid-chat switch, omits it where unset
- [x] Known id → `Opus 4.8`; unmapped-but-conventional id → derived name
- [x] Unmapped dated snapshot derives rather than regressing to a raw id
- [x] Id of no known shape (`gpt-4o`, `claude-3-5-sonnet-20241022`) shows as-is
- [x] Header renders `agent · model` per message; agent alone when no model
- [x] Re-normalize backfills model onto a row normalized before the field existed
- [x] Full suite green (690 tests), typecheck and build clean

## Additional Notes

Two things a reviewer should look at with fresh eyes:

**The empty override table.** It was populated with 8 entries before the derivation layer went in; every one turned out to be exactly what derivation produces, so keeping them would have been two sources of truth for the same names. If you would rather keep a few as regression anchors, say so — the tests already cover the names either way.

**Derivation is a deliberate reversal.** The first cut used exact-match keys only, on the reasoning that guessing a name is worse than showing an ugly id. The counter-argument that won: this label is cosmetic, so a wrong guess costs an imprecise name rather than wrong data, and the exact-match version needed a manual edit on every model release. The raw-id floor still catches anything that does not fit the convention.

Model ids from before Anthropic's current naming (version ahead of family, e.g. `claude-3-5-sonnet-20241022`) fall to the raw-id layer by design.

## Related Links

- Closes #195