### PR TITLE
feat: inline images end-to-end, lazy-served from Raw

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -12,6 +12,7 @@ import { createChatPageQuery } from "./list-pagination.js";
 import { createChatCountsQuery } from "./list-counts.js";
 import { reconcileTitleSortKeys } from "./metadata/reconcile-title-sort-keys.js";
 import { MAX_PAGE_LIMIT } from "./list-contract.js";
+import { ClaudeCodePlugin } from "./plugins/claude-code/plugin.js";
 
 interface ChatResponse {
   id: string;
@@ -64,15 +65,22 @@ function seedMessage(
     ts: Date;
     text: string;
     blocks: unknown[];
+    /**
+     * The Raw payload to archive alongside. Defaults to a stub: only the paths
+     * that read back through Raw (image serving) need a faithful one.
+     */
+    payload?: unknown;
+    /** The Source file the row came from. Defaults to an existing dummy path. */
+    sourcePath?: string;
   }
 ): void {
   archive.ensureChat(DEFAULT_AGENT, opts.sourceId, opts.ts);
   const raw = archive.insertRawMessage({
     agent: DEFAULT_AGENT,
     sourceId: opts.sourceId,
-    sourcePath: "/dev/null",
+    sourcePath: opts.sourcePath ?? "/dev/null",
     sourceLocator: `${opts.messageId}:0`,
-    payload: { id: opts.messageId },
+    payload: opts.payload ?? { id: opts.messageId },
     ingestedAt: opts.ts,
   });
   archive.upsertNormalizedMessage({
@@ -1984,5 +1992,154 @@ describe("Batch filter branch — select-all-matching (#164, ADR-0021)", () => {
     // Only the two "work" chats count: bug on both, idea on one.
     expect(byTag.get(bug.id)).toBe(2);
     expect(byTag.get(idea.id)).toBe(1);
+  });
+});
+
+// A 1x1 PNG, the smallest thing that is genuinely image bytes.
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+/**
+ * Seed a chat holding one pasted image, archived the way ingestion would: the
+ * Agent's own payload in Raw, the plugin's own normalize output in Normalized.
+ * Going through the real plugin is the point — it ties the `ref` the pane will
+ * request to the `ref` the endpoint has to resolve.
+ */
+function seedImageChat(
+  archive: ReturnType<typeof createArchiveRepository>,
+  opts: {
+    sourceId: string;
+    messageId: string;
+    base64?: string;
+    sourcePath?: string;
+  }
+): { ref: string } {
+  const payload = {
+    type: "user",
+    message: {
+      role: "user",
+      content: [
+        { type: "text", text: "Look at this" },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: opts.base64 ?? PNG_BASE64,
+          },
+        },
+      ],
+    },
+    uuid: opts.messageId,
+    timestamp: "2024-01-01T00:00:00Z",
+    sessionId: opts.sourceId,
+  };
+  const normalized = new ClaudeCodePlugin().normalize({
+    sourceId: opts.sourceId,
+    sourcePath: "/dev/null",
+    sourceLocator: "L1",
+    payload,
+  })!;
+  seedMessage(archive, {
+    sourceId: opts.sourceId,
+    messageId: opts.messageId,
+    role: "user",
+    ts: new Date(1_000),
+    text: normalized.text,
+    blocks: normalized.blocks,
+    payload,
+    ...(opts.sourcePath === undefined ? {} : { sourcePath: opts.sourcePath }),
+  });
+  const image = normalized.blocks.find((b) => b.type === "image");
+  if (!image || image.type !== "image") throw new Error("no image block");
+  return { ref: image.ref };
+}
+
+describe("GET /api/chats/:id/images/:ref", () => {
+  it("serves the bytes out of Raw, typed and cached forever", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const { ref } = seedImageChat(archive, {
+      sourceId: "img1",
+      messageId: "m-img",
+    });
+    const app = createApp({
+      archive,
+      metadata: createMetadataRepository({ dataDir }),
+      tags: createTagRepository({ dataDir }),
+    });
+
+    const res = await app.request(
+      `/api/chats/${wireIdFor(archive, "img1")}/images/${ref}`
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    // Archived bytes never change, so the browser may keep them forever.
+    expect(res.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable"
+    );
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.equals(Buffer.from(PNG_BASE64, "base64"))).toBe(true);
+  });
+
+  it("404s on a ref that names nothing, and on an unknown chat", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    seedImageChat(archive, { sourceId: "img2", messageId: "m-img" });
+    const app = createApp({
+      archive,
+      metadata: createMetadataRepository({ dataDir }),
+      tags: createTagRepository({ dataDir }),
+    });
+    const wireId = wireIdFor(archive, "img2");
+
+    // Index 0 of that message is the text block, not an image.
+    const notAnImage = await app.request(`/api/chats/${wireId}/images/m-img.0`);
+    expect(notAnImage.status).toBe(404);
+
+    // A message that does not exist in this chat.
+    const noSuchMessage = await app.request(
+      `/api/chats/${wireId}/images/m-nope.1`
+    );
+    expect(noSuchMessage.status).toBe(404);
+
+    // A ref that is not a ref at all.
+    const malformed = await app.request(`/api/chats/${wireId}/images/garbage`);
+    expect(malformed.status).toBe(404);
+
+    // A well-formed ref against a chat id that resolves to nothing.
+    const noSuchChat = await app.request(
+      "/api/chats/clog_0000000000000000/images/m-img.1"
+    );
+    expect(noSuchChat.status).toBe(404);
+  });
+});
+
+describe("GET /api/chats/:id/images/:ref — independent of the Source file", () => {
+  it("still serves the bytes after the screenshot is deleted from disk", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const deleted = path.join(dataDir, "gone.jsonl");
+    fs.writeFileSync(deleted, "");
+    const { ref } = seedImageChat(archive, {
+      sourceId: "img3",
+      messageId: "m-img",
+      sourcePath: deleted,
+    });
+    // The Archive copy is its own thing: the reader may have cleaned out the
+    // original log long ago.
+    fs.rmSync(deleted);
+
+    const app = createApp({
+      archive,
+      metadata: createMetadataRepository({ dataDir }),
+      tags: createTagRepository({ dataDir }),
+    });
+
+    const res = await app.request(
+      `/api/chats/${wireIdFor(archive, "img3")}/images/${ref}`
+    );
+
+    expect(res.status).toBe(200);
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.equals(Buffer.from(PNG_BASE64, "base64"))).toBe(true);
   });
 });

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -10,6 +10,7 @@ import type { ChatPageQuery } from "./list-pagination.js";
 import type { ChatCountsQuery } from "./list-counts.js";
 import type { ListEventHub } from "./list-events.js";
 import { MAX_PAGE_LIMIT } from "./list-contract.js";
+import { plugins } from "./plugins/registry.js";
 
 // Heartbeat cadence for the live-update SSE stream. A periodic comment keeps the
 // connection from idling out behind proxies and surfaces a dropped socket so the
@@ -419,6 +420,43 @@ export function createApp({
       return c.json({ error: "Chat not found" }, 404);
     }
     return c.json({ messages });
+  });
+
+  // Inline image bytes, extracted from the Raw payload at request time so the
+  // messages payload stays free of base64 and the archive stores each image once
+  // (ADR-0023). Nothing here reads the Source file, so an image outlives the
+  // screenshot being deleted from disk.
+  app.get("/api/chats/:id/images/:ref", (c) => {
+    const row = reader.findChat(c.req.param("id"));
+    if (!row) return c.json({ error: "Chat not found" }, 404);
+
+    const plugin = plugins.find((p) => p.id === row.agent);
+    if (!plugin?.resolveImage) {
+      return c.json({ error: "Image not found" }, 404);
+    }
+
+    const image = plugin.resolveImage(c.req.param("ref"), (messageId) => {
+      const payload = archive.read.findRawPayloadForMessage(
+        row.agent,
+        row.sourceId,
+        messageId
+      );
+      if (payload === null) return null;
+      try {
+        return JSON.parse(payload);
+      } catch {
+        return null;
+      }
+    });
+    if (!image) return c.json({ error: "Image not found" }, 404);
+
+    // Hono's body takes a plain Uint8Array; a Node Buffer's backing store is
+    // typed loosely enough that it does not satisfy that signature.
+    return c.body(new Uint8Array(image.bytes), 200, {
+      "Content-Type": image.mediaType,
+      // Archived bytes never change, so the browser can keep them forever.
+      "Cache-Control": "public, max-age=31536000, immutable",
+    });
   });
 
   app.get("/api/tags", (c) => {

--- a/api/src/archive/read-seam.ts
+++ b/api/src/archive/read-seam.ts
@@ -66,6 +66,17 @@ export interface ArchiveReadSeam {
   /** Messages for one `(agent, source_id)` chat, ordered by ascending ts. */
   listMessagesByChat(agent: string, sourceId: string): MessageRow[];
   /**
+   * The Raw payload one normalized message was parsed from, as stored JSON text.
+   * The image endpoint reads bytes back out of it at request time (ADR-0023), so
+   * an archived image survives its Source file being deleted. Null when the
+   * message does not exist.
+   */
+  findRawPayloadForMessage(
+    agent: string,
+    sourceId: string,
+    messageId: string
+  ): string | null;
+  /**
    * One grouped row per `(agent, source_id)` with the min/max message ts.
    * A single grouped query — constant query count regardless of chat count.
    * With `sourceIds`, scopes the scan to those chats so page hydration does not
@@ -133,6 +144,21 @@ export function createArchiveReadSeam(db: ArchiveDb): ArchiveReadSeam {
         .where(and(eq(messages.agent, agent), eq(messages.sourceId, sourceId)))
         .orderBy(asc(messages.ts))
         .all();
+    },
+    findRawPayloadForMessage(agent, sourceId, messageId) {
+      const row = db
+        .select({ rawPayload: rawMessages.rawPayload })
+        .from(messages)
+        .innerJoin(rawMessages, eq(messages.rawId, rawMessages.id))
+        .where(
+          and(
+            eq(messages.agent, agent),
+            eq(messages.sourceId, sourceId),
+            eq(messages.messageId, messageId)
+          )
+        )
+        .get();
+      return row?.rawPayload ?? null;
     },
     listChatTsRanges(opts) {
       const scope =

--- a/api/src/ingestion/renormalize.test.ts
+++ b/api/src/ingestion/renormalize.test.ts
@@ -263,3 +263,79 @@ describe("NORMALIZE_VERSION", () => {
     expect(NORMALIZE_VERSION).toBeGreaterThanOrEqual(3);
   });
 });
+
+describe("renormalizeFromRaw → inline images", () => {
+  it("surfaces images in a chat archived before images were normalized", () => {
+    const archive = createArchiveRepository({ dataDir });
+    archive.ensureChat("claude-code", "session-1", new Date(1700000000000));
+    const { id: rawId } = archive.insertRawMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/fake/session-1.jsonl",
+      sourceLocator: "L1",
+      payload: {
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Look at this" },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "iVBORw0KGgo=",
+              },
+            },
+          ],
+        },
+        uuid: "m-img",
+        timestamp: "2024-01-01T00:00:00Z",
+        sessionId: "session-1",
+      },
+      ingestedAt: new Date(1700000000000),
+    });
+    // The stale row a pre-image plugin produced: the image was simply dropped.
+    archive.upsertNormalizedMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      rawId,
+      message: {
+        messageId: "m-img",
+        role: "user",
+        ts: "2024-01-01T00:00:00Z",
+        text: "Look at this",
+        blocks: [{ type: "text", text: "Look at this" }],
+      },
+    });
+
+    renormalizeFromRaw({ archive, plugins: [new ClaudeCodePlugin()] });
+
+    expect(
+      archive.read.listMessagesByChat("claude-code", "session-1")[0].blocks
+    ).toEqual([
+      { type: "text", text: "Look at this" },
+      { type: "image", mediaType: "image/png", ref: "m-img.1" },
+    ]);
+
+    archive.close();
+  });
+
+  it("re-normalizes an archive stamped at the pre-image version", () => {
+    const archive = createArchiveRepository({ dataDir });
+    seedStaleCommand(archive);
+    // Version 3 is where the archive sits before this change; a boot on it must
+    // still have a pass to run, which is what carries images to dormant chats.
+    archive.setNormalizeVersion(3);
+
+    const ran = runRenormalizeIfStale({
+      archive,
+      plugins: [new ClaudeCodePlugin()],
+    });
+
+    expect(ran).toBe(true);
+    expect(archive.getNormalizeVersion()).toBe(NORMALIZE_VERSION);
+
+    archive.close();
+  });
+});

--- a/api/src/ingestion/renormalize.ts
+++ b/api/src/ingestion/renormalize.ts
@@ -70,8 +70,10 @@ export function renormalizeFromRaw({
  * first version that needs a re-normalize pass is 1. #194 adds the `system`
  * block, turning archived harness noise into collapsed rows: version 2. #195
  * captures the per-message `model`, backfilling it onto archived rows: version 3.
+ * #196 adds the `image` block, making pasted screenshots visible in chats that
+ * dropped them at ingest: version 4.
  */
-export const NORMALIZE_VERSION = 3;
+export const NORMALIZE_VERSION = 4;
 
 export interface RunRenormalizeIfStaleOptions {
   plugins: readonly AgentPlugin[];

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -586,3 +586,38 @@ describe("ClaudeCodePlugin.normalize → model capture", () => {
     expect(result).not.toHaveProperty("model");
   });
 });
+
+describe("ClaudeCodePlugin.normalize → inline images", () => {
+  it("emits an image block carrying media type and a ref, never the bytes", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Look at this" },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "iVBORw0KGgo=",
+              },
+            },
+          ],
+        },
+        uuid: "msg-img-1",
+        timestamp: "2024-01-01T00:00:30Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      { type: "text", text: "Look at this" },
+      { type: "image", mediaType: "image/png", ref: "msg-img-1.1" },
+    ]);
+    // The bytes stay in Raw; Normalized must not double the archive's image
+    // storage (ADR-0023).
+    expect(JSON.stringify(result)).not.toContain("iVBORw0KGgo=");
+  });
+});

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -121,10 +121,10 @@ export class ClaudeCodePlugin implements AgentPlugin {
 
     if (Array.isArray(message.content)) {
       const blocks: NormalizedBlock[] = [];
-      for (const block of message.content) {
-        const normalized = normalizeBlock(block);
+      message.content.forEach((block, index) => {
+        const normalized = normalizeBlock(block, messageId, index);
         if (normalized) blocks.push(normalized);
-      }
+      });
       const text = blocks
         .filter((b): b is { type: "text"; text: string } => b.type === "text")
         .map((b) => b.text)
@@ -133,6 +133,36 @@ export class ClaudeCodePlugin implements AgentPlugin {
     }
 
     return null;
+  }
+
+  resolveImage(
+    ref: string,
+    loadPayload: (messageId: string) => unknown | null
+  ): { mediaType: string; bytes: Buffer } | null {
+    const address = parseImageRef(ref);
+    if (!address) return null;
+
+    const record = loadPayload(address.messageId) as Record<
+      string,
+      unknown
+    > | null;
+    if (!record || typeof record !== "object") return null;
+
+    const message = record.message as { content?: unknown } | undefined;
+    if (!message || !Array.isArray(message.content)) return null;
+
+    const block = message.content[address.index] as
+      | Record<string, unknown>
+      | undefined;
+    if (!block || block.type !== "image") return null;
+
+    const source = block.source as Record<string, unknown> | undefined;
+    if (!source || source.type !== "base64") return null;
+    const mediaType = String(source.media_type ?? "");
+    const data = source.data;
+    if (!mediaType || typeof data !== "string") return null;
+
+    return { mediaType, bytes: Buffer.from(data, "base64") };
   }
 }
 
@@ -232,10 +262,45 @@ function parseSystemNoise(
   return null;
 }
 
-function normalizeBlock(raw: unknown): NormalizedBlock | null {
+// An image's address inside its own message: the message id plus the block's
+// position in the Agent's content array. Opaque to everyone but this plugin —
+// the endpoint hands it back untouched and the plugin resolves it.
+function imageRef(messageId: string, index: number): string {
+  return `${messageId}.${index}`;
+}
+
+// The inverse of `imageRef`. Splits on the last dot so a message id containing
+// dots still round-trips.
+function parseImageRef(
+  ref: string
+): { messageId: string; index: number } | null {
+  const dot = ref.lastIndexOf(".");
+  if (dot <= 0) return null;
+  const index = Number(ref.slice(dot + 1));
+  if (!Number.isInteger(index) || index < 0) return null;
+  return { messageId: ref.slice(0, dot), index };
+}
+
+// `index` is the block's position in the Agent's own content array, not in the
+// normalized output: unrecognized blocks get dropped, so only the raw position
+// survives as a stable address back into the Raw row (see `imageRef`).
+function normalizeBlock(
+  raw: unknown,
+  messageId: string,
+  index: number
+): NormalizedBlock | null {
   if (!raw || typeof raw !== "object") return null;
   const b = raw as Record<string, unknown>;
   switch (b.type) {
+    case "image": {
+      const source = b.source as Record<string, unknown> | undefined;
+      // Claude Code only writes inline base64 today. A source shape we don't
+      // recognize is dropped rather than served as a broken image.
+      if (!source || source.type !== "base64") return null;
+      const mediaType = String(source.media_type ?? "");
+      if (!mediaType) return null;
+      return { type: "image", mediaType, ref: imageRef(messageId, index) };
+    }
     case "text":
       return { type: "text", text: String(b.text ?? "") };
     case "thinking":

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -38,7 +38,13 @@ export type NormalizedBlock =
   // task notifications, local command echoes. `kind` is an open string so a new
   // noise type widens the data, not the type union (ADR-0023). `summary` is the
   // collapsed one-liner; `detail` is the original content, kept for expansion.
-  | { type: "system"; kind: string; summary: string; detail: string };
+  | { type: "system"; kind: string; summary: string; detail: string }
+  // An inline image, metadata only (ADR-0023). The bytes stay in the Raw layer
+  // where the Agent already wrote them verbatim; `ref` is an opaque token the
+  // image endpoint resolves back to their location in the message's Raw row.
+  // Never inline base64 here: it would double the Archive's image storage and
+  // force the messages API to ship every image up front.
+  | { type: "image"; mediaType: string; ref: string };
 
 export interface NormalizedMessage {
   messageId: string;
@@ -61,4 +67,17 @@ export interface AgentPlugin {
   discover(env: PluginEnv): AsyncIterable<ChatRef>;
   extractRaw(ref: ChatRef): AsyncIterable<RawRecord>;
   normalize(raw: RawRecord): NormalizedMessage | null;
+  /**
+   * Resolve an `image` block's `ref` back to the bytes the Agent wrote into Raw.
+   * The ref is the plugin's own token — only the plugin that minted it knows
+   * which message it addresses — so the endpoint hands it back untouched along
+   * with `loadPayload`, which fetches one message's Raw payload by message id.
+   * Keeping the lookup behind a callback keeps ref parsing wholly in the plugin
+   * and store access wholly in the endpoint. Returns null when the ref names
+   * nothing. Optional: an Agent whose logs carry no images never implements it.
+   */
+  resolveImage?(
+    ref: string,
+    loadPayload: (messageId: string) => unknown | null
+  ): { mediaType: string; bytes: Buffer } | null;
 }

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -828,3 +828,83 @@ describe("Conversation markdown typography", () => {
     expect(prose?.className).toContain("[overflow-wrap:anywhere]");
   });
 });
+
+describe("ConversationView — inline images", () => {
+  it("renders an image block as a lazy thumbnail served from its chat", async () => {
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-img",
+            role: "user",
+            content: [
+              { type: "text", text: "Look at this" },
+              { type: "image", mediaType: "image/png", ref: "m-img.1" },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    const img = await screen.findByRole("img");
+    // Bytes come from the endpoint, never from the messages payload.
+    expect(img.getAttribute("src")).toBe("/api/chats/c1/images/m-img.1");
+    // Only images scrolled into view are fetched.
+    expect(img.getAttribute("loading")).toBe("lazy");
+  });
+
+  it("opens the full-size image in a lightbox, and closes on Escape", async () => {
+    const user = userEvent.setup();
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-img",
+            role: "user",
+            content: [
+              { type: "image", mediaType: "image/png", ref: "m-img.0" },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    await user.click(await screen.findByRole("img"));
+
+    const lightbox = await screen.findByRole("dialog");
+    // The same immutable URL the thumbnail used, so the bytes are already cached.
+    expect(lightbox.querySelector("img")?.getAttribute("src")).toBe(
+      "/api/chats/c1/images/m-img.0"
+    );
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("gives a turn holding only an image the author byline and timestamp", async () => {
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-img",
+            role: "user",
+            content: [
+              { type: "image", mediaType: "image/png", ref: "m-img.0" },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    // Pasting a screenshot is the reader's own act, so it is attributed like
+    // anything else they wrote — and a screenshot's timestamp is the whole
+    // point of it ("was this before or after the fix?").
+    expect(await screen.findByText("You")).toBeTruthy();
+  });
+});

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -7,6 +7,7 @@ import { CollapsibleThinking } from "@/conversation/CollapsibleThinking";
 import { CollapsibleToolCall } from "@/conversation/CollapsibleToolCall";
 import { CommandLine } from "@/conversation/CommandLine";
 import { SystemRow } from "@/conversation/SystemRow";
+import { InlineImage } from "@/conversation/InlineImage";
 import { ScrollPill } from "@/conversation/ScrollPill";
 import { NewMessagesPill } from "@/conversation/NewMessagesPill";
 import { UnreadDivider } from "@/conversation/UnreadDivider";
@@ -153,7 +154,8 @@ type ToolResults = Map<string, ToolResultBlock>;
 function renderContentBlock(
   block: ContentBlock,
   index: number,
-  toolResults: ToolResults
+  toolResults: ToolResults,
+  chatId: string
 ) {
   switch (block.type) {
     case "text":
@@ -177,14 +179,22 @@ function renderContentBlock(
       return (
         <SystemRow key={index} summary={block.summary} detail={block.detail} />
       );
+    case "image":
+      return <InlineImage key={index} chatId={chatId} imageRef={block.ref} />;
   }
 }
 
-function renderContent(content: Message["content"], toolResults: ToolResults) {
+function renderContent(
+  content: Message["content"],
+  toolResults: ToolResults,
+  chatId: string
+) {
   if (typeof content === "string") {
     return <MarkdownText>{content}</MarkdownText>;
   }
-  return content.map((block, i) => renderContentBlock(block, i, toolResults));
+  return content.map((block, i) =>
+    renderContentBlock(block, i, toolResults, chatId)
+  );
 }
 
 // The assistant's byline: the Agent, then the model that turn ran on. Read per
@@ -199,10 +209,13 @@ function MessageItem({
   message,
   agentName,
   toolResults,
+  chatId,
 }: {
   message: Message;
   agentName: string;
   toolResults: ToolResults;
+  /** Owning chat, so an image block can address its own bytes. */
+  chatId: string;
 }) {
   return (
     <div
@@ -232,7 +245,7 @@ function MessageItem({
           </span>
         </div>
       )}
-      {renderContent(message.content, toolResults)}
+      {renderContent(message.content, toolResults, chatId)}
     </div>
   );
 }
@@ -477,6 +490,7 @@ export function ConversationView({
                     message={messages[virtualItem.index]}
                     agentName={agentName}
                     toolResults={toolResults}
+                    chatId={chat?.id ?? ""}
                   />
                 </div>
               ))}

--- a/web/src/conversation/InlineImage.tsx
+++ b/web/src/conversation/InlineImage.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { Dialog, DialogContent, DialogTitle } from "@/shared/ui/dialog";
+
+interface InlineImageProps {
+  /** The chat the image belongs to; the bytes are served under its id. */
+  chatId: string;
+  /** The plugin's opaque address for these bytes inside the Raw layer. */
+  imageRef: string;
+}
+
+/**
+ * The URL the image bytes come from. Archived bytes never change, so the
+ * response is cached forever and a thumbnail already scrolled past costs
+ * nothing to show again — including at full size in the lightbox.
+ */
+export function inlineImageSrc(chatId: string, imageRef: string): string {
+  return `/api/chats/${chatId}/images/${imageRef}`;
+}
+
+/**
+ * A pasted screenshot, in place in the conversation.
+ *
+ * Held to a thumbnail height so an image never shoves the surrounding prose off
+ * screen, and loaded only once scrolled into view — a chat can hold dozens, and
+ * the messages payload deliberately carries none of their bytes (ADR-0023).
+ * Clicking opens it at full size; the lightbox reuses the same URL, so the
+ * bytes are already in the browser's cache.
+ */
+export function InlineImage({ chatId, imageRef }: InlineImageProps) {
+  const [open, setOpen] = useState(false);
+  const src = inlineImageSrc(chatId, imageRef);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Open image full size"
+        className="block cursor-zoom-in rounded-md outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <img
+          src={src}
+          alt="Pasted image"
+          loading="lazy"
+          className="my-2 max-h-60 w-auto max-w-full rounded-md border border-border object-contain"
+        />
+      </button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        {/* Nearly the whole viewport: the point of opening it is to read what
+            the thumbnail was too small for. */}
+        <DialogContent className="w-auto max-w-[calc(100vw-4rem)] bg-transparent p-0 shadow-none ring-0">
+          <DialogTitle className="sr-only">Pasted image</DialogTitle>
+          <img
+            src={src}
+            alt="Pasted image"
+            className="max-h-[calc(100vh-4rem)] max-w-full rounded-md object-contain"
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/conversation/messageVisibility.ts
+++ b/web/src/conversation/messageVisibility.ts
@@ -23,6 +23,9 @@ function rendersSomething(block: ContentBlock): boolean {
     case "system":
       // Harness noise, shown as a collapsed row the reader skims past.
       return true;
+    case "image":
+      // A thumbnail; a turn holding only a pasted screenshot still shows it.
+      return true;
   }
 }
 
@@ -40,19 +43,23 @@ export function hasRenderableContent(message: Message): boolean {
 }
 
 /**
- * Whether a Message is authored prose, and so earns a `You` / agent-name
+ * Whether a Message is an authored act, and so earns a `You` / agent-name
  * header.
  *
- * Text and a slash-command invocation count: both are things the reader wrote,
- * so they earn a `You` header. Tool calls and thinking are collapsed units: the
- * Agent logs them as turns of their own, but the reader sees them as part of the
- * moment that prompted them, so they nest under the preceding header instead of
- * repeating it (#192).
+ * The line is who did it, not what shape it took: text, a slash-command
+ * invocation and a pasted image are all things someone deliberately put in the
+ * chat, so each earns a header — and with it the timestamp, which a screenshot
+ * needs more than prose does ("was this before or after the fix?"). Tool calls
+ * and thinking are collapsed units: the Agent logs them as turns of their own,
+ * but the reader sees them as part of the moment that prompted them, so they
+ * nest under the preceding header instead of repeating it (#192).
  */
 export function hasAuthorHeader(message: Message): boolean {
   if (typeof message.content === "string") return hasText(message.content);
   return message.content.some(
     (block) =>
-      (block.type === "text" && hasText(block.text)) || block.type === "command"
+      (block.type === "text" && hasText(block.text)) ||
+      block.type === "command" ||
+      block.type === "image"
   );
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -41,7 +41,11 @@ export type ContentBlock =
   | { type: "command"; name: string; args: string }
   // Harness noise the plugin classified at normalize time (ADR-0023). Renders as
   // a collapsed system row; `detail` is empty when the summary is the whole of it.
-  | { type: "system"; kind: string; summary: string; detail: string };
+  | { type: "system"; kind: string; summary: string; detail: string }
+  // An inline image the plugin recorded at normalize time (ADR-0023). Metadata
+  // only: `ref` addresses the bytes, which the image endpoint serves lazily so
+  // this payload stays light no matter how many screenshots a chat holds.
+  | { type: "image"; mediaType: string; ref: string };
 
 export interface Message {
   /** The Normalized `message_id`, unique within a Chat — the Message's stable handle. */


### PR DESCRIPTION
## Background (Why)

Pasted images were dropped at normalize time, even though their bytes were already sitting in the Raw layer verbatim. Screenshots are how a lot of chats actually explain themselves — a UI bug, a design reference, a stack trace someone grabbed rather than copied — and until now none of them were visible.

Because the Archive copy is independent of the filesystem, this also makes images readable in chats whose original log files have long since been deleted.

## Approach (How)

Per ADR-0023, normalize emits an `image` block carrying the media type and an opaque `ref` — never the base64 itself. Storing bytes in Normalized would double the archive's image storage and force the messages API to ship every image up front.

The bytes come from a dedicated endpoint that extracts them out of the message's Raw payload at request time, with `immutable` cache headers (archived content never changes, so the browser keeps them forever).

The `ref` is the plugin's own token. To keep ref parsing wholly inside the plugin and store access wholly inside the endpoint, `resolveImage(ref, loadPayload)` takes a callback that fetches one message's Raw payload by id — the endpoint never learns what a ref is made of.

## Changes (What)

- [ ] `image` added to the normalized block vocabulary; the Claude Code plugin translates base64 image blocks into it
- [ ] `AgentPlugin.resolveImage` — optional, so an Agent whose logs carry no images never implements it
- [ ] `GET /api/chats/:id/images/:ref` serves the bytes with `Cache-Control: public, max-age=31536000, immutable`
- [ ] `findRawPayloadForMessage` added to the Archive read seam
- [ ] `NORMALIZE_VERSION` → 4, so the next boot carries images into already-archived chats
- [ ] `InlineImage` renders a lazy thumbnail (max-height 240px) that opens full size in a lightbox
- [ ] A turn holding only an image now earns the author byline and timestamp

### Test Verification

- [ ] normalize emits `{type, mediaType, ref}` and no base64 survives into the message
- [ ] the endpoint returns the right bytes, content type, and immutable cache header
- [ ] 404 on a ref pointing at a non-image block, an unknown message, a malformed ref, and an unknown chat
- [ ] the image still serves after its Source file is deleted from disk
- [ ] re-normalize surfaces images on a row archived before images were normalized
- [ ] an archive stamped at the pre-image version still has a pass to run
- [ ] the thumbnail is `loading="lazy"` and points at the chat's own endpoint
- [ ] clicking opens a lightbox on the same URL; Escape closes it
- [ ] an image-only turn renders the `You` byline

Full suite: 357 api + 342 web, all green. Typecheck and build pass.

## Additional Notes

Two judgment calls worth a reviewer's eye:

**Images are not gated on trash visibility.** The route resolves the chat with `findChat`, not the visibility-checked path `getMessages` uses. An `<img src>` cannot carry `includeTrashed`, so gating would break every image in the Trash view. The unguessable chat id is the only gate. Happy to revisit if that is too loose.

Only `source.type === "base64"` resolves; any other shape is dropped at normalize rather than served as a broken image.

## Related Links

- Closes #196