### PR TITLE
feat: render SVG visualize widgets as inline images

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -2143,3 +2143,159 @@ describe("GET /api/chats/:id/images/:ref — independent of the Source file", ()
     expect(body.equals(Buffer.from(PNG_BASE64, "base64"))).toBe(true);
   });
 });
+
+// A visualize widget call, archived the way ingestion would have stored it.
+function seedWidgetChat(
+  archive: ReturnType<typeof createArchiveRepository>,
+  opts: { sourceId: string; messageId: string; widgetCode: string }
+): { ref: string | null } {
+  const payload = {
+    type: "assistant",
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "toolu_w",
+          name: "mcp__visualize__show_widget",
+          input: { title: "diagram", widget_code: opts.widgetCode },
+        },
+      ],
+    },
+    uuid: opts.messageId,
+    timestamp: "2024-01-01T00:00:00Z",
+    sessionId: opts.sourceId,
+  };
+  const normalized = new ClaudeCodePlugin().normalize({
+    sourceId: opts.sourceId,
+    sourcePath: "/dev/null",
+    sourceLocator: "L1",
+    payload,
+  })!;
+  seedMessage(archive, {
+    sourceId: opts.sourceId,
+    messageId: opts.messageId,
+    role: "assistant",
+    ts: new Date(1_000),
+    text: normalized.text,
+    blocks: normalized.blocks,
+    payload,
+  });
+  const image = normalized.blocks.find((b) => b.type === "image");
+  return { ref: image?.type === "image" ? image.ref : null };
+}
+
+describe("GET /api/chats/:id/images/:ref — visualize widgets", () => {
+  it("serves the widget's own SVG source back", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const { ref } = seedWidgetChat(archive, {
+      sourceId: "wid1",
+      messageId: "m-wid",
+      widgetCode:
+        '<svg viewBox="0 0 680 200"><text class="t">Hello</text></svg>',
+    });
+    const app = createApp({
+      archive,
+      metadata: createMetadataRepository({ dataDir }),
+      tags: createTagRepository({ dataDir }),
+    });
+
+    const res = await app.request(
+      `/api/chats/${wireIdFor(archive, "wid1")}/images/${ref}`
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/svg+xml");
+    const body = await res.text();
+    expect(body).toContain('<text class="t">Hello</text>');
+  });
+
+  // A screenshot's bytes came out of Raw verbatim, so they can be pinned in the
+  // browser forever. A widget's are rendered here from app code — the theme
+  // stylesheet and the viewBox sizing — so an upgrade must be able to change
+  // what the reader sees. Immutable would pin the old render for a year.
+  it("lets a rendered widget revalidate rather than pinning it forever", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const { ref } = seedWidgetChat(archive, {
+      sourceId: "wid4",
+      messageId: "m-wid",
+      widgetCode: '<svg viewBox="0 0 680 200"><g/></svg>',
+    });
+    const app = createApp({
+      archive,
+      metadata: createMetadataRepository({ dataDir }),
+      tags: createTagRepository({ dataDir }),
+    });
+    const url = `/api/chats/${wireIdFor(archive, "wid4")}/images/${ref}`;
+
+    const res = await app.request(url);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-cache");
+    const etag = res.headers.get("etag");
+    expect(etag).toBeTruthy();
+
+    // Revalidation stays cheap: the reader re-renders nothing and the bytes do
+    // not travel twice.
+    const again = await app.request(url, {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(again.status).toBe(304);
+  });
+
+  // The <img> tag is the real boundary: browsers refuse to run scripts or load
+  // external resources for an SVG in image context. The headers say the same
+  // thing a second time, so a future caller that reaches for the URL directly
+  // does not inherit a hole.
+  it("serves a script-bearing widget inert rather than scrubbing it", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const { ref } = seedWidgetChat(archive, {
+      sourceId: "wid2",
+      messageId: "m-wid",
+      widgetCode:
+        '<svg viewBox="0 0 680 200"><script>fetch("http://evil.test")</script></svg>',
+    });
+    const app = createApp({
+      archive,
+      metadata: createMetadataRepository({ dataDir }),
+      tags: createTagRepository({ dataDir }),
+    });
+
+    const res = await app.request(
+      `/api/chats/${wireIdFor(archive, "wid2")}/images/${ref}`
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-security-policy")).toBe(
+      "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+    );
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    // The archive is a faithful record: what the Agent wrote is what we keep.
+    expect(await res.text()).toContain('fetch("http://evil.test")');
+  });
+
+  // Normalize emits no image block for an HTML widget, so nothing in the pane
+  // asks for this URL. A hand-typed ref must not become a back door to serving
+  // one anyway.
+  it("404s on a ref pointing at an HTML widget", async () => {
+    const archive = createArchiveRepository({ dataDir });
+    const { ref } = seedWidgetChat(archive, {
+      sourceId: "wid3",
+      messageId: "m-wid",
+      widgetCode: '<div style="padding:8px">Before and after</div>',
+    });
+    expect(ref).toBeNull();
+
+    const app = createApp({
+      archive,
+      metadata: createMetadataRepository({ dataDir }),
+      tags: createTagRepository({ dataDir }),
+    });
+
+    const res = await app.request(
+      `/api/chats/${wireIdFor(archive, "wid3")}/images/m-wid.0`
+    );
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { serveStatic } from "@hono/node-server/serve-static";
@@ -450,12 +451,41 @@ export function createApp({
     });
     if (!image) return c.json({ error: "Image not found" }, 404);
 
+    // Rendered bytes (a themed, sized widget) depend on this app's version, not
+    // on the archive, so they get an ETag and revalidate. Pinning them would
+    // leave an upgraded reader looking at the render their old version made.
+    // Revalidation costs one local 304 and no bytes.
+    if (image.rendered) {
+      const etag = `"${createHash("sha256")
+        .update(image.bytes)
+        .digest("base64url")
+        .slice(0, 27)}"`;
+      if (c.req.header("if-none-match") === etag) {
+        return c.body(null, 304, { ETag: etag, "Cache-Control": "no-cache" });
+      }
+      return c.body(new Uint8Array(image.bytes), 200, {
+        "Content-Type": image.mediaType,
+        "Cache-Control": "no-cache",
+        ETag: etag,
+        "Content-Security-Policy":
+          "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+        "X-Content-Type-Options": "nosniff",
+      });
+    }
+
     // Hono's body takes a plain Uint8Array; a Node Buffer's backing store is
     // typed loosely enough that it does not satisfy that signature.
     return c.body(new Uint8Array(image.bytes), 200, {
       "Content-Type": image.mediaType,
-      // Archived bytes never change, so the browser can keep them forever.
+      // Verbatim archived bytes never change, so the browser keeps them forever.
       "Cache-Control": "public, max-age=31536000, immutable",
+      // Archived bytes are the Agent's, not ours — an SVG widget may carry a
+      // script. The pane renders these through `<img>`, which already refuses
+      // to run scripts or load external resources; saying it again in the
+      // headers keeps that true for anyone opening the URL on its own.
+      "Content-Security-Policy":
+        "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+      "X-Content-Type-Options": "nosniff",
     });
   });
 

--- a/api/src/ingestion/renormalize.test.ts
+++ b/api/src/ingestion/renormalize.test.ts
@@ -264,6 +264,80 @@ describe("NORMALIZE_VERSION", () => {
   });
 });
 
+describe("renormalizeFromRaw → visualize widgets", () => {
+  const WIDGET_SVG =
+    '<svg viewBox="0 0 680 200"><text class="t">Hi</text></svg>';
+
+  it("surfaces a widget image in a chat archived before widgets were drawn", () => {
+    const archive = createArchiveRepository({ dataDir });
+    archive.ensureChat("claude-code", "session-1", new Date(1700000000000));
+    const toolUse = {
+      type: "tool_use",
+      id: "toolu_w1",
+      name: "mcp__visualize__show_widget",
+      input: { title: "diagram", widget_code: WIDGET_SVG },
+    };
+    const { id: rawId } = archive.insertRawMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/fake/session-1.jsonl",
+      sourceLocator: "L1",
+      payload: {
+        type: "assistant",
+        message: { role: "assistant", content: [toolUse] },
+        uuid: "m-wid",
+        timestamp: "2024-01-01T00:00:00Z",
+        sessionId: "session-1",
+      },
+      ingestedAt: new Date(1700000000000),
+    });
+    // The stale row a pre-widget plugin produced: a bare tool row, the drawing
+    // invisible.
+    archive.upsertNormalizedMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      rawId,
+      message: {
+        messageId: "m-wid",
+        role: "assistant",
+        ts: "2024-01-01T00:00:00Z",
+        text: "",
+        blocks: [
+          {
+            type: "tool_use",
+            id: "toolu_w1",
+            name: "mcp__visualize__show_widget",
+            input: { title: "diagram", widget_code: WIDGET_SVG },
+          },
+        ],
+      },
+    });
+
+    renormalizeFromRaw({ archive, plugins: [new ClaudeCodePlugin()] });
+
+    expect(
+      archive.read.listMessagesByChat("claude-code", "session-1")[0].blocks
+    ).toEqual([
+      {
+        type: "tool_use",
+        id: "toolu_w1",
+        name: "mcp__visualize__show_widget",
+        input: { title: "diagram", widget_code: WIDGET_SVG },
+      },
+      { type: "image", mediaType: "image/svg+xml", ref: "m-wid.0" },
+    ]);
+
+    archive.close();
+  });
+
+  it("is ahead of the version that shipped inline images, so #230 re-normalizes", () => {
+    // Version 4 shipped the `image` block for pasted screenshots (#196). Drawing
+    // archived widgets is the next normalize-output change, and only a bump
+    // reaches chats whose Source files are long gone.
+    expect(NORMALIZE_VERSION).toBeGreaterThanOrEqual(5);
+  });
+});
+
 describe("renormalizeFromRaw → inline images", () => {
   it("surfaces images in a chat archived before images were normalized", () => {
     const archive = createArchiveRepository({ dataDir });

--- a/api/src/ingestion/renormalize.ts
+++ b/api/src/ingestion/renormalize.ts
@@ -71,9 +71,10 @@ export function renormalizeFromRaw({
  * block, turning archived harness noise into collapsed rows: version 2. #195
  * captures the per-message `model`, backfilling it onto archived rows: version 3.
  * #196 adds the `image` block, making pasted screenshots visible in chats that
- * dropped them at ingest: version 4.
+ * dropped them at ingest: version 4. #230 draws SVG visualize widgets as images
+ * too, so archived diagrams stop hiding behind a collapsed tool row: version 5.
  */
-export const NORMALIZE_VERSION = 4;
+export const NORMALIZE_VERSION = 5;
 
 export interface RunRenormalizeIfStaleOptions {
   plugins: readonly AgentPlugin[];

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -621,3 +621,57 @@ describe("ClaudeCodePlugin.normalize → inline images", () => {
     expect(JSON.stringify(result)).not.toContain("iVBORw0KGgo=");
   });
 });
+
+describe("ClaudeCodePlugin.normalize → visualize widgets", () => {
+  function widgetCall(widgetCode: string) {
+    return rawRecord({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_w1",
+            name: "mcp__visualize__show_widget",
+            input: { title: "arch_diagram", widget_code: widgetCode },
+          },
+        ],
+      },
+      uuid: "msg-w-1",
+      timestamp: "2024-01-01T00:00:40Z",
+      sessionId: "session-1",
+    });
+  }
+
+  it("emits an image block beside the tool row when the widget is SVG", () => {
+    const svg = '<svg viewBox="0 0 680 200"><text class="t">Hi</text></svg>';
+    const result = plugin.normalize(widgetCall(svg));
+
+    // The tool row stays: the reader can still open the widget's source.
+    expect(result?.blocks).toEqual([
+      {
+        type: "tool_use",
+        id: "toolu_w1",
+        name: "mcp__visualize__show_widget",
+        input: { title: "arch_diagram", widget_code: svg },
+      },
+      { type: "image", mediaType: "image/svg+xml", ref: "msg-w-1.0" },
+    ]);
+  });
+
+  // HTML widgets earn their keep by being interactive, which serving them would
+  // mean executing archived code. They stay a tool row the reader can expand.
+  it("leaves an HTML widget as a bare tool row", () => {
+    const html = '<div style="padding:8px">Before and after</div>';
+    const result = plugin.normalize(widgetCall(html));
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "tool_use",
+        id: "toolu_w1",
+        name: "mcp__visualize__show_widget",
+        input: { title: "arch_diagram", widget_code: html },
+      },
+    ]);
+  });
+});

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -9,6 +9,7 @@ import type {
   RawRecord,
   ChatRef,
 } from "../types.js";
+import { svgWidgetCode, themeWidgetSvg } from "../visualize-widget.js";
 
 export class ClaudeCodePlugin implements AgentPlugin {
   readonly id = "claude-code";
@@ -122,8 +123,7 @@ export class ClaudeCodePlugin implements AgentPlugin {
     if (Array.isArray(message.content)) {
       const blocks: NormalizedBlock[] = [];
       message.content.forEach((block, index) => {
-        const normalized = normalizeBlock(block, messageId, index);
-        if (normalized) blocks.push(normalized);
+        blocks.push(...normalizeBlock(block, messageId, index));
       });
       const text = blocks
         .filter((b): b is { type: "text"; text: string } => b.type === "text")
@@ -138,7 +138,7 @@ export class ClaudeCodePlugin implements AgentPlugin {
   resolveImage(
     ref: string,
     loadPayload: (messageId: string) => unknown | null
-  ): { mediaType: string; bytes: Buffer } | null {
+  ): { mediaType: string; bytes: Buffer; rendered?: boolean } | null {
     const address = parseImageRef(ref);
     if (!address) return null;
 
@@ -154,7 +154,20 @@ export class ClaudeCodePlugin implements AgentPlugin {
     const block = message.content[address.index] as
       | Record<string, unknown>
       | undefined;
-    if (!block || block.type !== "image") return null;
+    if (!block) return null;
+
+    // A visualize drawing: the "bytes" are the widget's own source, themed on
+    // the way out so its class-based colors resolve outside the harness.
+    const widget = svgWidgetCode(block);
+    if (widget) {
+      return {
+        mediaType: "image/svg+xml",
+        bytes: Buffer.from(themeWidgetSvg(widget), "utf8"),
+        rendered: true,
+      };
+    }
+
+    if (block.type !== "image") return null;
 
     const source = block.source as Record<string, unknown> | undefined;
     if (!source || source.type !== "base64") return null;
@@ -284,7 +297,31 @@ function parseImageRef(
 // `index` is the block's position in the Agent's own content array, not in the
 // normalized output: unrecognized blocks get dropped, so only the raw position
 // survives as a stable address back into the Raw row (see `imageRef`).
+// Usually one block in, one block out — but a visualize widget yields two: the
+// tool row plus the drawing it renders to, which is why this returns a list.
 function normalizeBlock(
+  raw: unknown,
+  messageId: string,
+  index: number
+): NormalizedBlock[] {
+  const one = normalizeOneBlock(raw, messageId, index);
+  if (!one) return [];
+  if (one.type === "tool_use" && svgWidgetCode(raw)) {
+    // The tool row stays alongside the image: the drawing is the point, but the
+    // reader can still expand the row to read the source that produced it.
+    return [
+      one,
+      {
+        type: "image",
+        mediaType: "image/svg+xml",
+        ref: imageRef(messageId, index),
+      },
+    ];
+  }
+  return [one];
+}
+
+function normalizeOneBlock(
   raw: unknown,
   messageId: string,
   index: number

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -79,5 +79,17 @@ export interface AgentPlugin {
   resolveImage?(
     ref: string,
     loadPayload: (messageId: string) => unknown | null
-  ): { mediaType: string; bytes: Buffer } | null;
+  ): {
+    mediaType: string;
+    bytes: Buffer;
+    /**
+     * True when the bytes were rendered here rather than copied out of Raw — a
+     * visualize widget, whose theme and sizing this code injects at request
+     * time. Those bytes are a function of the app's version, not the archive's
+     * content, so they must stay revalidatable: an upgrade that changes the
+     * rendering has to reach browsers that already hold the old one. Absent for
+     * verbatim bytes, which never change and are cached forever.
+     */
+    rendered?: boolean;
+  } | null;
 }

--- a/api/src/plugins/visualize-widget.test.ts
+++ b/api/src/plugins/visualize-widget.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { svgWidgetCode, themeWidgetSvg } from "./visualize-widget.js";
+
+describe("svgWidgetCode", () => {
+  function widgetBlock(widgetCode: unknown) {
+    return {
+      type: "tool_use",
+      id: "toolu_1",
+      name: "mcp__visualize__show_widget",
+      input: { title: "diagram", widget_code: widgetCode },
+    };
+  }
+
+  it("accepts an SVG widget, leading whitespace and all", () => {
+    expect(
+      svgWidgetCode(widgetBlock('\n  <svg viewBox="0 0 680 100"></svg>'))
+    ).toBe('\n  <svg viewBox="0 0 680 100"></svg>');
+  });
+
+  it("rejects an HTML widget, another tool, and a malformed call", () => {
+    expect(svgWidgetCode(widgetBlock("<div>chart</div>"))).toBeNull();
+    expect(svgWidgetCode(widgetBlock(undefined))).toBeNull();
+    expect(
+      svgWidgetCode({ type: "tool_use", id: "t", name: "Read", input: {} })
+    ).toBeNull();
+    expect(svgWidgetCode({ type: "text", text: "<svg>" })).toBeNull();
+  });
+});
+
+describe("themeWidgetSvg", () => {
+  const svg = '<svg viewBox="0 0 680 200"><text class="t">Hi</text></svg>';
+
+  // Visualize SVGs carry no colors of their own — the harness supplies a
+  // stylesheet keyed on class names. Served bare in an <img>, every text and
+  // every node would fall back to SVG's default black.
+  it("defines the text and ramp classes the widget's markup relies on", () => {
+    const themed = themeWidgetSvg(svg);
+
+    expect(themed).toContain("<style>");
+    for (const cls of ["t", "ts", "th"]) {
+      expect(themed).toMatch(new RegExp(`\\.${cls}\\s*[,{]`));
+    }
+    for (const ramp of [
+      "c-gray",
+      "c-blue",
+      "c-red",
+      "c-amber",
+      "c-green",
+      "c-teal",
+      "c-purple",
+      "c-coral",
+      "c-pink",
+    ]) {
+      expect(themed).toContain(`.${ramp}`);
+    }
+  });
+
+  it("injects the stylesheet inside the root element, keeping the markup intact", () => {
+    const themed = themeWidgetSvg(svg);
+
+    expect(themed.indexOf("<style>")).toBeGreaterThan(themed.indexOf("<svg"));
+    expect(themed.indexOf("<style>")).toBeLessThan(themed.indexOf("<text"));
+    expect(themed).toContain('<text class="t">Hi</text>');
+    expect(themed.trimEnd().endsWith("</svg>")).toBe(true);
+  });
+
+  it("leaves a widget alone when it has no root element to inject into", () => {
+    expect(themeWidgetSvg("not markup at all")).toBe("not markup at all");
+  });
+
+  // A visualize SVG declares only a viewBox. Served through `<img>` that leaves
+  // it with no intrinsic size, and `width: auto` collapses the thumbnail to
+  // nothing — it loads fine and renders 2px wide. jsdom does no layout, so only
+  // a check on the served markup can hold this down.
+  it("gives the root an intrinsic size taken from its viewBox", () => {
+    const themed = themeWidgetSvg('<svg viewBox="0 0 780 440"><g/></svg>');
+
+    expect(themed).toMatch(/<svg[^>]*\bwidth="780"/);
+    expect(themed).toMatch(/<svg[^>]*\bheight="440"/);
+  });
+
+  it("keeps a size the widget declared for itself", () => {
+    const themed = themeWidgetSvg(
+      '<svg viewBox="0 0 780 440" width="100" height="50"><g/></svg>'
+    );
+
+    expect(themed).toContain('width="100"');
+    expect(themed).toContain('height="50"');
+    expect(themed).not.toContain('width="780"');
+  });
+
+  // `stroke-width` is a presentation attribute a widget may set on the root. It
+  // is not a size, and mistaking it for one leaves the thumbnail collapsed.
+  it("is not fooled by an attribute merely ending in width", () => {
+    const themed = themeWidgetSvg(
+      '<svg viewBox="0 0 780 440" stroke-width="2"><g/></svg>'
+    );
+
+    expect(themed).toMatch(/<svg[^>]*\swidth="780"/);
+    expect(themed).toMatch(/<svg[^>]*\sheight="440"/);
+  });
+
+  it("leaves the root alone when the viewBox is missing or malformed", () => {
+    expect(themeWidgetSvg("<svg><g/></svg>")).toContain("<svg><style>");
+    expect(themeWidgetSvg('<svg viewBox="nonsense"><g/></svg>')).not.toContain(
+      "width="
+    );
+  });
+});

--- a/api/src/plugins/visualize-widget.ts
+++ b/api/src/plugins/visualize-widget.ts
@@ -1,0 +1,132 @@
+/**
+ * Agent-produced drawings from the `visualize` MCP server.
+ *
+ * The call arrives as an ordinary `tool_use` block whose `widget_code` holds
+ * either an SVG document or an HTML fragment. Only the SVG half becomes an
+ * image: HTML widgets are worth archiving for their interactivity, which would
+ * mean executing archived code, so they stay a collapsed tool row instead.
+ */
+
+/** The tool name every visualize drawing arrives under. */
+export const SHOW_WIDGET_TOOL = "mcp__visualize__show_widget";
+
+/**
+ * The widget's SVG source, or null when this is not an SVG widget call.
+ * Accepts anything shaped like a `tool_use` block so both the normalize path
+ * and the ref-resolution path can ask the same question.
+ */
+export function svgWidgetCode(block: unknown): string | null {
+  if (!block || typeof block !== "object") return null;
+  const b = block as Record<string, unknown>;
+  if (b.type !== "tool_use" || b.name !== SHOW_WIDGET_TOOL) return null;
+
+  const input = b.input as Record<string, unknown> | undefined;
+  const code = input?.widget_code;
+  if (typeof code !== "string") return null;
+
+  // The same test the harness itself uses to pick its render mode.
+  return code.trimStart().startsWith("<svg") ? code : null;
+}
+
+// The nine categorical ramps a widget's `c-{ramp}` classes name, in the three
+// stops dark mode uses: 800 fills the shape, 200 strokes it and carries the
+// subtitle, 100 carries the title. Copied verbatim from the visualize palette
+// rather than remapped onto chat-logbook's own colors — the ramps carry meaning
+// (red is an error, green a success), and recoloring them would rewrite what
+// the drawing says.
+const RAMPS: Record<string, { fill: string; stroke: string; title: string }> = {
+  "c-purple": { fill: "#3C3489", stroke: "#AFA9EC", title: "#CECBF6" },
+  "c-teal": { fill: "#085041", stroke: "#5DCAA5", title: "#9FE1CB" },
+  "c-coral": { fill: "#712B13", stroke: "#F0997B", title: "#F5C4B3" },
+  "c-pink": { fill: "#72243E", stroke: "#ED93B1", title: "#F4C0D1" },
+  "c-gray": { fill: "#444441", stroke: "#B4B2A9", title: "#D3D1C7" },
+  "c-blue": { fill: "#0C447C", stroke: "#85B7EB", title: "#B5D4F4" },
+  "c-green": { fill: "#27500A", stroke: "#97C459", title: "#C0DD97" },
+  "c-amber": { fill: "#633806", stroke: "#EF9F27", title: "#FAC775" },
+  "c-red": { fill: "#791F1F", stroke: "#F09595", title: "#F7C1C1" },
+};
+
+// Text outside any ramp, in chat-logbook's own palette so a bare diagram sits in
+// the conversation rather than on top of it. Literal hex, not `var(--…)`: an SVG
+// served as an image is its own document and never sees the app's stylesheet.
+const TEXT_PRIMARY = "#eee8d5";
+const TEXT_SECONDARY = "#93a1a1";
+const FONT_SANS =
+  "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif";
+
+function widgetStylesheet(): string {
+  const ramps = Object.entries(RAMPS)
+    .map(
+      ([name, c]) =>
+        `.${name}>rect,.${name}>circle,.${name}>ellipse,` +
+        `rect.${name},circle.${name},ellipse.${name}` +
+        `{fill:${c.fill};stroke:${c.stroke};stroke-width:1.5}` +
+        `.${name}>text.t,.${name}>text.th{fill:${c.title}}` +
+        `.${name}>text.ts{fill:${c.stroke}}`
+    )
+    .join("");
+  return (
+    `text{font-family:${FONT_SANS}}` +
+    `.t{font-size:14px;fill:${TEXT_PRIMARY}}` +
+    `.th{font-size:14px;font-weight:500;fill:${TEXT_PRIMARY}}` +
+    `.ts{font-size:12px;fill:${TEXT_SECONDARY}}` +
+    ramps
+  );
+}
+
+/**
+ * The widget's SVG with the harness's class definitions folded in.
+ *
+ * A visualize SVG carries no colors of its own: every `<text>` wears `t`/`ts`/
+ * `th` and every node a `c-{ramp}` class, all defined in a stylesheet the
+ * harness wraps around the drawing. Served on its own, those classes match
+ * nothing and the whole drawing falls back to SVG's default black-on-nothing.
+ *
+ * Returned unchanged when there is no root element to inject into — a broken
+ * widget is better served as its own broken self than mangled.
+ */
+export function themeWidgetSvg(svg: string): string {
+  const root = /<svg\b[^>]*>/.exec(svg);
+  if (!root) return svg;
+
+  const sized = withIntrinsicSize(root[0]);
+  const at = root.index + root[0].length;
+  return (
+    svg.slice(0, root.index) +
+    sized +
+    `<style>${widgetStylesheet()}</style>` +
+    svg.slice(at)
+  );
+}
+
+/**
+ * The opening `<svg>` tag with `width`/`height` filled in from its viewBox.
+ *
+ * A visualize SVG declares only a viewBox, which is enough inside the harness
+ * but not in an `<img>`: with no intrinsic size the browser hands the element a
+ * 300×150 placeholder, and a `width: auto` thumbnail collapses to nothing. The
+ * viewBox already states the drawing's own pixel units, so copying them across
+ * is what the widget meant all along.
+ *
+ * A widget that sized itself keeps its own numbers.
+ */
+function withIntrinsicSize(rootTag: string): string {
+  // Anchored on whitespace, not a word boundary: `stroke-width` ends in "width"
+  // but says nothing about the drawing's size.
+  if (/\s(width|height)\s*=/.test(rootTag)) return rootTag;
+
+  const viewBox = /\bviewBox\s*=\s*"([^"]*)"/.exec(rootTag);
+  if (!viewBox) return rootTag;
+
+  const parts = viewBox[1]
+    .trim()
+    .split(/[\s,]+/)
+    .map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n))) {
+    return rootTag;
+  }
+  const [, , width, height] = parts;
+  if (width <= 0 || height <= 0) return rootTag;
+
+  return `${rootTag.slice(0, -1)} width="${width}" height="${height}">`;
+}

--- a/docs/adr/0023-normalized-block-vocabulary.md
+++ b/docs/adr/0023-normalized-block-vocabulary.md
@@ -25,7 +25,11 @@ type NormalizedBlock =
 - **`system`** — harness noise addressed to the Agent, not written by the user (task-notifications, hook output, …). `kind` is an open string (e.g. `"task-notification"`), so new noise types widen the data, not the type union. `summary` is the one-line collapsed row; `detail` is the full original content, preserved for expansion. Renders as a collapsed system row.
 - **`image`** — metadata only. The bytes stay in the Raw layer (they are already there verbatim); `ref` is an opaque token the image endpoint resolves back to the bytes' location in the message's Raw row. Never inline base64 into Normalized: it would double the Archive's image storage and force the messages API to ship every image up front. Served by `GET /api/chats/:chatId/images/:ref` with immutable cache headers — archived bytes never change.
 
-Two adjacent rules ride on the same contract:
+Three adjacent rules ride on the same contract:
+
+- **Agent-drawn widgets.** A `visualize` MCP call whose `widget_code` is SVG emits an `image` block _in addition to_ its `tool_use` block — the only case where one raw block yields two normalized ones. The `ref` addresses the tool call itself, and the image endpoint serves the widget's SVG source with a theme stylesheet injected, since a visualize SVG carries no colors of its own (its `t`/`ts`/`th` and `c-{ramp}` classes are defined by the harness, not the document). Serving through `<img>` is the security boundary: browsers run no scripts and load no external resources for an SVG in image context. HTML widgets emit no image block — their value is interactivity, and rendering them would mean executing archived code.
+
+  This splits the endpoint's caching in two. Bytes copied verbatim out of Raw are pinned forever (`immutable`) because nothing can change them. Rendered bytes carry an `ETag` and `no-cache` instead: they are a function of the app's version rather than the archive's content, so an upgrade that changes the theme or the sizing has to reach browsers that already hold the old render. Revalidation is one local 304 and no bytes.
 
 - **Inline file mentions.** Agent-private file-mention syntax is translated at normalize time into a standard markdown link with a `file://` URL inside the `text` block. The renderer has exactly one generic rule — `file://` links render as a file chip — and never sees the Agent's syntax.
 - **`NormalizedMessage.model`** — an optional field capturing the model id the Agent recorded on the message (e.g. `claude-opus-4-8`). Absent when the Agent doesn't record one.

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -908,3 +908,39 @@ describe("ConversationView — inline images", () => {
     expect(await screen.findByText("You")).toBeTruthy();
   });
 });
+
+describe("ConversationView — visualize widgets", () => {
+  const widgetCall = {
+    type: "tool_use" as const,
+    id: "toolu_w1",
+    name: "mcp__visualize__show_widget",
+    input: { title: "arch_diagram", widget_code: "<svg />" },
+  };
+
+  it("draws the widget beside its tool row, named as a drawing not a screenshot", async () => {
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-wid",
+            role: "assistant",
+            content: [
+              widgetCall,
+              { type: "image", mediaType: "image/svg+xml", ref: "m-wid.0" },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    const img = await screen.findByRole("img");
+    expect(img.getAttribute("src")).toBe("/api/chats/c1/images/m-wid.0");
+    // "Pasted image" would be a lie: nobody pasted this, the agent drew it.
+    expect(img.getAttribute("alt")).toBe("Diagram");
+    // The source stays reachable — the drawing is the point, but the reader can
+    // still open the row that produced it.
+    expect(screen.getByText(/show_widget/)).toBeTruthy();
+  });
+});

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -180,7 +180,14 @@ function renderContentBlock(
         <SystemRow key={index} summary={block.summary} detail={block.detail} />
       );
     case "image":
-      return <InlineImage key={index} chatId={chatId} imageRef={block.ref} />;
+      return (
+        <InlineImage
+          key={index}
+          chatId={chatId}
+          imageRef={block.ref}
+          mediaType={block.mediaType}
+        />
+      );
   }
 }
 

--- a/web/src/conversation/InlineImage.tsx
+++ b/web/src/conversation/InlineImage.tsx
@@ -6,29 +6,48 @@ interface InlineImageProps {
   chatId: string;
   /** The plugin's opaque address for these bytes inside the Raw layer. */
   imageRef: string;
+  /** The block's media type, which is all that tells a drawing from a photo. */
+  mediaType: string;
 }
 
 /**
- * The URL the image bytes come from. Archived bytes never change, so the
- * response is cached forever and a thumbnail already scrolled past costs
- * nothing to show again — including at full size in the lightbox.
+ * What to call this image where a reader hears it rather than sees it.
+ *
+ * SVG only reaches the archive as an agent-drawn widget — a diagram or a chart
+ * — while every other type got here because someone pasted it.
  */
-export function inlineImageSrc(chatId: string, imageRef: string): string {
+function imageLabel(mediaType: string): string {
+  return mediaType === "image/svg+xml" ? "Diagram" : "Pasted image";
+}
+
+/**
+ * The URL the image bytes come from. The endpoint caches aggressively — forever
+ * for a pasted screenshot, revalidated for a drawing the app renders — so a
+ * thumbnail already scrolled past costs little to show again, including at full
+ * size in the lightbox.
+ */
+function inlineImageSrc(chatId: string, imageRef: string): string {
   return `/api/chats/${chatId}/images/${imageRef}`;
 }
 
 /**
- * A pasted screenshot, in place in the conversation.
+ * An image in place in the conversation — a pasted screenshot, or a diagram the
+ * agent drew.
  *
  * Held to a thumbnail height so an image never shoves the surrounding prose off
  * screen, and loaded only once scrolled into view — a chat can hold dozens, and
  * the messages payload deliberately carries none of their bytes (ADR-0023).
  * Clicking opens it at full size; the lightbox reuses the same URL, so the
  * bytes are already in the browser's cache.
+ *
+ * A widget's bytes are rendered per request rather than stored, so its URL
+ * revalidates instead of being pinned — an upgrade that redraws it reaches a
+ * reader who already viewed the old one.
  */
-export function InlineImage({ chatId, imageRef }: InlineImageProps) {
+export function InlineImage({ chatId, imageRef, mediaType }: InlineImageProps) {
   const [open, setOpen] = useState(false);
   const src = inlineImageSrc(chatId, imageRef);
+  const label = imageLabel(mediaType);
 
   return (
     <>
@@ -40,7 +59,7 @@ export function InlineImage({ chatId, imageRef }: InlineImageProps) {
       >
         <img
           src={src}
-          alt="Pasted image"
+          alt={label}
           loading="lazy"
           className="my-2 max-h-60 w-auto max-w-full rounded-md border border-border object-contain"
         />
@@ -49,10 +68,10 @@ export function InlineImage({ chatId, imageRef }: InlineImageProps) {
         {/* Nearly the whole viewport: the point of opening it is to read what
             the thumbnail was too small for. */}
         <DialogContent className="w-auto max-w-[calc(100vw-4rem)] bg-transparent p-0 shadow-none ring-0">
-          <DialogTitle className="sr-only">Pasted image</DialogTitle>
+          <DialogTitle className="sr-only">{label}</DialogTitle>
           <img
             src={src}
-            alt="Pasted image"
+            alt={label}
             className="max-h-[calc(100vh-4rem)] max-w-full rounded-md object-contain"
           />
         </DialogContent>


### PR DESCRIPTION
## Background (Why)

Agent-produced drawings from the `visualize` MCP server were recorded faithfully — the SVG source sits in Raw — but the pane showed only a collapsed `mcp__visualize__show_widget` tool row. Dependency graphs, charts, and diagrams were archived and invisible.

## Approach (How)

Normalize emits an `image` block *beside* the widget's `tool_use` block when `widget_code` is SVG, riding the inline-image pipeline from #196 end to end: lazy thumbnail, lightbox, and survival after the Source file is deleted. This is the only case where one raw block yields two normalized ones — the drawing is the point, but the row stays so the reader can still open the source that produced it.

Two things had to be true for the served bytes to actually render:

**Theming.** A visualize SVG carries no colors of its own. Every `<text>` wears `t`/`ts`/`th` and every node a `c-{ramp}` class, all defined by a stylesheet the harness wraps around the drawing. Served bare, those classes match nothing and the whole diagram falls back to SVG's default black. The endpoint injects a stylesheet defining them. The nine ramps are copied verbatim from the visualize palette rather than remapped onto chat-logbook's colors: the ramps carry meaning (red is an error, green a success), so recoloring them would rewrite what the drawing says. Only text outside a ramp uses the app's own palette.

**Sizing.** A visualize SVG declares only a `viewBox`. In an `<img>` that leaves it with no intrinsic size, and a `width: auto` thumbnail collapses — it loads fine and renders 2px wide. The endpoint copies the viewBox's dimensions onto the root.

Serving through `<img>` is the security boundary: browsers run no scripts and load no external resources for an SVG in image context. HTML widgets emit no image block at all — their value is interactivity, and rendering them would mean executing archived code, which sits badly against the local-only guarantee. They stay a tool row where the source is still readable.

## Changes (What)

- [x] `visualize-widget.ts` (new): discriminates SVG from HTML widgets, injects the theme stylesheet and the viewBox-derived size
- [x] Normalize emits `image` beside `tool_use` for SVG widgets; `normalizeBlock` returns a list to allow it
- [x] `resolveImage` resolves a widget ref back to its themed SVG source
- [x] The image endpoint splits its caching: verbatim bytes stay `immutable`, rendered bytes get an `ETag` and `no-cache`
- [x] `NORMALIZE_VERSION` 4 → 5, so archived chats gain their drawings on next boot
- [x] `InlineImage` names an SVG "Diagram" rather than "Pasted image"
- [x] ADR-0023 records the two-blocks-from-one rule and the caching split

### Test Verification

- [x] SVG `widget_code` normalizes to `tool_use` + `image`; HTML normalizes to `tool_use` alone
- [x] A widget ref resolves to that widget's SVG source; an HTML widget's ref 404s
- [x] Served SVG defines `t`/`ts`/`th` and all nine `c-{ramp}` classes, injected inside the root element
- [x] `width`/`height` derive from the viewBox; a self-sized widget keeps its own numbers; `stroke-width` is not mistaken for a size; a missing or malformed viewBox is left alone
- [x] Script inside `widget_code` is served intact (the archive is a faithful record) under CSP `default-src 'none'; sandbox` and `nosniff`
- [x] A rendered widget answers `no-cache` + `ETag` and 304s on revalidation, while a pasted screenshot stays `immutable`
- [x] Re-normalize surfaces widget images in already-archived chats
- [x] The pane renders the image block as a thumbnail beside its tool row, labelled "Diagram"
- [x] Full suite green: 717 tests, plus typecheck and build

## Additional Notes

**Dark mode only.** The injected stylesheet assumes the app's solarized dark theme, which is the only theme today. A future light mode has to reach this file.

**Two bugs found by driving the real browser, not by tests.** The 2×2 collapse passed every component test — jsdom does no layout, so `naturalWidth` and `getBoundingClientRect()` are always zero and "renders but invisible" is indistinguishable from "renders". Then the fix appeared not to work, because `immutable` had pinned the broken render in the browser for a year; the correct bytes were being served and never requested. That second one is why the caching split is in this PR rather than left for later — it is a real upgrade hazard for any content rendered from app code rather than copied from the archive.

## Related Links

- Closes #230