### PR TITLE
feat: render @-mentioned files as inline chips

### DIFF
--- a/api/src/ingestion/renormalize.ts
+++ b/api/src/ingestion/renormalize.ts
@@ -73,8 +73,10 @@ export function renormalizeFromRaw({
  * #196 adds the `image` block, making pasted screenshots visible in chats that
  * dropped them at ingest: version 4. #230 draws SVG visualize widgets as images
  * too, so archived diagrams stop hiding behind a collapsed tool row: version 5.
+ * #197 translates `@` file mentions into `file://` links, turning them into
+ * chips in chats archived before the rule existed: version 6.
  */
-export const NORMALIZE_VERSION = 5;
+export const NORMALIZE_VERSION = 6;
 
 export interface RunRenormalizeIfStaleOptions {
   plugins: readonly AgentPlugin[];

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -675,3 +675,213 @@ describe("ClaudeCodePlugin.normalize → visualize widgets", () => {
     ]);
   });
 });
+
+describe("ClaudeCodePlugin.normalize → file mentions", () => {
+  function userText(content: string, cwd?: string) {
+    return rawRecord({
+      type: "user",
+      message: { role: "user", content },
+      uuid: "msg-mention",
+      timestamp: "2024-01-01T00:00:06Z",
+      sessionId: "session-1",
+      ...(cwd ? { cwd } : {}),
+    });
+  }
+
+  it("translates a bare absolute mention into a file:// markdown link", () => {
+    const result = plugin.normalize(
+      userText("Read @/Users/eva/notes/plan.md before you start")
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "text",
+        text:
+          "Read [/Users/eva/notes/plan.md](file:///Users/eva/notes/plan.md) " +
+          "before you start",
+      },
+    ]);
+  });
+
+  it("translates a quoted mention so a path with spaces stays one link", () => {
+    const result = plugin.normalize(
+      userText('Check @"/Users/eva/My Notes/plan a.md" first')
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "text",
+        text:
+          "Check [/Users/eva/My Notes/plan a.md]" +
+          "(file:///Users/eva/My%20Notes/plan%20a.md) first",
+      },
+    ]);
+  });
+
+  // `@` is overwhelmingly not a file mention in a developer log: npm scopes,
+  // import aliases, CSS at-rules and handles all share the sigil. Requiring a
+  // file extension (or a trailing slash for a directory) is what separates them.
+  it.each([
+    ["an npm scope", "we depend on @tanstack/react-virtual here"],
+    ["an import alias", "import { Chat } from @/types"],
+    ["a CSS at-rule", "the @apply directive"],
+    ["an email address", "mail eva@example.com about it"],
+    ["a bare handle", "ask @evaaaaawu about it"],
+  ])("leaves %s untouched", (_label, content) => {
+    const result = plugin.normalize(userText(content));
+
+    expect(result?.blocks).toEqual([{ type: "text", text: content }]);
+  });
+
+  it("leaves a mention inside a fenced code block as written", () => {
+    const content = [
+      "run this:",
+      "```sh",
+      "grep @docs/PLAN.md",
+      "```",
+      "then @docs/PLAN.md",
+    ].join("\n");
+
+    const result = plugin.normalize(userText(content));
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "text",
+        text: [
+          "run this:",
+          "```sh",
+          "grep @docs/PLAN.md",
+          "```",
+          "then [docs/PLAN.md](file://docs/PLAN.md)",
+        ].join("\n"),
+      },
+    ]);
+  });
+
+  it("leaves a mention inside inline code as written", () => {
+    const result = plugin.normalize(
+      userText("type `@docs/PLAN.md` to attach @docs/PLAN.md")
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "text",
+        text:
+          "type `@docs/PLAN.md` to attach " +
+          "[docs/PLAN.md](file://docs/PLAN.md)",
+      },
+    ]);
+  });
+
+  it("resolves a relative mention against the message's cwd", () => {
+    const result = plugin.normalize(
+      userText("Read @docs/PLAN.md", "/Users/eva/proj")
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "text",
+        text: "Read [docs/PLAN.md](file:///Users/eva/proj/docs/PLAN.md)",
+      },
+    ]);
+  });
+
+  // `~` is the reader's shorthand, not a path the plugin can expand — normalize
+  // runs without the session's home directory, and guessing one would point the
+  // link at the wrong machine's user.
+  it("leaves a ~ mention unexpanded", () => {
+    const result = plugin.normalize(
+      userText("Read @~/ai-config/MEMORY.md", "/Users/eva/proj")
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "text",
+        text: "Read [~/ai-config/MEMORY.md](file://~/ai-config/MEMORY.md)",
+      },
+    ]);
+  });
+
+  it("translates mentions in a text block of an array-form message", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Read @docs/PLAN.md" }],
+        },
+        uuid: "msg-mention-array",
+        timestamp: "2024-01-01T00:00:07Z",
+        sessionId: "session-1",
+        cwd: "/Users/eva/proj",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "text",
+        text: "Read [docs/PLAN.md](file:///Users/eva/proj/docs/PLAN.md)",
+      },
+    ]);
+  });
+
+  // `text` is the FTS source and the fallback chat title (`deriveTitle`), so it
+  // holds the path as prose — never the markdown the blocks render from. The
+  // `command` block splits the same way: a clean line in `text`, markup in the
+  // block.
+  it("keeps the searchable text free of markdown syntax", () => {
+    const result = plugin.normalize(
+      userText("Read @docs/PLAN.md", "/Users/eva/proj")
+    );
+
+    expect(result?.text).toBe("Read docs/PLAN.md");
+  });
+
+  it("drops the quotes from a quoted mention in the searchable text", () => {
+    const result = plugin.normalize(
+      userText('Check @"/Users/eva/My Notes/plan a.md" first')
+    );
+
+    expect(result?.text).toBe("Check /Users/eva/My Notes/plan a.md first");
+  });
+
+  it("keeps the searchable text of an array-form message free of markdown", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Read @docs/PLAN.md" }],
+        },
+        uuid: "msg-mention-array-text",
+        timestamp: "2024-01-01T00:00:08Z",
+        sessionId: "session-1",
+        cwd: "/Users/eva/proj",
+      })
+    );
+
+    expect(result?.text).toBe("Read docs/PLAN.md");
+  });
+
+  // A dotfile is named entirely by its leading dot — `.env`, `.gitignore` — so
+  // the extension rule alone would drop the mentions people make most often
+  // when talking about config.
+  it.each([
+    ["a dotfile", "check @.env for the key", ".env"],
+    [
+      "a dot-directory file",
+      "see @.github/workflows/ci.yml",
+      ".github/workflows/ci.yml",
+    ],
+  ])("chips %s", (_label, content, mentioned) => {
+    const result = plugin.normalize(userText(content));
+
+    expect(result?.blocks[0]).toMatchObject({
+      type: "text",
+      text: content.replace(
+        `@${mentioned}`,
+        `[${mentioned}](file://${mentioned})`
+      ),
+    });
+  });
+});

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -81,6 +81,9 @@ export class ClaudeCodePlugin implements AgentPlugin {
         ? { model: message.model }
         : {};
 
+    // The directory the turn ran in, used to resolve relative file mentions.
+    const cwd = typeof payload.cwd === "string" ? payload.cwd : undefined;
+
     if (typeof message.content === "string") {
       const command = parseCommandMarkup(message.content);
       if (command) {
@@ -109,25 +112,33 @@ export class ClaudeCodePlugin implements AgentPlugin {
         };
       }
 
-      const text = message.content;
       return {
         messageId,
         role,
         ts,
-        text,
-        blocks: [{ type: "text", text }],
+        text: translateFileMentions(message.content, cwd, asPath),
+        blocks: [
+          {
+            type: "text",
+            text: translateFileMentions(message.content, cwd, asLink),
+          },
+        ],
         ...model,
       };
     }
 
     if (Array.isArray(message.content)) {
-      const blocks: NormalizedBlock[] = [];
-      message.content.forEach((block, index) => {
-        blocks.push(...normalizeBlock(block, messageId, index));
-      });
-      const text = blocks
+      const raw = message.content.flatMap((block, index) =>
+        normalizeBlock(block, messageId, index)
+      );
+      const blocks: NormalizedBlock[] = raw.map((block) =>
+        block.type === "text"
+          ? { ...block, text: translateFileMentions(block.text, cwd, asLink) }
+          : block
+      );
+      const text = raw
         .filter((b): b is { type: "text"; text: string } => b.type === "text")
-        .map((b) => b.text)
+        .map((b) => translateFileMentions(b.text, cwd, asPath))
         .join("\n");
       return { messageId, role, ts, text, blocks, ...model };
     }
@@ -273,6 +284,88 @@ function parseSystemNoise(
   }
 
   return null;
+}
+
+// Claude Code spells a file mention `@path` — agent-private markup carrying
+// only a path, never the file's content. Translate it into a standard markdown
+// link with a `file://` URL so the frontend has one generic rule (file links
+// render as a chip) and never sees the Agent's syntax (ADR-0023).
+// The quoted form is what Claude Code writes when the path contains spaces.
+const FILE_MENTION_RE = /(^|\s)@(?:"([^"\n]+)"|(\S+))/g;
+
+// Code is quoted, not addressed: an `@path` a reader typed inside a fence or an
+// inline span is being shown, not attached, so it stays verbatim.
+const CODE_SEGMENT_RE = /```[\s\S]*?```|`[^`\n]*`/g;
+
+// How a matched mention is written back out. A message carries two renderings
+// of the same sentence: `asLink` for the blocks the frontend draws chips from,
+// `asPath` for `text`, which is the FTS source and the fallback chat title —
+// markdown syntax there would leak into the chat list. The `command` block
+// splits the same way: a clean line in `text`, the markup in the block.
+type MentionWriter = (mentioned: string, cwd: string | undefined) => string;
+
+// The link text keeps the path as the reader wrote it; only the target is
+// resolved, so a relative mention still points somewhere on re-reading.
+const asLink: MentionWriter = (mentioned, cwd) =>
+  `[${mentioned}](${fileUrl(resolveAgainst(mentioned, cwd))})`;
+
+const asPath: MentionWriter = (mentioned) => mentioned;
+
+function translateFileMentions(
+  text: string,
+  cwd: string | undefined,
+  write: MentionWriter
+): string {
+  let out = "";
+  let last = 0;
+  for (const code of text.matchAll(CODE_SEGMENT_RE)) {
+    out += translateProse(text.slice(last, code.index), cwd, write) + code[0];
+    last = code.index + code[0].length;
+  }
+  return out + translateProse(text.slice(last), cwd, write);
+}
+
+function translateProse(
+  text: string,
+  cwd: string | undefined,
+  write: MentionWriter
+): string {
+  return text.replace(
+    FILE_MENTION_RE,
+    (match, lead: string, quoted: string | undefined, bare: string) => {
+      const mentioned = quoted ?? bare;
+      if (!looksLikeFilePath(mentioned)) return match;
+      return `${lead}${write(mentioned, cwd)}`;
+    }
+  );
+}
+
+// `~` stays as written: normalize runs without the session's home directory,
+// and guessing one would point the link at the wrong machine's user.
+function resolveAgainst(mentioned: string, cwd: string | undefined): string {
+  if (!cwd) return mentioned;
+  if (mentioned.startsWith("/") || mentioned.startsWith("~")) return mentioned;
+  return path.posix.join(cwd, mentioned);
+}
+
+// `@` is overwhelmingly not a file mention in a developer log — npm scopes
+// (`@tanstack/react-virtual`), import aliases (`@/types`), CSS at-rules
+// (`@apply`) and handles all share the sigil. A mention has to end in a file
+// extension, in a slash for a directory, or be a dotfile — named entirely by
+// its leading dot, like `.env`. Anything looser turns every mention of a
+// package into a chip.
+function looksLikeFilePath(mentioned: string): boolean {
+  if (mentioned.endsWith("/")) return true;
+  const basename = mentioned.slice(mentioned.lastIndexOf("/") + 1);
+  if (/^\.[A-Za-z0-9]/.test(basename)) return true;
+  return /^[^.].*\.[A-Za-z0-9]+$/.test(basename);
+}
+
+// A markdown link's target ends at the first space or unbalanced paren, so the
+// path has to be percent-encoded to survive as one link. The link *text* keeps
+// the path verbatim — it is what the reader searches for (FTS reads `text`).
+function fileUrl(filePath: string): string {
+  return `file://${encodeURI(filePath).replace(/[()]/g, encodeURIComponent)}`;
 }
 
 // An image's address inside its own message: the message id plus the block's

--- a/web/src/conversation/FileChip.tsx
+++ b/web/src/conversation/FileChip.tsx
@@ -1,0 +1,80 @@
+import { Check, File } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+const COPIED_FEEDBACK_MS = 1400;
+
+interface FileChipProps {
+  /** The full path the mention pointed at, as a `file://` URL. */
+  href: string;
+}
+
+/**
+ * A file the reader attached to a turn, rendered inline in the sentence as a
+ * chip: an icon and the basename, which is what identifies the file at a
+ * glance. The full path is the tooltip, and clicking copies it.
+ *
+ * The path is a historical reference, not a live pointer — nothing checks
+ * whether the file still exists. Checking would cost a stat per chip and
+ * promise a freshness the archive cannot keep. That is also why the chip never
+ * navigates: there may be nothing at the other end.
+ */
+export function FileChip({ href }: FileChipProps) {
+  const filePath = decodePath(href);
+  const basename = filePath.slice(filePath.lastIndexOf("/") + 1);
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<number | undefined>(undefined);
+
+  useEffect(() => () => window.clearTimeout(timer.current), []);
+
+  // The icon carries the confirmation so the chip keeps its width — swapping
+  // the basename for "Copied" would reflow the sentence around it. The word is
+  // there for screen readers, and for anyone whose eye missed the icon.
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(filePath);
+    setCopied(true);
+    window.clearTimeout(timer.current);
+    timer.current = window.setTimeout(
+      () => setCopied(false),
+      COPIED_FEEDBACK_MS
+    );
+  };
+
+  return (
+    <button
+      type="button"
+      data-testid="file-chip"
+      title={filePath}
+      aria-label={`Copy path ${filePath}`}
+      onClick={handleCopy}
+      // The theme paints every surface token the same shade, so a `bg-muted`
+      // chip on a message bubble draws no chip at all. The page background is
+      // the one darker value available — it reads as inset against the bubble —
+      // and the hairline border keeps the edge legible either way.
+      className="mx-0.5 inline-flex max-w-full items-baseline gap-1 rounded border border-muted-foreground/30 bg-background px-1.5 py-0.5 align-baseline text-[0.875em] leading-tight text-foreground no-underline hover:border-muted-foreground/60"
+    >
+      {copied ? (
+        <Check
+          aria-hidden="true"
+          className="size-[1em] shrink-0 self-center text-chart-5"
+        />
+      ) : (
+        <File aria-hidden="true" className="size-[1em] shrink-0 self-center" />
+      )}
+      <span className="truncate">{basename}</span>
+      {copied && (
+        <span className="sr-only" aria-live="polite">
+          Copied
+        </span>
+      )}
+    </button>
+  );
+}
+
+function decodePath(href: string): string {
+  const raw = href.slice("file://".length);
+  try {
+    return decodeURI(raw);
+  } catch {
+    return raw; // A malformed escape is shown as written rather than dropped.
+  }
+}

--- a/web/src/conversation/MarkdownText.test.tsx
+++ b/web/src/conversation/MarkdownText.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MarkdownText } from "@/conversation/MarkdownText";
@@ -67,5 +67,102 @@ describe("MarkdownText code block copying", () => {
     render(<MarkdownText>{"use the `id` field"}</MarkdownText>);
 
     expect(screen.queryByRole("button", { name: "Copy code" })).toBeNull();
+  });
+});
+
+describe("MarkdownText file chips", () => {
+  it("renders a file:// link as a chip showing the basename", () => {
+    render(
+      <MarkdownText>
+        {"Read [docs/PLAN.md](file:///Users/eva/proj/docs/PLAN.md) first"}
+      </MarkdownText>
+    );
+
+    const chip = screen.getByTestId("file-chip");
+    expect(chip).toHaveTextContent("PLAN.md");
+    expect(chip).not.toHaveTextContent("/Users/eva");
+  });
+});
+
+describe("MarkdownText file chip interaction", () => {
+  const MENTION =
+    "Read [docs/PLAN.md](file:///Users/eva/proj/docs/PLAN.md) first";
+
+  it("reveals the full path on hover", () => {
+    render(<MarkdownText>{MENTION}</MarkdownText>);
+
+    expect(screen.getByTestId("file-chip")).toHaveAttribute(
+      "title",
+      "/Users/eva/proj/docs/PLAN.md"
+    );
+  });
+
+  it("copies the full path on click", async () => {
+    // `setup()` installs its own clipboard stub, so ours has to land after it.
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<MarkdownText>{MENTION}</MarkdownText>);
+    await user.click(screen.getByTestId("file-chip"));
+
+    expect(writeText).toHaveBeenCalledWith("/Users/eva/proj/docs/PLAN.md");
+  });
+
+  it("decodes a percent-encoded path back to what the reader typed", () => {
+    render(
+      <MarkdownText>
+        {"[My Notes/plan a.md](file:///Users/eva/My%20Notes/plan%20a.md)"}
+      </MarkdownText>
+    );
+
+    const chip = screen.getByTestId("file-chip");
+    expect(chip).toHaveTextContent("plan a.md");
+    expect(chip).toHaveAttribute("title", "/Users/eva/My Notes/plan a.md");
+  });
+});
+
+describe("MarkdownText non-file links", () => {
+  it("still renders an http link as an anchor that opens in a new tab", () => {
+    render(
+      <MarkdownText>{"see [the ADR](https://example.com/adr)"}</MarkdownText>
+    );
+
+    const link = screen.getByRole("link", { name: "the ADR" });
+    expect(link).toHaveAttribute("href", "https://example.com/adr");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(screen.queryByTestId("file-chip")).toBeNull();
+  });
+});
+
+describe("MarkdownText file chip copy feedback", () => {
+  it("confirms the copy, then goes quiet again", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    try {
+      render(
+        <MarkdownText>
+          {"[docs/PLAN.md](file:///Users/eva/PLAN.md)"}
+        </MarkdownText>
+      );
+      await user.click(screen.getByTestId("file-chip"));
+
+      expect(screen.getByText("Copied")).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(screen.queryByText("Copied")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/web/src/conversation/MarkdownText.tsx
+++ b/web/src/conversation/MarkdownText.tsx
@@ -1,9 +1,13 @@
-import Markdown, { type Components } from "react-markdown";
+import Markdown, {
+  defaultUrlTransform,
+  type Components,
+} from "react-markdown";
 import type { Element, ElementContent } from "hast";
 import rehypeHighlight from "rehype-highlight";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { CopyButton } from "@/shared/CopyButton";
+import { FileChip } from "@/conversation/FileChip";
 
 // The code as written, read off the syntax tree rather than the rendered
 // output: highlighting has already wrapped keywords in spans by the time this
@@ -22,11 +26,20 @@ function codeSource(node: Element | undefined): string {
 }
 
 const markdownComponents: Components = {
-  a: ({ children, ...props }) => (
-    <a {...props} target="_blank" rel="noreferrer noopener">
-      {children}
-    </a>
-  ),
+  a: ({ children, ...props }) => {
+    // The frontend's one generic rule: a file link renders as a chip. The
+    // Agent's own mention syntax was already translated into this link at
+    // normalize time, so the renderer never learns any Agent's markup
+    // (ADR-0023).
+    if (props.href?.startsWith("file://")) {
+      return <FileChip href={props.href} />;
+    }
+    return (
+      <a {...props} target="_blank" rel="noreferrer noopener">
+        {children}
+      </a>
+    );
+  },
   table: ({ children, ...props }) => (
     <div className="overflow-x-auto">
       <table {...props}>{children}</table>
@@ -76,6 +89,12 @@ export function MarkdownText({ children }: { children: string }) {
         // tables, code) still parses normally.
         remarkPlugins={[remarkGfm, remarkBreaks]}
         rehypePlugins={[rehypeHighlight]}
+        // react-markdown drops `file:` URLs by default, as a defence against
+        // links a page might navigate to. These never navigate — the chip
+        // copies the path instead — so the URL has to survive to be read.
+        urlTransform={(url) =>
+          url.startsWith("file://") ? url : defaultUrlTransform(url)
+        }
         components={markdownComponents}
       >
         {children}


### PR DESCRIPTION
## Background (Why)

A file you `@`-mention in Claude Code is written to the log as `@"/path/to/file.pdf"` — agent-private markup carrying only a path. The file's content was never logged. Until now chat-logbook showed that markup raw, so a turn that attached a design doc read as a wall of punctuation, and a chat whose first turn was a mention took the whole quoted path as its title.

## Approach (How)

Classification happens at normalize time, inside the plugin, per ADR-0023. The plugin translates the mention into a standard markdown link with a `file://` URL; the renderer has exactly one generic rule — a file link is a chip — and never learns any Agent's syntax.

Two decisions carry most of the design:

**`text` and `blocks` diverge.** `text` keeps the path as prose; the blocks carry the markdown. This is the split the `command` block already makes, and it matters because `text` is the FTS source and the fallback chat title — link syntax there leaks percent-encoded URLs into the chat list.

**The match rule is deliberately narrow.** `@` is overwhelmingly not a file mention in a developer log: sampling this machine's real logs turned up 1,414 `@chat-logbook/api`, 1,644 `@/types`, plus `@apply` and e-mail addresses, against a handful of genuine mentions. A mention has to end in a file extension, end in a slash for a directory, or be a dotfile. Mentions inside code fences and inline spans stay verbatim — that code is being quoted, not attached.

No existence check. The path is a historical reference, not a live pointer: a stat per chip would cost real time and promise a freshness the archive cannot keep. That is also why the chip copies instead of navigating.

## Changes (What)

- [x] `plugin.normalize` translates `@` mentions into `file://` markdown links, resolving relative paths against the message's `cwd` and leaving `~` unexpanded
- [x] Match rule keyed on extension / trailing slash / dotfile, skipping fenced and inline code
- [x] `text` renders mentions as plain paths so FTS and derived chat titles stay readable
- [x] New `FileChip` — file icon plus basename, full path as tooltip, click to copy with transient confirmation
- [x] `MarkdownText` renders any `file://` link as a chip, and keeps `file:` URLs alive through `urlTransform` (react-markdown strips them by default)
- [x] `NORMALIZE_VERSION` 5 → 6 so chats archived before the rule get the chips on next start

### Test Verification

- [x] Bare and quoted mentions translate, including paths with spaces (percent-encoded target, verbatim link text)
- [x] npm scopes, import aliases, `@apply`, e-mail addresses and bare handles are left untouched
- [x] Mentions inside fenced blocks and inline code stay verbatim
- [x] Relative paths resolve against `cwd`; `~` and absolute paths pass through
- [x] Dotfiles (`.env`) and dot-directories (`.github/workflows/ci.yml`) chip
- [x] Array-form messages translate in both their blocks and their `text`
- [x] Chip shows the basename, reveals the full path on hover, copies it on click, decodes percent-encoding, and confirms then goes quiet
- [x] Non-`file://` links still render as anchors opening in a new tab
- [x] Full suite: 752 tests, typecheck, build

## Additional Notes

- The dotfile rule accepts `@.5` as a path. Real logs do not contain such strings, and the alternative — a curated list of extensionless filenames — is worse to maintain.
- A mention followed immediately by sentence punctuation (`@docs/PLAN.md.`) is left untranslated. Worth revisiting if it shows up in practice.

## Related Links

- Issue #197