### PR TITLE
feat: carry the edit patch through, and show its shape on the collapsed row

### DIFF
--- a/api/src/chat-reader.test.ts
+++ b/api/src/chat-reader.test.ts
@@ -1233,6 +1233,60 @@ describe("ChatReader.getMessages", () => {
     ]);
   });
 
+  it("serves an edit result's patch and path as patch and file_path", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const metadata = createMetadataRepository({ dataDir });
+    const patch = [
+      {
+        oldStart: 3,
+        oldLines: 7,
+        newStart: 3,
+        newLines: 8,
+        lines: [" context", "-gone", "+added"],
+      },
+    ];
+
+    seedChat(archive, {
+      sourceId: "session-1",
+      firstSeenAt: new Date(1700000000000),
+    });
+    seedMessage(archive, {
+      sourceId: "session-1",
+      messageId: "m-tool",
+      role: "user",
+      ts: new Date(1700000100000),
+      text: "",
+      blocks: [
+        {
+          type: "tool_result",
+          toolUseId: "tool-1",
+          content: "updated",
+          filePath: "/repo/a.ts",
+          patch,
+        },
+      ],
+    });
+
+    const reader = createChatReader({
+      archive,
+      metadata,
+      tags: createTagRepository({ dataDir }),
+      pageQuery: createChatPageQuery({ dataDir }),
+    });
+    const messages = reader.getMessages(wireIdFor(archive, "session-1"), {
+      includeTrashed: false,
+    });
+    expect(messages![0].content).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: "tool-1",
+        content: "updated",
+        file_path: "/repo/a.ts",
+        patch,
+      },
+    ]);
+  });
+
   it("serves a command block unchanged", () => {
     const archive = createArchiveRepository({ dataDir });
     const metadata = createMetadataRepository({ dataDir });

--- a/api/src/chat-reader.ts
+++ b/api/src/chat-reader.ts
@@ -14,6 +14,7 @@ import {
 } from "./list-pagination.js";
 import type { ChatCountsQuery, ListCounts } from "./list-counts.js";
 import type { TagMode } from "./list-filter.js";
+import type { PatchHunk } from "./plugins/types.js";
 
 /**
  * The Chat read face. At read time it composes Archive + Metadata into the
@@ -53,6 +54,12 @@ export type ApiContentBlock =
       content: unknown;
       /** Set when the tool reported a failure. Absent on success. */
       is_error?: boolean;
+      /**
+       * The file a file-editing tool applied to, and the diff hunks it produced
+       * (ADR-0023). Served together or not at all; absent for every other tool.
+       */
+      file_path?: string;
+      patch?: PatchHunk[];
     }
   // A slash-command invocation, served as-is from Normalized (ADR-0023). No
   // field remap: the frontend renders it as a chip.
@@ -97,6 +104,9 @@ function toApiBlock(block: StoredBlock): ApiContentBlock {
       tool_use_id: String(block.toolUseId ?? ""),
       content: block.content,
       ...(block.isError === true ? { is_error: true } : {}),
+      ...(typeof block.filePath === "string" && Array.isArray(block.patch)
+        ? { file_path: block.filePath, patch: block.patch as PatchHunk[] }
+        : {}),
     };
   }
   return block as ApiContentBlock;

--- a/api/src/ingestion/renormalize.test.ts
+++ b/api/src/ingestion/renormalize.test.ts
@@ -82,6 +82,74 @@ describe("renormalizeFromRaw", () => {
     archive.close();
   });
 
+  it("backfills an edit's patch onto a row normalized before #235", () => {
+    const archive = createArchiveRepository({ dataDir });
+    const hunk = {
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 1,
+      lines: ["-old", "+new"],
+    };
+    archive.ensureChat("claude-code", "session-1", new Date(1700000000000));
+    const { id: rawId } = archive.insertRawMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/fake/session-1.jsonl",
+      sourceLocator: "L1",
+      payload: {
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "t1", content: "updated" },
+          ],
+        },
+        toolUseResult: { filePath: "/repo/a.ts", structuredPatch: [hunk] },
+        uuid: "m-edit",
+        timestamp: "2024-01-01T00:00:00Z",
+        sessionId: "session-1",
+      },
+      ingestedAt: new Date(1700000000000),
+    });
+    // The stale row a pre-#235 plugin wrote: the prose result, no patch.
+    archive.upsertNormalizedMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      rawId,
+      message: {
+        messageId: "m-edit",
+        role: "user",
+        ts: "2024-01-01T00:00:00Z",
+        text: "",
+        blocks: [{ type: "tool_result", toolUseId: "t1", content: "updated" }],
+      },
+    });
+
+    renormalizeFromRaw({ plugins: [new ClaudeCodePlugin()], archive });
+
+    expect(
+      archive.read.listMessagesByChat("claude-code", "session-1")[0].blocks
+    ).toEqual([
+      {
+        type: "tool_result",
+        toolUseId: "t1",
+        content: "updated",
+        filePath: "/repo/a.ts",
+        patch: [hunk],
+      },
+    ]);
+
+    archive.close();
+  });
+
+  it("is ahead of the version that shipped widget drawings, so #235 re-normalizes", () => {
+    // Version 7 shipped the reasoning effort (#234). The edit patch is the next
+    // normalize-output change, and only a bump reaches chats whose Source files
+    // are long gone.
+    expect(NORMALIZE_VERSION).toBeGreaterThanOrEqual(8);
+  });
+
   it("leaves the Raw layer byte-identical", () => {
     const archive = createArchiveRepository({ dataDir });
     seedStaleCommand(archive);

--- a/api/src/ingestion/renormalize.ts
+++ b/api/src/ingestion/renormalize.ts
@@ -76,8 +76,10 @@ export function renormalizeFromRaw({
  * #197 translates `@` file mentions into `file://` links, turning them into
  * chips in chats archived before the rule existed: version 6. #234 captures the
  * per-message reasoning `effort`, backfilling it onto archived rows: version 7.
+ * #235 carries an edit's `filePath` and `patch` into the tool result, so
+ * archived edits can summarise as a diff: version 8.
  */
-export const NORMALIZE_VERSION = 7;
+export const NORMALIZE_VERSION = 8;
 
 export interface RunRenormalizeIfStaleOptions {
   plugins: readonly AgentPlugin[];

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -325,6 +325,116 @@ describe("ClaudeCodePlugin.normalize", () => {
     ]);
   });
 
+  it("carries an Edit result's patch and file path into the tool_result", () => {
+    const hunk = {
+      oldStart: 3,
+      oldLines: 7,
+      newStart: 3,
+      newLines: 8,
+      lines: [" context", "-gone", "+added", "+added too"],
+    };
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-1",
+              content: "The file /repo/a.ts has been updated successfully.",
+            },
+          ],
+        },
+        // Claude Code writes the patch beside the message, not inside it.
+        toolUseResult: {
+          filePath: "/repo/a.ts",
+          oldString: "gone",
+          newString: "added\nadded too",
+          structuredPatch: [hunk],
+        },
+        isMeta: false,
+        isSidechain: false,
+        uuid: "msg-9",
+        timestamp: "2024-01-01T00:00:09Z",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "tool_result",
+        toolUseId: "tool-1",
+        content: "The file /repo/a.ts has been updated successfully.",
+        filePath: "/repo/a.ts",
+        patch: [hunk],
+      },
+    ]);
+  });
+
+  it("carries a Write result's patch, which records no old string at all", () => {
+    const hunk = {
+      oldStart: 1,
+      oldLines: 0,
+      newStart: 1,
+      newLines: 2,
+      lines: ["+one", "+two"],
+    };
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "tool-2", content: "ok" },
+          ],
+        },
+        toolUseResult: {
+          type: "create",
+          filePath: "/repo/new.ts",
+          content: "one\ntwo\n",
+          structuredPatch: [hunk],
+        },
+        isMeta: false,
+        isSidechain: false,
+        uuid: "msg-10",
+        timestamp: "2024-01-01T00:00:10Z",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "tool_result",
+        toolUseId: "tool-2",
+        content: "ok",
+        filePath: "/repo/new.ts",
+        patch: [hunk],
+      },
+    ]);
+  });
+
+  it("leaves both fields off a result that edited no file", () => {
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "tool-3", content: "hello\n" },
+          ],
+        },
+        toolUseResult: { stdout: "hello\n", stderr: "" },
+        isMeta: false,
+        isSidechain: false,
+        uuid: "msg-11",
+        timestamp: "2024-01-01T00:00:11Z",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      { type: "tool_result", toolUseId: "tool-3", content: "hello\n" },
+    ]);
+  });
+
   it("normalizes a user text message", () => {
     const result = plugin.normalize(
       rawRecord({

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -5,6 +5,7 @@ import type {
   AgentPlugin,
   NormalizedMessage,
   NormalizedBlock,
+  PatchHunk,
   PluginEnv,
   RawRecord,
   ChatRef,
@@ -136,7 +137,7 @@ export class ClaudeCodePlugin implements AgentPlugin {
 
     if (Array.isArray(message.content)) {
       const raw = message.content.flatMap((block, index) =>
-        normalizeBlock(block, messageId, index)
+        normalizeBlock(block, messageId, index, payload.toolUseResult)
       );
       const blocks: NormalizedBlock[] = raw.map((block) =>
         block.type === "text"
@@ -402,9 +403,10 @@ function parseImageRef(
 function normalizeBlock(
   raw: unknown,
   messageId: string,
-  index: number
+  index: number,
+  toolUseResult?: unknown
 ): NormalizedBlock[] {
-  const one = normalizeOneBlock(raw, messageId, index);
+  const one = normalizeOneBlock(raw, messageId, index, toolUseResult);
   if (!one) return [];
   if (one.type === "tool_use" && svgWidgetCode(raw)) {
     // The tool row stays alongside the image: the drawing is the point, but the
@@ -421,10 +423,40 @@ function normalizeBlock(
   return [one];
 }
 
+// Edit, Write and MultiEdit all record the same two things beside the message:
+// the file they touched and the unified-diff hunks they produced. Every other
+// tool records something else, so the shape itself is the test — no tool-name
+// table to keep in step with the Agent.
+function editedFile(
+  toolUseResult: unknown
+): { filePath: string; patch: PatchHunk[] } | Record<string, never> {
+  if (!toolUseResult || typeof toolUseResult !== "object") return {};
+  const r = toolUseResult as Record<string, unknown>;
+  if (typeof r.filePath !== "string" || !r.filePath) return {};
+  if (!Array.isArray(r.structuredPatch)) return {};
+  const patch = r.structuredPatch.filter(isPatchHunk);
+  if (patch.length === 0) return {};
+  return { filePath: r.filePath, patch };
+}
+
+function isPatchHunk(hunk: unknown): hunk is PatchHunk {
+  if (!hunk || typeof hunk !== "object") return false;
+  const h = hunk as Record<string, unknown>;
+  return (
+    typeof h.oldStart === "number" &&
+    typeof h.oldLines === "number" &&
+    typeof h.newStart === "number" &&
+    typeof h.newLines === "number" &&
+    Array.isArray(h.lines) &&
+    h.lines.every((line) => typeof line === "string")
+  );
+}
+
 function normalizeOneBlock(
   raw: unknown,
   messageId: string,
-  index: number
+  index: number,
+  toolUseResult?: unknown
 ): NormalizedBlock | null {
   if (!raw || typeof raw !== "object") return null;
   const b = raw as Record<string, unknown>;
@@ -457,6 +489,7 @@ function normalizeOneBlock(
         // Only carried when the tool actually failed: a `false` on every
         // successful result would grow the stored block for nothing.
         ...(b.is_error === true ? { isError: true } : {}),
+        ...editedFile(toolUseResult),
       };
     default:
       return null;

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -17,6 +17,19 @@ export interface RawRecord {
   payload: unknown;
 }
 
+/**
+ * One hunk of a unified diff, in the shape every Agent's patch already speaks:
+ * where the hunk starts on each side, how many lines it covers, and the lines
+ * themselves with their `+`/`-`/` ` prefixes.
+ */
+export interface PatchHunk {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  lines: string[];
+}
+
 export type NormalizedBlock =
   | { type: "text"; text: string }
   | { type: "thinking"; thinking: string }
@@ -30,6 +43,15 @@ export type NormalizedBlock =
        * only ever widens a stored block (ADR-0023).
        */
       isError?: boolean;
+      /**
+       * The file a file-editing tool applied to, and the unified-diff hunks it
+       * produced (ADR-0023). Carried together or not at all: a result that
+       * edited no file has neither. Kept verbatim from the Agent's own patch —
+       * the real line numbers are what the diff view renders from, and nothing
+       * in the call itself can recover them.
+       */
+      filePath?: string;
+      patch?: PatchHunk[];
     }
   // A slash-command invocation, translated from the Agent's private markup at
   // normalize time so the frontend never parses it (ADR-0023). Renders as a chip.

--- a/docs/adr/0023-normalized-block-vocabulary.md
+++ b/docs/adr/0023-normalized-block-vocabulary.md
@@ -14,6 +14,9 @@ type NormalizedBlock =
       toolUseId: string;
       content: unknown;
       isError?: boolean;
+      // Only on a result that edited a file:
+      filePath?: string;
+      patch?: PatchHunk[];
     }
   // New kinds:
   | { type: "command"; name: string; args: string }
@@ -32,6 +35,7 @@ Three adjacent rules ride on the same contract:
   This splits the endpoint's caching in two. Bytes copied verbatim out of Raw are pinned forever (`immutable`) because nothing can change them. Rendered bytes carry an `ETag` and `no-cache` instead: they are a function of the app's version rather than the archive's content, so an upgrade that changes the theme or the sizing has to reach browsers that already hold the old render. Revalidation is one local 304 and no bytes.
 
 - **Inline file mentions.** Agent-private file-mention syntax is translated at normalize time into a standard markdown link with a `file://` URL inside the `text` block. The renderer has exactly one generic rule — `file://` links render as a file chip — and never sees the Agent's syntax.
+- **`tool_result.filePath` + `tool_result.patch`** — the file a file-editing tool applied to, and the unified-diff hunks it produced, carried together or not at all. Claude Code writes both beside the message rather than inside it, so the Plugin reads them off the record's top level, and it keys on the shape of what it finds rather than on a list of tool names — a new editing tool that records the same two things is carried without a code change. The hunks stay verbatim: their `oldStart`/`newStart` are real line numbers, and nothing in the call itself can recover them (deriving a diff in the browser from `old_string`/`new_string` was considered and rejected — it loses the line numbers, and Write has no old string at all). The counts a collapsed row shows (`Edited App.tsx +3 -1`) are derived at render from the `+`/`-` prefixes, not stored.
 - **`NormalizedMessage.model`** — an optional field capturing the model id the Agent recorded on the message (e.g. `claude-opus-4-8`). Absent when the Agent doesn't record one.
 - **`NormalizedMessage.effort`** — an optional field capturing the reasoning effort the Agent recorded for the message (e.g. `medium`). Per message, exactly like `model`, and absent when the Agent recorded none. Claude Code writes it beside the message rather than inside it, so the Plugin reads it off the record's top level. Stored in the Agent's own wording. Unlike a model id, an effort is already a readable word, so the frontend needs no id→name table for it — it capitalizes the first letter at render and shows the rest untouched.
 

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -29,7 +29,7 @@ export function CollapsibleToolCall({
   return (
     <CollapsibleRow
       icon={Terminal}
-      summary={generateToolSummary(block)}
+      summary={generateToolSummary(block, result)}
       hasError={result?.is_error}
     >
       <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -627,6 +627,56 @@ describe("Conversation tool units", () => {
     expect(await screen.findByText(/17 passed/)).not.toBeNull();
   });
 
+  it("collapses a file edit to the file it touched and how much it changed", async () => {
+    // The patch rides on the result, which an Agent commonly records in the
+    // next turn — so the row can only say this if the unit's two halves are
+    // joined before the summary is drawn (#235).
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-call",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Edit",
+                input: { file_path: "/repo/web/src/App.tsx" },
+              },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "m-result",
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "t1",
+                content: "The file /repo/web/src/App.tsx has been updated",
+                file_path: "/repo/web/src/App.tsx",
+                patch: [
+                  {
+                    oldStart: 10,
+                    oldLines: 3,
+                    newStart: 10,
+                    newLines: 5,
+                    lines: [" keep", "-gone", "+a", "+b", "+c"],
+                  },
+                ],
+              },
+            ],
+            timestamp: "2024-01-01T00:01:00Z",
+          },
+        ]}
+      />
+    );
+
+    expect(await screen.findByText("Edited App.tsx +3 -1")).not.toBeNull();
+  });
+
   it("shows input and output under one left rule marking the unit's extent", async () => {
     // The rule is what makes an expanded unit read as a nested aside rather
     // than more prose: it marks where the unit's detail starts and ends (#193).

--- a/web/src/conversation/generateToolSummary.test.ts
+++ b/web/src/conversation/generateToolSummary.test.ts
@@ -64,6 +64,111 @@ describe("generateToolSummary", () => {
     ).toBe("Write: README.md");
   });
 
+  it("summarizes an Edit that carries a patch as a diff line", () => {
+    expect(
+      generateToolSummary(
+        {
+          type: "tool_use",
+          id: "t4",
+          name: "Edit",
+          input: { file_path: "web/src/conversation/CollapsibleToolCall.tsx" },
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "t4",
+          content: "updated",
+          file_path: "web/src/conversation/CollapsibleToolCall.tsx",
+          patch: [
+            {
+              oldStart: 3,
+              oldLines: 4,
+              newStart: 3,
+              newLines: 6,
+              lines: [" keep", "-gone", "+one", "+two", "+three"],
+            },
+          ],
+        }
+      )
+    ).toBe("Edited CollapsibleToolCall.tsx +3 -1");
+  });
+
+  it("summarizes a Write as written, counting a whole new file as added", () => {
+    expect(
+      generateToolSummary(
+        {
+          type: "tool_use",
+          id: "t5",
+          name: "Write",
+          input: { file_path: "/repo/docs/README.md", content: "a\nb\n" },
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "t5",
+          content: "created",
+          file_path: "/repo/docs/README.md",
+          patch: [
+            {
+              oldStart: 1,
+              oldLines: 0,
+              newStart: 1,
+              newLines: 2,
+              lines: ["+a", "+b"],
+            },
+          ],
+        }
+      )
+    ).toBe("Wrote README.md +2 -0");
+  });
+
+  it("sums a MultiEdit's hunks into one pair of counts", () => {
+    expect(
+      generateToolSummary(
+        {
+          type: "tool_use",
+          id: "t6",
+          name: "MultiEdit",
+          input: { file_path: "/repo/src/app.ts" },
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "t6",
+          content: "updated",
+          file_path: "/repo/src/app.ts",
+          patch: [
+            {
+              oldStart: 1,
+              oldLines: 2,
+              newStart: 1,
+              newLines: 2,
+              lines: ["-a", "+b"],
+            },
+            {
+              oldStart: 40,
+              oldLines: 3,
+              newStart: 40,
+              newLines: 4,
+              lines: [" keep", "-c", "+d", "+e"],
+            },
+          ],
+        }
+      )
+    ).toBe("Edited app.ts +3 -2");
+  });
+
+  it("keeps the plain summary for an edit whose result carries no patch", () => {
+    expect(
+      generateToolSummary(
+        {
+          type: "tool_use",
+          id: "t7",
+          name: "Edit",
+          input: { file_path: "src/app.ts" },
+        },
+        { type: "tool_result", tool_use_id: "t7", content: "updated" }
+      )
+    ).toBe("Edit: src/app.ts");
+  });
+
   it("summarizes Glob tool with pattern", () => {
     expect(
       generateToolSummary({

--- a/web/src/conversation/generateToolSummary.ts
+++ b/web/src/conversation/generateToolSummary.ts
@@ -1,6 +1,34 @@
-import type { ContentBlock } from "@/types";
+import type { ContentBlock, PatchHunk } from "@/types";
 
 type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
+type ToolResultBlock = Extract<ContentBlock, { type: "tool_result" }>;
+
+// A file edit reads better as what changed than as which tool ran, so a result
+// carrying a patch names the act and the shape of it. `Wrote` covers both of
+// Write's cases — a new file and an overwrite — where `Created` would be wrong
+// for one of them.
+const EDIT_VERBS: Record<string, string> = {
+  Edit: "Edited",
+  MultiEdit: "Edited",
+  Write: "Wrote",
+};
+
+function countLines(patch: PatchHunk[]): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  for (const hunk of patch) {
+    for (const line of hunk.lines) {
+      if (line.startsWith("+")) added += 1;
+      else if (line.startsWith("-")) removed += 1;
+    }
+  }
+  return { added, removed };
+}
+
+function basename(filePath: string): string {
+  const slash = filePath.lastIndexOf("/");
+  return slash === -1 ? filePath : filePath.slice(slash + 1);
+}
 
 const MAX_DETAIL_LENGTH = 100;
 
@@ -20,9 +48,18 @@ function getString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-export function generateToolSummary(block: ToolUseBlock): string {
+export function generateToolSummary(
+  block: ToolUseBlock,
+  result?: ToolResultBlock
+): string {
   const { name } = block;
   const input = getInput(block.input);
+
+  const verb = EDIT_VERBS[name];
+  if (verb && result?.file_path && result.patch?.length) {
+    const { added, removed } = countLines(result.patch);
+    return `${verb} ${basename(result.file_path)} +${added} -${removed}`;
+  }
 
   const filePath = getString(input.file_path);
   if (filePath) return `${name}: ${filePath}`;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -25,6 +25,16 @@ export interface Chat {
   tags?: Tag[];
 }
 
+/** One hunk of a unified diff, served as the Agent recorded it (ADR-0023). */
+export interface PatchHunk {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  /** The hunk's lines, each still carrying its `+`, `-` or space prefix. */
+  lines: string[];
+}
+
 export type ContentBlock =
   | { type: "text"; text: string }
   | { type: "thinking"; thinking: string }
@@ -35,6 +45,14 @@ export type ContentBlock =
       content: unknown;
       /** Set when the tool reported a failure. Absent on success. */
       is_error?: boolean;
+      /**
+       * The file a file-editing tool applied to, and the diff hunks it produced
+       * (ADR-0023). Carried together or not at all — every other tool has
+       * neither. The line numbers are the Agent's own, which is why the diff
+       * comes from here rather than from the call's old/new strings.
+       */
+      file_path?: string;
+      patch?: PatchHunk[];
     }
   // A slash-command invocation the plugin translated from the Agent's private
   // markup (ADR-0023). Renders as a chip; the frontend never parses markup.


### PR DESCRIPTION
## Background (Why)

An Edit, Write or MultiEdit result in Source carries a `structuredPatch` — standard unified-diff hunks with real `oldStart`/`newStart` line numbers — plus the `filePath` it applied to. Normalization kept only the prose result ("The file ... has been updated") and threw the patch away.

That left the collapsed row saying the least useful thing it could about a file edit: a bare tool name and an absolute path. This carries the patch through and spends it immediately on the row the reader skims.

## Approach (How)

The patch sits beside the message in Source rather than inside it, so the Plugin reads it off the record's top level, the same way it already reads the reasoning effort. Extraction keys on the **shape** of what it finds — a `filePath` plus a well-formed `structuredPatch` — rather than on a list of tool names, so all three editing tools go through one path and a future editing tool is carried without a code change.

The hunks are stored verbatim. Deriving the diff in the browser from the call's own `old_string`/`new_string` was considered and rejected: it cannot recover real line numbers, and Write has no old string at all. The added/removed counts are derived at render from the `+`/`-` prefixes rather than stored, so the next slice (rendering the diff itself) has everything it needs.

`NORMALIZE_VERSION` goes 7 → 8 so archived chats gain the patch on the next start.

## Changes (What)

- [x] `tool_result` gains optional `filePath` + `patch` (new `PatchHunk` type), carried together or not at all — Normalized, API wire (`file_path` / `patch`), and web types
- [x] The Claude Code Plugin extracts both from the record's `toolUseResult`
- [x] `NORMALIZE_VERSION` bumped to 8
- [x] `generateToolSummary` takes the unit's result: an editing tool with a patch collapses to `Edited App.tsx +3 -1` (`Wrote` for Write — it covers both a new file and an overwrite, where `Created` would be wrong for one)
- [x] ADR-0023 records the two fields and why the patch is the only workable source

The expanded detail is unchanged — rendering the diff is the next slice.

### Test Verification

- [x] An Edit result carries `patch` and `filePath` into the normalized block
- [x] A Write result does too, despite recording no old string at all
- [x] A result that edited no file (Bash) gets neither field — absent, not empty
- [x] Re-normalize backfills the patch onto a row normalized before this change
- [x] `NORMALIZE_VERSION` is ahead of the version that shipped the reasoning effort
- [x] The API serves the two fields as `file_path` and `patch`
- [x] Edit, Write and MultiEdit each summarise with the right verb and counts; MultiEdit sums across hunks
- [x] An edit whose result carries no patch keeps the existing summary, with no empty counts
- [x] End to end in the conversation view: a call and a result recorded in *different* turns still collapse to the diff line

Full suite green: 767 tests (api 400, web 367), plus typecheck and build.

## Related Links

- Closes #235