### PR TITLE
feat(web): copy a message or a code block from the conversation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       "@testing-library/user-event":
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      "@types/hast":
+        specifier: ^3.0.5
+        version: 3.0.5
       "@types/node":
         specifier: ^24.12.0
         version: 24.12.0
@@ -2375,10 +2378,10 @@ packages:
         integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
       }
 
-  "@types/hast@3.0.4":
+  "@types/hast@3.0.5":
     resolution:
       {
-        integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==,
+        integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==,
       }
 
   "@types/json-schema@7.0.15":
@@ -8818,7 +8821,7 @@ snapshots:
 
   "@types/estree@1.0.8": {}
 
-  "@types/hast@3.0.4":
+  "@types/hast@3.0.5":
     dependencies:
       "@types/unist": 3.0.3
 
@@ -9956,12 +9959,12 @@ snapshots:
 
   hast-util-is-element@3.0.0:
     dependencies:
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       "@types/estree": 1.0.8
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       "@types/unist": 3.0.3
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
@@ -9980,14 +9983,14 @@ snapshots:
 
   hast-util-to-text@4.0.2:
     dependencies:
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       "@types/unist": 3.0.3
       hast-util-is-element: 3.0.0
       unist-util-find-after: 5.0.0
 
   hast-util-whitespace@3.0.0:
     dependencies:
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
 
   headers-polyfill@4.0.3: {}
 
@@ -10339,7 +10342,7 @@ snapshots:
 
   lowlight@3.3.0:
     dependencies:
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       devlop: 1.1.0
       highlight.js: 11.11.1
 
@@ -10447,7 +10450,7 @@ snapshots:
   mdast-util-mdx-expression@2.0.1:
     dependencies:
       "@types/estree-jsx": 1.0.5
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       "@types/mdast": 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
@@ -10458,7 +10461,7 @@ snapshots:
   mdast-util-mdx-jsx@3.2.0:
     dependencies:
       "@types/estree-jsx": 1.0.5
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       "@types/mdast": 4.0.4
       "@types/unist": 3.0.3
       ccount: 2.0.1
@@ -10475,7 +10478,7 @@ snapshots:
   mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       "@types/estree-jsx": 1.0.5
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       "@types/mdast": 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
@@ -10495,7 +10498,7 @@ snapshots:
 
   mdast-util-to-hast@13.2.1:
     dependencies:
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       "@types/mdast": 4.0.4
       "@ungap/structured-clone": 1.3.0
       devlop: 1.1.0
@@ -11149,7 +11152,7 @@ snapshots:
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
     dependencies:
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       "@types/mdast": 4.0.4
       "@types/react": 19.2.14
       devlop: 1.1.0
@@ -11213,7 +11216,7 @@ snapshots:
 
   rehype-highlight@7.0.2:
     dependencies:
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       hast-util-to-text: 4.0.2
       lowlight: 3.3.0
       unist-util-visit: 5.1.0
@@ -11247,7 +11250,7 @@ snapshots:
 
   remark-rehype@11.1.2:
     dependencies:
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       "@types/mdast": 4.0.4
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5

--- a/web/e2e/copy-buttons.spec.ts
+++ b/web/e2e/copy-buttons.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "@playwright/test";
+
+const CODE = "const answer = 42;\nreturn answer;";
+
+async function openChatWithCode(page: import("@playwright/test").Page) {
+  // Benign empty SSE stream so the live-update EventSource connects cleanly.
+  await page.route(/\/api\/chats\/stream(\?|$)/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: ":ok\n\n",
+    })
+  );
+  await page.route(/\/api\/chats\/counts(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1, projects: [], tags: [], untagged: 1 } })
+  );
+  await page.route(/\/api\/chats\/list-total(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1 } })
+  );
+  await page.route(/\/api\/chats(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        chats: [
+          {
+            id: "clog_copy1",
+            sourceId: "copy-chat",
+            agent: "claude-code",
+            title: "Copyable conversation",
+            project: "/test/project",
+            sourceFilePath: null,
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      },
+    })
+  );
+  await page.route(/\/api\/chats\/clog_copy1(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: `Here you go:\n\n\`\`\`ts\n${CODE}\n\`\`\``,
+              },
+            ],
+            timestamp: "2023-11-14T22:13:20.000Z",
+          },
+        ],
+      },
+    })
+  );
+
+  await page.goto("/");
+  await page.getByText("Copyable conversation").click();
+}
+
+test.describe("Copy affordances", () => {
+  test.use({ permissions: ["clipboard-read", "clipboard-write"] });
+
+  test("reveals both copy buttons on hover, each with a real box", async ({
+    page,
+  }) => {
+    await openChatWithCode(page);
+
+    const messageCopy = page.getByRole("button", { name: "Copy message" });
+    const codeCopy = page.getByRole("button", { name: "Copy code" });
+
+    // Hidden until the reader reaches for them: present in the tree, but not
+    // painted. A component test cannot see this — jsdom computes no opacity.
+    await expect(messageCopy).toHaveCSS("opacity", "0");
+    await expect(codeCopy).toHaveCSS("opacity", "0");
+
+    await page.getByText("Here you go:").hover();
+    await expect(messageCopy).toHaveCSS("opacity", "1");
+
+    // A button can be "visible" to a query while rendering as a collapsed box.
+    const box = await messageCopy.boundingBox();
+    expect(box?.width).toBeGreaterThan(12);
+    expect(box?.height).toBeGreaterThan(12);
+  });
+
+  test("takes the code away exactly as written", async ({ page }) => {
+    await openChatWithCode(page);
+
+    await page
+      .getByRole("button", { name: "Copy code" })
+      .click({ force: true });
+
+    await expect(page.getByRole("button", { name: "Copied" })).toBeVisible();
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toBe(CODE);
+  });
+});

--- a/web/package.json
+++ b/web/package.json
@@ -40,6 +40,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/hast": "^3.0.5",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConversationView } from "@/conversation/ConversationView";
 import { messageAnchorId } from "@/conversation/messageAnchor";
 import type { Chat, Message } from "@/types";
@@ -942,5 +942,89 @@ describe("ConversationView — visualize widgets", () => {
     // The source stays reachable — the drawing is the point, but the reader can
     // still open the row that produced it.
     expect(screen.getByText(/show_widget/)).toBeTruthy();
+  });
+});
+
+describe("copying a whole message", () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    writeText.mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  it("copies the message's prose, leaving the tool traffic behind", async () => {
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-copy",
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "considering" },
+              { type: "text", text: "Here is the answer." },
+              { type: "tool_use", id: "t1", name: "Read", input: {} },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Copy message" })
+    );
+
+    expect(writeText).toHaveBeenCalledWith("Here is the answer.");
+  });
+});
+
+describe("messages with nothing to take away", () => {
+  it("offers no copy button on a turn that is only a tool call", async () => {
+    // The turn renders — a collapsed tool row is worth seeing — but there is no
+    // prose in it, so a copy button could only ever hand back nothing.
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-tool-only",
+            role: "assistant",
+            content: [{ type: "tool_use", id: "t1", name: "Read", input: {} }],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    expect(await screen.findByText(/Read/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Copy message" })).toBeNull();
+  });
+
+  it("still offers it when prose sits alongside the tool call", async () => {
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-mixed",
+            role: "assistant",
+            content: [
+              { type: "text", text: "Reading the file." },
+              { type: "tool_use", id: "t2", name: "Read", input: {} },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Copy message" })
+    ).toBeTruthy();
   });
 });

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -17,6 +17,8 @@ import {
 } from "@/conversation/scrollPillVisibility";
 import { formatMessageTimestamp } from "@/conversation/formatMessageTimestamp";
 import { messageAnchorId } from "@/conversation/messageAnchor";
+import { messageToMarkdown } from "@/conversation/messageToMarkdown";
+import { CopyButton } from "@/shared/CopyButton";
 import { deriveArrivalAction } from "@/conversation/liveArrival";
 import { deriveFirstUnseenIndex } from "@/conversation/firstUnseenIndex";
 import {
@@ -224,6 +226,7 @@ function MessageItem({
   /** Owning chat, so an image block can address its own bytes. */
   chatId: string;
 }) {
+  const copyValue = messageToMarkdown(message);
   return (
     <div
       id={messageAnchorId(message.id)}
@@ -232,12 +235,24 @@ function MessageItem({
       // only the reader's own turns take a background block, as scanning
       // anchors. Both roles keep the same horizontal padding so their text
       // aligns down a single edge (#192).
-      className={`w-full px-4 py-3 text-sm leading-relaxed ${
+      className={`group relative w-full px-4 py-3 text-sm leading-relaxed ${
         message.role === "user"
           ? "rounded-md bg-card text-accent-foreground"
           : "text-foreground"
       }`}
     >
+      {/* Recall usually ends in taking the turn away with you (#198). A turn
+          worth showing is not always a turn worth copying: one that is only a
+          tool call, a thought or an image renders as something to look at, but
+          holds no prose, and a button that hands back nothing is worse than no
+          button at all. */}
+      {copyValue && (
+        <CopyButton
+          value={copyValue}
+          label="Copy message"
+          className="absolute right-2 top-2 z-10"
+        />
+      )}
       {hasAuthorHeader(message) && (
         // Set as a name, not a label: the old all-caps role tag belonged to the
         // bubble layout, and an agent's display name is written "Claude Code".

--- a/web/src/conversation/MarkdownText.test.tsx
+++ b/web/src/conversation/MarkdownText.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MarkdownText } from "@/conversation/MarkdownText";
 
 describe("MarkdownText line breaks", () => {
@@ -35,5 +36,36 @@ describe("MarkdownText line breaks", () => {
     expect(container.querySelector("li br")).toBeNull();
     expect(screen.getByText("bold").tagName).toBe("STRONG");
     expect(screen.getByText("code").tagName).toBe("CODE");
+  });
+});
+
+describe("MarkdownText code block copying", () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    writeText.mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  it("copies a code block's source, without the highlighting markup", async () => {
+    // Highlighting wraps keywords in spans; what the reader takes away has to
+    // be the code they could paste back into a file.
+    render(
+      <MarkdownText>{"```ts\nconst x = 1;\nreturn x;\n```"}</MarkdownText>
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy code" }));
+
+    expect(writeText).toHaveBeenCalledWith("const x = 1;\nreturn x;");
+  });
+
+  it("offers no copy button for inline code", () => {
+    // Inline code is a word inside a sentence, not something to take away.
+    render(<MarkdownText>{"use the `id` field"}</MarkdownText>);
+
+    expect(screen.queryByRole("button", { name: "Copy code" })).toBeNull();
   });
 });

--- a/web/src/conversation/MarkdownText.tsx
+++ b/web/src/conversation/MarkdownText.tsx
@@ -1,7 +1,25 @@
 import Markdown, { type Components } from "react-markdown";
+import type { Element, ElementContent } from "hast";
 import rehypeHighlight from "rehype-highlight";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
+import { CopyButton } from "@/shared/CopyButton";
+
+// The code as written, read off the syntax tree rather than the rendered
+// output: highlighting has already wrapped keywords in spans by the time this
+// renders, and what the reader takes away has to paste back into a file.
+function nodeText(node: ElementContent): string {
+  if (node.type === "text") return node.value;
+  if (node.type === "element") return node.children.map(nodeText).join("");
+  return "";
+}
+
+// The closing fence leaves one trailing newline: markdown's punctuation, not
+// part of the code.
+function codeSource(node: Element | undefined): string {
+  if (!node) return "";
+  return node.children.map(nodeText).join("").replace(/\n$/, "");
+}
 
 const markdownComponents: Components = {
   a: ({ children, ...props }) => (
@@ -12,6 +30,19 @@ const markdownComponents: Components = {
   table: ({ children, ...props }) => (
     <div className="overflow-x-auto">
       <table {...props}>{children}</table>
+    </div>
+  ),
+  // Only fenced blocks get a copy button — inline code is a word inside a
+  // sentence, not something to take away. `group` scopes the hover reveal to
+  // this block, so one button appears at a time.
+  pre: ({ children, node, ...props }) => (
+    <div className="group relative">
+      <pre {...props}>{children}</pre>
+      <CopyButton
+        value={codeSource(node)}
+        label="Copy code"
+        className="absolute right-2 top-2 bg-[#002b36]/80"
+      />
     </div>
   ),
 };

--- a/web/src/conversation/messageToMarkdown.test.ts
+++ b/web/src/conversation/messageToMarkdown.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { ContentBlock, Message } from "@/types";
+import { messageToMarkdown } from "@/conversation/messageToMarkdown";
+
+function message(content: string | ContentBlock[]): Message {
+  return { id: "m1", role: "assistant", content, timestamp: "2026-07-21" };
+}
+
+describe("messageToMarkdown", () => {
+  it("returns the text of a message whose content is a plain string", () => {
+    expect(messageToMarkdown(message("hello **there**"))).toBe(
+      "hello **there**"
+    );
+  });
+
+  it("joins several text blocks with a blank line", () => {
+    // A blank line is markdown's paragraph break, so pasted text keeps the
+    // separation the reader saw on screen rather than running together.
+    const md = messageToMarkdown(
+      message([
+        { type: "text", text: "first para" },
+        { type: "text", text: "second para" },
+      ])
+    );
+
+    expect(md).toBe("first para\n\nsecond para");
+  });
+
+  it("drops the blocks that are not the message's content", () => {
+    // Reasoning, tool traffic, harness noise and image metadata are collapsed
+    // or lazily addressed on screen precisely because they are not what the
+    // reader came to take away.
+    const md = messageToMarkdown(
+      message([
+        { type: "thinking", thinking: "let me consider" },
+        { type: "text", text: "the answer" },
+        { type: "tool_use", id: "t1", name: "Read", input: {} },
+        { type: "tool_result", tool_use_id: "t1", content: "file body" },
+        {
+          type: "system",
+          kind: "task-notification",
+          summary: "s",
+          detail: "d",
+        },
+        { type: "image", mediaType: "image/png", ref: "r1" },
+      ])
+    );
+
+    expect(md).toBe("the answer");
+  });
+
+  it("writes a command invocation back as the reader typed it", () => {
+    // A slash command renders as a chip, but it is something a person typed —
+    // content, not noise — so it comes back in its written form.
+    const md = messageToMarkdown(
+      message([
+        { type: "command", name: "/tdd", args: "issue 198" },
+        { type: "text", text: "go" },
+      ])
+    );
+
+    expect(md).toBe("/tdd issue 198\n\ngo");
+  });
+
+  it("leaves no trailing space on a command with no arguments", () => {
+    const md = messageToMarkdown(
+      message([{ type: "command", name: "/clear", args: "" }])
+    );
+
+    expect(md).toBe("/clear");
+  });
+});

--- a/web/src/conversation/messageToMarkdown.ts
+++ b/web/src/conversation/messageToMarkdown.ts
@@ -1,0 +1,28 @@
+import type { ContentBlock, Message } from "@/types";
+
+// What survives a copy: the blocks a person wrote. Reasoning, tool traffic,
+// harness noise and image metadata are collapsed or lazily addressed on screen
+// precisely because they are not what the reader came to take away.
+function blockToMarkdown(block: ContentBlock): string | null {
+  switch (block.type) {
+    case "text":
+      return block.text;
+    case "command":
+      return block.args ? `${block.name} ${block.args}` : block.name;
+    default:
+      return null;
+  }
+}
+
+/**
+ * The markdown a reader takes away when they copy a Message. Blocks are joined
+ * by a blank line — markdown's paragraph break — so pasted text keeps the
+ * separation the reader saw on screen.
+ */
+export function messageToMarkdown(message: Message): string {
+  if (typeof message.content === "string") return message.content;
+  return message.content
+    .map(blockToMarkdown)
+    .filter((part) => part !== null)
+    .join("\n\n");
+}

--- a/web/src/shared/CopyButton.test.tsx
+++ b/web/src/shared/CopyButton.test.tsx
@@ -1,0 +1,43 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CopyButton } from "@/shared/CopyButton";
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  writeText.mockClear();
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+});
+
+describe("CopyButton", () => {
+  it("puts its value on the clipboard when clicked", async () => {
+    render(<CopyButton value="const x = 1;" label="Copy code" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy code" }));
+
+    expect(writeText).toHaveBeenCalledWith("const x = 1;");
+  });
+
+  it("confirms the copy, then settles back to offering it again", async () => {
+    vi.useFakeTimers();
+    render(<CopyButton value="anything" label="Copy code" />);
+
+    // fireEvent, not userEvent: userEvent awaits its own internal delays, which
+    // never resolve while the clock is frozen.
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(
+      screen.getByRole("button", { name: "Copy code" })
+    ).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+});

--- a/web/src/shared/CopyButton.tsx
+++ b/web/src/shared/CopyButton.tsx
@@ -1,0 +1,54 @@
+import { Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+interface CopyButtonProps {
+  /** The exact text placed on the clipboard. */
+  value: string;
+  /** Names the action for screen readers. Becomes "Copied" while confirming. */
+  label: string;
+  /** Extra positioning for the surface this button sits on. */
+  className?: string;
+}
+
+const COPIED_FEEDBACK_MS = 1500;
+
+/**
+ * A quiet copy affordance: takes `value` away on click, then confirms for a
+ * beat before offering itself again. The confirmation rides on the button's own
+ * accessible name, so a screen reader hears the result of the act it just took
+ * rather than a separate region it has to go find.
+ */
+export function CopyButton({ value, label, className = "" }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<number | undefined>(undefined);
+
+  useEffect(() => () => window.clearTimeout(timer.current), []);
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(value);
+    setCopied(true);
+    window.clearTimeout(timer.current);
+    timer.current = window.setTimeout(
+      () => setCopied(false),
+      COPIED_FEEDBACK_MS
+    );
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={copied ? "Copied" : label}
+      onClick={handleCopy}
+      // Quiet action per ADR-0024: card-foreground at rest, brightening on
+      // hover. Hidden until the surface is hovered, but always focusable, so
+      // the keyboard reaches it without a pointer.
+      className={`flex h-6 w-6 items-center justify-center rounded text-card-foreground opacity-0 transition-opacity hover:bg-white/[0.04] hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 ${className}`}
+    >
+      {copied ? (
+        <Check size={13} aria-hidden="true" className="text-chart-5" />
+      ) : (
+        <Copy size={13} aria-hidden="true" />
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Background (Why)

Recall usually ends in taking something away. You find the turn you were looking for, and then you want it out of the app — into a file, a message, a note. Until now the only way was to select it by hand, which on a code block means dragging across a scrolling box and hoping you caught the last line.

## Approach (How)

Two seams, one shared button.

**What a message copies** lives in a pure function, `messageToMarkdown`. Per ADR-0023 a message holds seven kinds of block; only two are things a person wrote — `text` and `command`. Reasoning, tool traffic, harness noise and image metadata are collapsed or lazily addressed on screen precisely because they are not the content, so they do not survive a copy. Keeping this as a pure function means the rule is testable without a DOM and lives in exactly one place.

**What a code block copies** is read off the hast syntax tree in `MarkdownText`'s `pre` override, not off the rendered output. By render time `rehype-highlight` has wrapped keywords in spans; walking the tree gives back the source as written. The closing fence's trailing newline is dropped as markdown punctuation.

**The button itself** is one component, `CopyButton`, holding the clipboard write, the confirmation, and the timer cleanup. The confirmation rides on the button's own accessible name (`Copy code` → `Copied`) rather than a separate live region, so a screen reader hears the result of the act it just took. Quiet action colors per ADR-0024.

A turn that renders but holds no prose — one that is only a tool call, a thought, or an image — gets no button at all. A button that hands back nothing is worse than no button.

## Changes (What)

- [x] `messageToMarkdown` — new pure function deciding what a copied message contains
- [x] `CopyButton` — new shared component: clipboard write, `Copied` confirmation, timer cleanup, hover reveal that stays keyboard-reachable
- [x] `MarkdownText` — `pre` override adds a corner copy button to fenced blocks only; inline code is left alone
- [x] `ConversationView` — `MessageItem` carries a copy button, suppressed when there is nothing to take away
- [x] `@types/hast` added as a devDependency (needed to type the syntax-tree walk)

### Test Verification

- [x] `messageToMarkdown`: string content passes through; multiple text blocks join with a blank line; thinking / tool_use / tool_result / system / image blocks are dropped; a command block round-trips as `/name args`; a command with no args leaves no trailing space
- [x] `CopyButton`: click writes the value to the clipboard; `Copied` appears and then clears
- [x] `MarkdownText`: a fenced block copies its source without highlighting markup or the fence's trailing newline; inline code offers no button
- [x] `ConversationView`: a message copies its prose and leaves tool traffic behind; a turn that is only a tool call offers no button; a turn with prose alongside a tool call still does
- [x] Playwright: both buttons sit at `opacity: 0` until hover, reach `opacity: 1` on hover, measure larger than 12×12, and the clipboard receives the code verbatim
- [x] Full suite green: api 374, web 355, plus 2 e2e. `typecheck`, `lint` and `build` pass

## Additional Notes

- Hover reveal itself is CSS. The buttons stay in the DOM and remain focusable rather than being conditionally mounted, which is better for keyboard users and is what makes the behaviour testable at all.

## Related Links

- Closes #198