### PR TITLE
feat: show the reasoning effort a turn ran at

### DIFF
--- a/api/drizzle/archive/0013_add_message_effort.sql
+++ b/api/drizzle/archive/0013_add_message_effort.sql
@@ -1,0 +1,6 @@
+-- The reasoning effort the Agent recorded for a message (e.g. `medium`), so the
+-- assistant byline can name it beside the model (ADR-0023, #234). Additive and
+-- nullable on the same terms as `model`: many turns record no effort, and rows
+-- normalized before this column existed read as NULL until the
+-- NORMALIZE_VERSION bump re-normalizes them from Raw.
+ALTER TABLE `messages` ADD COLUMN `effort` text;

--- a/api/drizzle/archive/meta/_journal.json
+++ b/api/drizzle/archive/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1779700000000,
       "tag": "0012_add_message_model",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1779800000000,
+      "tag": "0013_add_message_effort",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/archive/repository.ts
+++ b/api/src/archive/repository.ts
@@ -44,6 +44,8 @@ export interface NormalizedMessageInput {
   blocks: unknown;
   /** The model id the Agent recorded, when it recorded one (ADR-0023). */
   model?: string;
+  /** The reasoning effort the Agent recorded, when it recorded one (ADR-0023). */
+  effort?: string;
 }
 
 export interface UpsertNormalizedMessageInput {
@@ -327,6 +329,7 @@ export function createArchiveRepository({
             text: message.text,
             blocks: message.blocks,
             model: message.model ?? null,
+            effort: message.effort ?? null,
             rawId,
           })
           .run();
@@ -341,6 +344,7 @@ export function createArchiveRepository({
             text: message.text,
             blocks: message.blocks,
             model: message.model ?? null,
+            effort: message.effort ?? null,
             rawId,
           })
           .where(eq(messages.id, existing.id))

--- a/api/src/archive/schema.ts
+++ b/api/src/archive/schema.ts
@@ -91,6 +91,9 @@ export const messages = sqliteTable(
     // reader turns record none, and neither do rows normalized before #195 —
     // those get backfilled by the next re-normalize pass.
     model: text("model"),
+    // The reasoning effort the Agent recorded for this message (ADR-0023).
+    // Nullable on the same terms as `model`: many turns record none.
+    effort: text("effort"),
     rawId: integer("raw_id")
       .notNull()
       .references(() => rawMessages.id),

--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -75,6 +75,7 @@ function seedMessage(
     blocks: unknown[];
     agent?: string;
     model?: string;
+    effort?: string;
   }
 ): void {
   const agent = opts.agent ?? DEFAULT_AGENT;
@@ -98,6 +99,7 @@ function seedMessage(
       text: opts.text,
       blocks: opts.blocks,
       ...(opts.model === undefined ? {} : { model: opts.model }),
+      ...(opts.effort === undefined ? {} : { effort: opts.effort }),
     },
   });
 }
@@ -974,6 +976,49 @@ describe("ChatReader.getMessages", () => {
       "claude-haiku-4-5-20251001",
     ]);
     expect(messages![0]).not.toHaveProperty("model");
+  });
+
+  it("serves each message's own reasoning effort, and omits it where none was recorded", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-medium",
+      role: "assistant",
+      ts: new Date(1700000100000),
+      text: "Sure",
+      blocks: [{ type: "text", text: "Sure" }],
+      model: "claude-opus-4-8",
+      effort: "medium",
+    });
+    // A turn archived before the Agent recorded effort keeps none.
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-none",
+      role: "assistant",
+      ts: new Date(1700000200000),
+      text: "Done",
+      blocks: [{ type: "text", text: "Done" }],
+      model: "claude-opus-4-8",
+    });
+
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
+      includeTrashed: false,
+    });
+
+    expect(messages!.map((m) => m.effort)).toEqual(["medium", undefined]);
+    expect(messages![1]).not.toHaveProperty("effort");
   });
 
   it("exposes each message's Normalized message id", () => {

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -78,6 +78,11 @@ export interface MessageResponse {
    * renders. Absent when no model was recorded.
    */
   model?: string;
+  /**
+   * The reasoning effort the Agent recorded for this message (ADR-0023), served
+   * raw in the Agent's own wording. Absent when no effort was recorded.
+   */
+  effort?: string;
 }
 
 interface StoredBlock {
@@ -398,6 +403,7 @@ export function createChatReader({
       content: (m.blocks as StoredBlock[]).map(toApiBlock),
       timestamp: m.ts.toISOString(),
       ...(m.model === null ? {} : { model: m.model }),
+      ...(m.effort === null ? {} : { effort: m.effort }),
     }));
   }
 

--- a/api/src/ingestion/renormalize.ts
+++ b/api/src/ingestion/renormalize.ts
@@ -74,9 +74,10 @@ export function renormalizeFromRaw({
  * dropped them at ingest: version 4. #230 draws SVG visualize widgets as images
  * too, so archived diagrams stop hiding behind a collapsed tool row: version 5.
  * #197 translates `@` file mentions into `file://` links, turning them into
- * chips in chats archived before the rule existed: version 6.
+ * chips in chats archived before the rule existed: version 6. #234 captures the
+ * per-message reasoning `effort`, backfilling it onto archived rows: version 7.
  */
-export const NORMALIZE_VERSION = 6;
+export const NORMALIZE_VERSION = 7;
 
 export interface RunRenormalizeIfStaleOptions {
   plugins: readonly AgentPlugin[];

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -587,6 +587,45 @@ describe("ClaudeCodePlugin.normalize → model capture", () => {
   });
 });
 
+describe("ClaudeCodePlugin.normalize → reasoning effort capture", () => {
+  it("captures the effort the Agent recorded beside the message, not inside it", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-8",
+          content: [{ type: "text", text: "Done." }],
+        },
+        effort: "medium",
+        uuid: "msg-effort-1",
+        timestamp: "2024-01-01T00:00:22Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result?.effort).toBe("medium");
+  });
+
+  it("leaves effort absent on a turn that recorded none", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-8",
+          content: [{ type: "text", text: "Done." }],
+        },
+        uuid: "msg-effort-2",
+        timestamp: "2024-01-01T00:00:23Z",
+        sessionId: "session-1",
+      })
+    );
+
+    expect(result).not.toHaveProperty("effort");
+  });
+});
+
 describe("ClaudeCodePlugin.normalize → inline images", () => {
   it("emits an image block carrying media type and a ref, never the bytes", () => {
     const result = plugin.normalize(

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -80,6 +80,12 @@ export class ClaudeCodePlugin implements AgentPlugin {
       typeof message.model === "string" && message.model !== ""
         ? { model: message.model }
         : {};
+    // Effort sits on the record, not inside `message` — Claude Code writes it
+    // beside the model rather than in the API payload it echoes back.
+    const effort =
+      typeof payload.effort === "string" && payload.effort !== ""
+        ? { effort: payload.effort }
+        : {};
 
     // The directory the turn ran in, used to resolve relative file mentions.
     const cwd = typeof payload.cwd === "string" ? payload.cwd : undefined;
@@ -124,6 +130,7 @@ export class ClaudeCodePlugin implements AgentPlugin {
           },
         ],
         ...model,
+        ...effort,
       };
     }
 
@@ -140,7 +147,7 @@ export class ClaudeCodePlugin implements AgentPlugin {
         .filter((b): b is { type: "text"; text: string } => b.type === "text")
         .map((b) => translateFileMentions(b.text, cwd, asPath))
         .join("\n");
-      return { messageId, role, ts, text, blocks, ...model };
+      return { messageId, role, ts, text, blocks, ...model, ...effort };
     }
 
     return null;

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -59,6 +59,12 @@ export interface NormalizedMessage {
    * message by message.
    */
   model?: string;
+  /**
+   * The reasoning effort the Agent recorded for this message (e.g. `medium`),
+   * per ADR-0023. Carried raw — the Agent's own wording, not a mapped label.
+   * Absent when the Agent recorded none.
+   */
+  effort?: string;
 }
 
 export interface AgentPlugin {

--- a/docs/adr/0023-normalized-block-vocabulary.md
+++ b/docs/adr/0023-normalized-block-vocabulary.md
@@ -33,6 +33,7 @@ Three adjacent rules ride on the same contract:
 
 - **Inline file mentions.** Agent-private file-mention syntax is translated at normalize time into a standard markdown link with a `file://` URL inside the `text` block. The renderer has exactly one generic rule — `file://` links render as a file chip — and never sees the Agent's syntax.
 - **`NormalizedMessage.model`** — an optional field capturing the model id the Agent recorded on the message (e.g. `claude-opus-4-8`). Absent when the Agent doesn't record one.
+- **`NormalizedMessage.effort`** — an optional field capturing the reasoning effort the Agent recorded for the message (e.g. `medium`). Per message, exactly like `model`, and absent when the Agent recorded none. Claude Code writes it beside the message rather than inside it, so the Plugin reads it off the record's top level. Stored in the Agent's own wording. Unlike a model id, an effort is already a readable word, so the frontend needs no id→name table for it — it capitalizes the first letter at render and shows the rest untouched.
 
 The API serves these shapes as-is (with `tool_result.toolUseId` mapped to wire-form `tool_use_id`, matching the existing convention).
 

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -236,6 +236,32 @@ describe("Conversation note-style headers", () => {
 
     expect(await screen.findByText("Claude Code")).not.toBeNull();
   });
+
+  it("names the reasoning effort after the model, capitalized to sit beside it", async () => {
+    render(
+      <ConversationView
+        chat={{ ...chat, agent: "claude-code" }}
+        messages={[
+          {
+            ...assistant("Thought about it."),
+            model: "claude-opus-4-8",
+            effort: "medium",
+          },
+          // An effort the Agent already capitalized is left alone, not shouted.
+          {
+            ...assistant("And again."),
+            model: "claude-opus-4-8",
+            effort: "High",
+          },
+        ]}
+      />
+    );
+
+    expect(
+      await screen.findByText("Claude Code · Opus 4.8 · Medium")
+    ).not.toBeNull();
+    expect(screen.getByText("Claude Code · Opus 4.8 · High")).not.toBeNull();
+  });
 });
 
 describe("Conversation note-style layout", () => {

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -206,12 +206,21 @@ function renderContent(
   );
 }
 
-// The assistant's byline: the Agent, then the model that turn ran on. Read per
-// message, not per chat, so a chat that switched models mid-way shows where.
-// A message with no recorded model keeps the bare Agent name.
+// An effort is already a readable word, so it needs no id→name table the way a
+// model id does — only a capital to sit level with the segments beside it.
+function formatEffort(effort: string): string {
+  return effort.charAt(0).toUpperCase() + effort.slice(1);
+}
+
+// The assistant's byline: the Agent, then the model that turn ran on, then the
+// reasoning effort it ran at. Read per message, not per chat, so a chat that
+// switched models mid-way shows where. Each segment drops out when the message
+// records none.
 function authorName(agentName: string, message: Message): string {
-  if (!message.model) return agentName;
-  return `${agentName} · ${getModelDisplayName(message.model)}`;
+  const segments = [agentName];
+  if (message.model) segments.push(getModelDisplayName(message.model));
+  if (message.effort) segments.push(formatEffort(message.effort));
+  return segments.join(" · ");
 }
 
 function MessageItem({

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -59,4 +59,10 @@ export interface Message {
    * switch. Absent when the Agent recorded none.
    */
   model?: string;
+  /**
+   * The reasoning effort the Agent recorded for this message, served raw by the
+   * API in the Agent's own wording — capitalized at render, never mapped to a
+   * different label. Absent when the Agent recorded none.
+   */
+  effort?: string;
 }


### PR DESCRIPTION
## Background (Why)

Claude Code records a reasoning `effort` on each assistant line in Source, alongside the model. It sits at the top level of the record rather than inside the `message` object it echoes back, so normalization dropped it and the byline could only ever name the model.

## Approach (How)

Effort follows the same path `model` took in #195, one layer at a time: the Plugin reads it off the record, the normalized vocabulary carries it as an optional per-message field, an additive nullable column stores it, and the API serves it raw.

Two deliberate choices:

- **No display mapping.** A model id needs a lookup table because `claude-opus-4-8` and `Opus 4.8` have no rule between them. An effort is already a readable word, so the frontend only capitalizes the first letter and leaves the rest alone. An effort the Agent already capitalized passes through untouched.
- **Raw in the Archive, formatted at render.** The stored value stays the Agent's own word, so a later change to how effort is displayed needs no re-normalize pass.

This is the first `NORMALIZE_VERSION` bump of this batch (6 → 7), so it also exercises the re-normalize-from-Raw path end to end.

## Changes (What)

- [ ] `ClaudeCodePlugin.normalize` reads the record's top-level `effort`; `NormalizedMessage.effort` carries it, absent rather than undefined when unrecorded
- [ ] Migration `0013_add_message_effort` adds a nullable `messages.effort`; the repository writes it and the chat reader serves it, omitting the field when null
- [ ] `NORMALIZE_VERSION` 6 → 7, backfilling effort onto rows archived before the column existed
- [ ] The assistant byline renders `Agent · Model · Effort`, in the same muted weight as the model — no badge, pill, or `effort:` label
- [ ] ADR-0023 documents `NormalizedMessage.effort` and why it needs no id→name table

### Test Verification

- [ ] A record carrying top-level `effort` normalizes with the value
- [ ] A record carrying none leaves the field absent, not `undefined`
- [ ] Effort round-trips through the Archive to the chat reader, and is omitted where none was recorded
- [ ] The byline renders `Claude Code · Opus 4.8 · Medium`, capitalizing a lowercase value and leaving an already-capitalized one alone
- [ ] The byline stays `Claude Code · Opus 4.8` when no effort was recorded — covered by the existing exact-text model assertion, which fails if a third segment appears
- [ ] Full suite: 756 tests, typecheck, and build all pass

## Additional Notes

Verified against the real dev archive after the bump: `archive_meta` reads version 7, and the 2,526 messages carrying effort match exactly the 2,526 Raw rows that record one — nothing was dropped. Effort only appears in sessions from 2026-07-19 onward, because Claude Code started writing the field then. Older chats keep the shorter byline by design.

Migration `0013` is hand-written, matching every migration since `0005` — `drizzle-kit generate` needs an interactive prompt this environment cannot answer.

Expect the first dev boot after this merge to show "No chats" briefly while the re-normalize pass runs.

## Related Links

- Closes #234
- ADR-0023 — normalized block vocabulary
- Follows #195, which carried `model` down the same path