### PR TITLE
feat(web): group consecutive skim-layer rows into a Run

### DIFF
--- a/web/e2e/run-grouping.spec.ts
+++ b/web/e2e/run-grouping.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "@playwright/test";
+
+// The Run is a spacing claim, and spacing is exactly what a component test in
+// jsdom cannot see: every box there measures zero. Measured here instead (#236).
+async function openRunChat(page: import("@playwright/test").Page) {
+  await page.route(/\/api\/chats\/stream(\?|$)/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: ":ok\n\n",
+    })
+  );
+  await page.route(/\/api\/chats\/counts(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1, projects: [], tags: [], untagged: 1 } })
+  );
+  await page.route(/\/api\/chats\/list-total(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1 } })
+  );
+  await page.route(/\/api\/chats(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        chats: [
+          {
+            id: "clog_run1",
+            sourceId: "run-chat",
+            agent: "claude-code",
+            title: "A burst of activity",
+            project: "/test/project",
+            sourceFilePath: null,
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      },
+    })
+  );
+  const call = (id: string, path: string) => ({
+    type: "tool_use",
+    id,
+    name: "Read",
+    input: { file_path: path },
+  });
+  await page.route(/\/api\/chats\/clog_run1(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        messages: [
+          {
+            id: "m-prose",
+            role: "user",
+            content: [{ type: "text", text: "Find where this breaks." }],
+            timestamp: "2023-11-14T22:13:20.000Z",
+          },
+          {
+            id: "m-1",
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "Start with the entry point." },
+              call("t1", "/a.ts"),
+            ],
+            timestamp: "2023-11-14T22:13:21.000Z",
+          },
+          {
+            id: "m-2",
+            role: "assistant",
+            content: [call("t2", "/b.ts")],
+            timestamp: "2023-11-14T22:13:22.000Z",
+          },
+          {
+            id: "m-3",
+            role: "assistant",
+            content: [call("t3", "/c.ts")],
+            timestamp: "2023-11-14T22:13:23.000Z",
+          },
+        ],
+      },
+    })
+  );
+
+  await page.goto("/");
+  await page.getByText("A burst of activity").click();
+}
+
+async function rowTop(
+  page: import("@playwright/test").Page,
+  path: string
+): Promise<{ top: number; bottom: number }> {
+  const box = await page
+    .getByRole("button", { name: new RegExp(`Read: ${path}`) })
+    .boundingBox();
+  return { top: box!.y, bottom: box!.y + box!.height };
+}
+
+test.describe("Run density", () => {
+  test("sits the rows of a Run a few pixels apart, across turns", async ({
+    page,
+  }) => {
+    await openRunChat(page);
+
+    const a = await rowTop(page, "/a\\.ts");
+    const b = await rowTop(page, "/b\\.ts");
+    const c = await rowTop(page, "/c\\.ts");
+
+    // Every gap here crosses a message boundary the Agent recorded, which used
+    // to cost roughly 40px of air each.
+    expect(b.top - a.bottom).toBeLessThan(8);
+    expect(c.top - b.bottom).toBeLessThan(8);
+  });
+
+  test("keeps prose apart from the Run that follows it", async ({ page }) => {
+    await openRunChat(page);
+
+    const prose = (await page
+      .getByText("Find where this breaks.")
+      .boundingBox())!;
+    const thinking = (await page
+      .getByRole("button", { name: /Thinking/ })
+      .boundingBox())!;
+
+    expect(thinking.y - (prose.y + prose.height)).toBeGreaterThan(16);
+  });
+});

--- a/web/src/conversation/CollapsibleRow.tsx
+++ b/web/src/conversation/CollapsibleRow.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { ChevronDown, type LucideIcon } from "lucide-react";
 
 interface CollapsibleRowProps {
@@ -8,6 +8,12 @@ interface CollapsibleRowProps {
   summary: string;
   /** Marks the row as reporting a failure. */
   hasError?: boolean;
+  /**
+   * Whether the row is open. Controlled from above, because the virtualizer
+   * recycles rows by position and state kept here would not survive it (#236).
+   */
+  isExpanded: boolean;
+  onToggle: () => void;
   /**
    * The detail revealed when expanded. Omit it when the summary is already the
    * whole row — it then renders as a plain line, with no control that would
@@ -27,13 +33,13 @@ export function CollapsibleRow({
   icon: Icon,
   summary,
   hasError,
+  isExpanded,
+  onToggle,
   children,
 }: CollapsibleRowProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-
   if (!children) {
     return (
-      <div className="my-1">
+      <div>
         <div className="flex w-full items-center gap-1.5 px-1.5 py-1 text-xs text-muted-foreground">
           {/* Stands in for the chevron so this row's icon still lines up with
               the expandable rows around it. */}
@@ -46,10 +52,10 @@ export function CollapsibleRow({
   }
 
   return (
-    <div className="my-1">
+    <div>
       <button
         type="button"
-        onClick={() => setIsExpanded((prev) => !prev)}
+        onClick={onToggle}
         aria-expanded={isExpanded}
         // Muted and a size down from body text: these rows are the parts of a
         // session the reader scans past, not the prose they came to read.

--- a/web/src/conversation/CollapsibleThinking.tsx
+++ b/web/src/conversation/CollapsibleThinking.tsx
@@ -4,11 +4,22 @@ import { MarkdownText } from "@/conversation/MarkdownText";
 
 interface CollapsibleThinkingProps {
   thinking: string;
+  isExpanded: boolean;
+  onToggle: () => void;
 }
 
-export function CollapsibleThinking({ thinking }: CollapsibleThinkingProps) {
+export function CollapsibleThinking({
+  thinking,
+  isExpanded,
+  onToggle,
+}: CollapsibleThinkingProps) {
   return (
-    <CollapsibleRow icon={Brain} summary="Thinking...">
+    <CollapsibleRow
+      icon={Brain}
+      summary="Thinking..."
+      isExpanded={isExpanded}
+      onToggle={onToggle}
+    >
       <div className="overflow-x-auto rounded bg-card p-2 text-xs italic text-muted-foreground">
         <MarkdownText>{thinking}</MarkdownText>
       </div>

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -9,6 +9,8 @@ type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
 interface CollapsibleToolCallProps {
   block: ToolUseBlock;
   result?: ToolResultBlock;
+  isExpanded: boolean;
+  onToggle: () => void;
 }
 
 function formatResultContent(content: unknown): string {
@@ -25,12 +27,16 @@ function formatResultContent(content: unknown): string {
 export function CollapsibleToolCall({
   block,
   result,
+  isExpanded,
+  onToggle,
 }: CollapsibleToolCallProps) {
   return (
     <CollapsibleRow
       icon={Terminal}
       summary={generateToolSummary(block)}
       hasError={result?.is_error}
+      isExpanded={isExpanded}
+      onToggle={onToggle}
     >
       <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
         {JSON.stringify(block.input, null, 2)}

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -1054,3 +1054,200 @@ describe("messages with nothing to take away", () => {
     ).toBeTruthy();
   });
 });
+
+describe("Run grouping", () => {
+  // A stretch of tool calls arrives as one turn per call, so without grouping
+  // it renders as a column of stranded one-line fragments. The Run is what
+  // pulls them back together (#236).
+  const skimRun: Message[] = [
+    {
+      id: "m-1",
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "weighing the options" },
+        { type: "tool_use", id: "t1", name: "Read", input: {} },
+      ],
+      timestamp: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "m-2",
+      role: "assistant",
+      content: [{ type: "tool_use", id: "t2", name: "Bash", input: {} }],
+      timestamp: "2024-01-01T00:01:00Z",
+    },
+    {
+      id: "m-3",
+      role: "assistant",
+      content: [{ type: "text", text: "All green." }],
+      timestamp: "2024-01-01T00:02:00Z",
+    },
+  ];
+
+  function messageEl(container: HTMLElement, id: string): HTMLElement {
+    return container.querySelector<HTMLElement>(`#${messageAnchorId(id)}`)!;
+  }
+
+  it("gathers the skim-layer rows of a turn into one group", async () => {
+    const { container } = render(
+      <ConversationView chat={chat} messages={skimRun} />
+    );
+    await screen.findByText("All green.");
+
+    const groups = messageEl(container, "m-1").querySelectorAll(
+      '[data-testid="run"]'
+    );
+    expect(groups).toHaveLength(1);
+    // Thinking sits inside the Run: a stretch of thinking-then-tools is one
+    // continuous piece of work, not two islands.
+    expect(groups[0]!.querySelectorAll("button")).toHaveLength(2);
+  });
+
+  it("marks the seam where a Run carries on into the next turn", async () => {
+    const { container } = render(
+      <ConversationView chat={chat} messages={skimRun} />
+    );
+    await screen.findByText("All green.");
+
+    expect(messageEl(container, "m-1")).toHaveAttribute(
+      "data-run-continues-after",
+      "true"
+    );
+    expect(messageEl(container, "m-2")).toHaveAttribute(
+      "data-run-continues-before",
+      "true"
+    );
+  });
+
+  it("ends the Run at message text, which keeps its own breathing room", async () => {
+    const { container } = render(
+      <ConversationView chat={chat} messages={skimRun} />
+    );
+    await screen.findByText("All green.");
+
+    const prose = messageEl(container, "m-3");
+    expect(prose.querySelector('[data-testid="run"]')).toBeNull();
+    expect(prose).not.toHaveAttribute("data-run-continues-before");
+    expect(messageEl(container, "m-2")).not.toHaveAttribute(
+      "data-run-continues-after"
+    );
+  });
+});
+
+describe("Row expansion", () => {
+  function tool(id: string, path: string): Message {
+    return {
+      id,
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: `t-${id}`,
+          name: "Read",
+          input: { file_path: path },
+        },
+      ],
+      timestamp: "2024-01-01T00:00:00Z",
+    };
+  }
+
+  it("keeps a row open when the list shifts under the virtualizer", async () => {
+    // The virtualizer keys rows by list position, so a message arriving above
+    // hands a row's instance to a different Message. Expansion that lived in
+    // that instance would follow the position instead of the row (#236).
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ConversationView
+        chat={chat}
+        messages={[tool("m-a", "/a.ts"), tool("m-b", "/b.ts")]}
+      />
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /Read: \/b\.ts/ })
+    );
+
+    rerender(
+      <ConversationView
+        chat={chat}
+        messages={[
+          tool("m-new", "/new.ts"),
+          tool("m-a", "/a.ts"),
+          tool("m-b", "/b.ts"),
+        ]}
+      />
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /Read: \/b\.ts/ })
+    ).toHaveAttribute("aria-expanded", "true");
+    // and no neighbour inherited it
+    expect(
+      screen.getByRole("button", { name: /Read: \/a\.ts/ })
+    ).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.getByRole("button", { name: /Read: \/new\.ts/ })
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+  it("remembers each row of a turn separately", async () => {
+    const user = userEvent.setup();
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-pair",
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Read",
+                input: { file_path: "/a.ts" },
+              },
+              {
+                type: "tool_use",
+                id: "t2",
+                name: "Read",
+                input: { file_path: "/b.ts" },
+              },
+            ],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
+      />
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /Read: \/b\.ts/ })
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Read: \/b\.ts/ })
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByRole("button", { name: /Read: \/a\.ts/ })
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("opens a different chat with every row closed", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ConversationView chat={chat} messages={[tool("m-a", "/a.ts")]} />
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /Read: \/a\.ts/ })
+    );
+
+    rerender(
+      <ConversationView
+        chat={{ ...chat, id: "c2" }}
+        messages={[tool("m-a", "/a.ts")]}
+      />
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /Read: \/a\.ts/ })
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -29,6 +29,11 @@ import {
   collectToolResults,
   type ToolResultBlock,
 } from "@/conversation/toolUnits";
+import { planLayout, type MessageLayout } from "@/conversation/runs";
+import {
+  useRowExpansion,
+  type RowExpansion,
+} from "@/conversation/useRowExpansion";
 import { useScrollShortcuts } from "@/conversation/useScrollShortcuts";
 import { getAgentDisplayName } from "@/agent/agentDisplayName";
 import { getModelDisplayName } from "@/agent/modelDisplayName";
@@ -153,24 +158,44 @@ function ConversationHeader({
 
 type ToolResults = Map<string, ToolResultBlock>;
 
+/** What every block needs to render, gathered so it can be threaded as one. */
+interface RenderContext {
+  toolResults: ToolResults;
+  /** Owning chat, so an image block can address its own bytes. */
+  chatId: string;
+  /** Owning message, half of the key a collapsible row is remembered under. */
+  messageId: string;
+  expansion: RowExpansion;
+}
+
 function renderContentBlock(
   block: ContentBlock,
   index: number,
-  toolResults: ToolResults,
-  chatId: string
+  { toolResults, chatId, messageId, expansion }: RenderContext
 ) {
+  const isExpanded = expansion.isExpanded(messageId, index);
+  const onToggle = () => expansion.toggle(messageId, index);
   switch (block.type) {
     case "text":
       return <MarkdownText key={index}>{block.text}</MarkdownText>;
     case "thinking":
       if (!block.thinking) return null;
-      return <CollapsibleThinking key={index} thinking={block.thinking} />;
+      return (
+        <CollapsibleThinking
+          key={index}
+          thinking={block.thinking}
+          isExpanded={isExpanded}
+          onToggle={onToggle}
+        />
+      );
     case "tool_use":
       return (
         <CollapsibleToolCall
           key={index}
           block={block}
           result={toolResults.get(block.id)}
+          isExpanded={isExpanded}
+          onToggle={onToggle}
         />
       );
     case "tool_result":
@@ -179,7 +204,13 @@ function renderContentBlock(
       return <CommandLine key={index} name={block.name} args={block.args} />;
     case "system":
       return (
-        <SystemRow key={index} summary={block.summary} detail={block.detail} />
+        <SystemRow
+          key={index}
+          summary={block.summary}
+          detail={block.detail}
+          isExpanded={isExpanded}
+          onToggle={onToggle}
+        />
       );
     case "image":
       return (
@@ -195,15 +226,34 @@ function renderContentBlock(
 
 function renderContent(
   content: Message["content"],
-  toolResults: ToolResults,
-  chatId: string
+  layout: MessageLayout,
+  context: RenderContext
 ) {
   if (typeof content === "string") {
     return <MarkdownText>{content}</MarkdownText>;
   }
-  return content.map((block, i) =>
-    renderContentBlock(block, i, toolResults, chatId)
-  );
+  return layout.segments.map((segment) => {
+    if (segment.kind === "block") {
+      return renderContentBlock(
+        content[segment.blockIndex]!,
+        segment.blockIndex,
+        context
+      );
+    }
+    return (
+      // The Run's own container: its rows sit a few pixels apart, where prose
+      // around them keeps its breathing room. The contrast is the point (#236).
+      <div
+        key={`run-${segment.blockIndices[0]}`}
+        data-testid="run"
+        className="flex flex-col gap-0.5"
+      >
+        {segment.blockIndices.map((blockIndex) =>
+          renderContentBlock(content[blockIndex]!, blockIndex, context)
+        )}
+      </div>
+    );
+  });
 }
 
 // An effort is already a readable word, so it needs no id→name table the way a
@@ -225,26 +275,41 @@ function authorName(agentName: string, message: Message): string {
 
 function MessageItem({
   message,
+  layout,
   agentName,
   toolResults,
   chatId,
+  expansion,
 }: {
   message: Message;
+  layout: MessageLayout;
   agentName: string;
   toolResults: ToolResults;
   /** Owning chat, so an image block can address its own bytes. */
   chatId: string;
+  expansion: RowExpansion;
 }) {
   const copyValue = messageToMarkdown(message);
+  // A Run recorded as several turns gives up the padding at its seams, so the
+  // stretch reads as one group rather than a column of fragments (#236).
+  const seamClass = `${layout.runContinuesBefore ? "pt-0.5" : "pt-3"} ${
+    layout.runContinuesAfter ? "pb-0" : "pb-3"
+  }`;
   return (
     <div
       id={messageAnchorId(message.id)}
       data-role={message.role}
+      {...(layout.runContinuesBefore
+        ? { "data-run-continues-before": "true" }
+        : {})}
+      {...(layout.runContinuesAfter
+        ? { "data-run-continues-after": "true" }
+        : {})}
       // A note-style document flow: every turn spans the pane's column, and
       // only the reader's own turns take a background block, as scanning
       // anchors. Both roles keep the same horizontal padding so their text
       // aligns down a single edge (#192).
-      className={`group relative w-full px-4 py-3 text-sm leading-relaxed ${
+      className={`group relative w-full px-4 text-sm leading-relaxed ${seamClass} ${
         message.role === "user"
           ? "rounded-md bg-card text-accent-foreground"
           : "text-foreground"
@@ -276,7 +341,12 @@ function MessageItem({
           </span>
         </div>
       )}
-      {renderContent(message.content, toolResults, chatId)}
+      {renderContent(message.content, layout, {
+        toolResults,
+        chatId,
+        messageId: message.id,
+        expansion,
+      })}
     </div>
   );
 }
@@ -308,6 +378,10 @@ export function ConversationView({
     () => collectToolResults(allMessages),
     [allMessages]
   );
+  // Grouping is decided here, once, as a pure function of what is rendered —
+  // never measured at layout time (#236).
+  const layouts = useMemo(() => planLayout(messages), [messages]);
+  const expansion = useRowExpansion(chat?.id);
   const tagControls: TagControls | undefined =
     allTags && onAssignTag && onRemoveTag && onCreateTag
       ? { allTags, onAssignTag, onRemoveTag, onCreateTag }
@@ -509,7 +583,11 @@ export function ConversationView({
                   key={virtualItem.index}
                   data-index={virtualItem.index}
                   ref={virtualizer.measureElement}
-                  className="absolute left-0 right-0 flex flex-col pb-4"
+                  className={`absolute left-0 right-0 flex flex-col ${
+                    layouts[virtualItem.index]?.runContinuesAfter
+                      ? "pb-0"
+                      : "pb-4"
+                  }`}
                   style={{ transform: `translateY(${virtualItem.start}px)` }}
                 >
                   {virtualItem.index === firstUnseenIndex && (
@@ -519,9 +597,11 @@ export function ConversationView({
                   )}
                   <MessageItem
                     message={messages[virtualItem.index]}
+                    layout={layouts[virtualItem.index]}
                     agentName={agentName}
                     toolResults={toolResults}
                     chatId={chat?.id ?? ""}
+                    expansion={expansion}
                   />
                 </div>
               ))}

--- a/web/src/conversation/SystemRow.tsx
+++ b/web/src/conversation/SystemRow.tsx
@@ -6,6 +6,8 @@ interface SystemRowProps {
   summary: string;
   /** The original content, revealed on expand. Empty when there is no more. */
   detail: string;
+  isExpanded: boolean;
+  onToggle: () => void;
 }
 
 /**
@@ -15,14 +17,28 @@ interface SystemRowProps {
  * so this only renders it and knows nothing about which Agent produced it
  * (ADR-0023). A gear marks it as machinery rather than something anyone wrote.
  */
-export function SystemRow({ summary, detail }: SystemRowProps) {
+export function SystemRow({
+  summary,
+  detail,
+  isExpanded,
+  onToggle,
+}: SystemRowProps) {
   return (
-    <CollapsibleRow icon={Cog} summary={summary}>
-      {detail ? (
-        <pre className="whitespace-pre-wrap break-words font-mono text-xs text-muted-foreground">
-          {detail}
-        </pre>
-      ) : null}
-    </CollapsibleRow>
+    // Not a skim-layer row, so it takes no part in a Run and carries its own
+    // spacing rather than inheriting a Run container's density (#236).
+    <div className="my-1">
+      <CollapsibleRow
+        icon={Cog}
+        summary={summary}
+        isExpanded={isExpanded}
+        onToggle={onToggle}
+      >
+        {detail ? (
+          <pre className="whitespace-pre-wrap break-words font-mono text-xs text-muted-foreground">
+            {detail}
+          </pre>
+        ) : null}
+      </CollapsibleRow>
+    </div>
   );
 }

--- a/web/src/conversation/runs.test.ts
+++ b/web/src/conversation/runs.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import type { Message } from "@/types";
+import { groupRuns } from "@/conversation/runs";
+
+function message(id: string, content: Message["content"]): Message {
+  return { id, role: "assistant", content, timestamp: "2026-07-22T00:00:00Z" };
+}
+
+function toolUse(id: string): Message["content"] {
+  return [{ type: "tool_use", id, name: "Bash", input: {} }];
+}
+
+describe("groupRuns", () => {
+  it("groups consecutive tool units into one Run, and ends it at message text", () => {
+    const runs = groupRuns([
+      message("m1", toolUse("t1")),
+      message("m2", toolUse("t2")),
+      message("m3", [{ type: "text", text: "Done." }]),
+      message("m4", toolUse("t3")),
+    ]);
+
+    expect(runs).toEqual([
+      {
+        rows: [
+          { messageId: "m1", blockIndex: 0 },
+          { messageId: "m2", blockIndex: 0 },
+        ],
+      },
+      { rows: [{ messageId: "m4", blockIndex: 0 }] },
+    ]);
+  });
+
+  it("keeps thinking inside the Run, across message boundaries", () => {
+    const runs = groupRuns([
+      message("m1", [
+        { type: "thinking", thinking: "Let me look." },
+        { type: "tool_use", id: "t1", name: "Read", input: {} },
+      ]),
+      message("m2", toolUse("t2")),
+      message("m3", [{ type: "thinking", thinking: "Now edit." }]),
+    ]);
+
+    expect(runs).toEqual([
+      {
+        rows: [
+          { messageId: "m1", blockIndex: 0 },
+          { messageId: "m1", blockIndex: 1 },
+          { messageId: "m2", blockIndex: 0 },
+          { messageId: "m3", blockIndex: 0 },
+        ],
+      },
+    ]);
+  });
+
+  it("splits a Run where text sits between blocks of one message", () => {
+    const runs = groupRuns([
+      message("m1", [
+        { type: "tool_use", id: "t1", name: "Bash", input: {} },
+        { type: "text", text: "Here's what I found." },
+        { type: "thinking", thinking: "Next." },
+      ]),
+    ]);
+
+    expect(runs).toEqual([
+      { rows: [{ messageId: "m1", blockIndex: 0 }] },
+      { rows: [{ messageId: "m1", blockIndex: 2 }] },
+    ]);
+  });
+
+  it("does not split a Run at a tool result, which renders nothing of its own", () => {
+    const runs = groupRuns([
+      message("m1", [
+        { type: "tool_use", id: "t1", name: "Bash", input: {} },
+        { type: "tool_result", tool_use_id: "t1", content: "ok" },
+        { type: "tool_use", id: "t2", name: "Bash", input: {} },
+      ]),
+    ]);
+
+    expect(runs).toEqual([
+      {
+        rows: [
+          { messageId: "m1", blockIndex: 0 },
+          { messageId: "m1", blockIndex: 2 },
+        ],
+      },
+    ]);
+  });
+});

--- a/web/src/conversation/runs.ts
+++ b/web/src/conversation/runs.ts
@@ -1,0 +1,171 @@
+import type { ContentBlock, Message } from "@/types";
+
+/** One skim-layer row, addressed by the Message that carries it. */
+export interface RowRef {
+  messageId: string;
+  blockIndex: number;
+}
+
+/**
+ * A consecutive stretch of skim-layer rows with no message text between them,
+ * presented as one tight visual group (see CONTEXT.md, #236).
+ */
+export interface Run {
+  rows: RowRef[];
+}
+
+function isSkimRow(block: ContentBlock): boolean {
+  return block.type === "tool_use" || block.type === "thinking";
+}
+
+/**
+ * Every Run in the Chat, in reading order.
+ *
+ * A pure function of the rendered Messages, so grouping is decided before
+ * layout rather than measured after it (#236).
+ */
+export function groupRuns(messages: Message[]): Run[] {
+  const runs: Run[] = [];
+  let current: RowRef[] = [];
+  const close = () => {
+    if (current.length > 0) runs.push({ rows: current });
+    current = [];
+  };
+
+  for (const message of messages) {
+    if (typeof message.content === "string") {
+      close();
+      continue;
+    }
+    message.content.forEach((block, blockIndex) => {
+      if (isSkimRow(block)) {
+        current.push({ messageId: message.id, blockIndex });
+        return;
+      }
+      // A result renders nothing on its own — it belongs to the call that
+      // produced it — so it neither starts a row nor breaks the stretch.
+      if (block.type === "tool_result") return;
+      close();
+    });
+  }
+  close();
+  return runs;
+}
+
+/** One message's content, cut into the pieces layout treats differently. */
+export type Segment =
+  | { kind: "run"; blockIndices: number[] }
+  | { kind: "block"; blockIndex: number };
+
+export interface MessageLayout {
+  segments: Segment[];
+  /** The message opens inside a Run that started in an earlier turn. */
+  runContinuesBefore: boolean;
+  /** The message closes inside a Run that carries on into a later turn. */
+  runContinuesAfter: boolean;
+}
+
+/**
+ * How each Message lays out, in the same order as the Messages given.
+ *
+ * The seam flags are what let a Run read as one group even though the Agent
+ * recorded it as many turns: the message boundaries inside a Run give up their
+ * spacing, so the rows sit a few pixels apart instead of forty (#236).
+ */
+export function planLayout(messages: Message[]): MessageLayout[] {
+  const runs = groupRuns(messages);
+  // Which run each row belongs to, so a message can tell a seam from an end.
+  const runIndexByRow = new Map<string, number>();
+  runs.forEach((run, runIndex) => {
+    for (const row of run.rows) {
+      runIndexByRow.set(rowKey(row.messageId, row.blockIndex), runIndex);
+    }
+  });
+
+  return messages.map((message, messageIndex) => {
+    const segments: Segment[] = [];
+    let openRun: Extract<Segment, { kind: "run" }> | null = null;
+    if (typeof message.content !== "string") {
+      message.content.forEach((block, blockIndex) => {
+        if (!runIndexByRow.has(rowKey(message.id, blockIndex))) {
+          if (block.type === "tool_result") return;
+          openRun = null;
+          segments.push({ kind: "block", blockIndex });
+          return;
+        }
+        if (openRun) {
+          openRun.blockIndices.push(blockIndex);
+          return;
+        }
+        openRun = { kind: "run", blockIndices: [blockIndex] };
+        segments.push(openRun);
+      });
+    }
+
+    return {
+      segments,
+      runContinuesBefore: sharesRun(
+        runIndexByRow,
+        firstRow(segments, message.id),
+        lastRowOf(messages[messageIndex - 1], runIndexByRow)
+      ),
+      runContinuesAfter: sharesRun(
+        runIndexByRow,
+        lastRow(segments, message.id),
+        firstRowOf(messages[messageIndex + 1], runIndexByRow)
+      ),
+    };
+  });
+}
+
+function rowKey(messageId: string, blockIndex: number): string {
+  return `${messageId}:${blockIndex}`;
+}
+
+function sharesRun(
+  runIndexByRow: Map<string, number>,
+  a: string | null,
+  b: string | null
+): boolean {
+  if (a === null || b === null) return false;
+  const runA = runIndexByRow.get(a);
+  return runA !== undefined && runA === runIndexByRow.get(b);
+}
+
+function firstRow(segments: Segment[], messageId: string): string | null {
+  const first = segments[0];
+  if (!first || first.kind !== "run") return null;
+  return rowKey(messageId, first.blockIndices[0]!);
+}
+
+function lastRow(segments: Segment[], messageId: string): string | null {
+  const last = segments[segments.length - 1];
+  if (!last || last.kind !== "run") return null;
+  return rowKey(messageId, last.blockIndices[last.blockIndices.length - 1]!);
+}
+
+function firstRowOf(
+  message: Message | undefined,
+  runIndexByRow: Map<string, number>
+): string | null {
+  if (!message || typeof message.content === "string") return null;
+  for (let i = 0; i < message.content.length; i += 1) {
+    const key = rowKey(message.id, i);
+    if (runIndexByRow.has(key)) return key;
+    if (message.content[i]!.type !== "tool_result") return null;
+  }
+  return null;
+}
+
+function lastRowOf(
+  message: Message | undefined,
+  runIndexByRow: Map<string, number>
+): string | null {
+  if (!message || typeof message.content === "string") return null;
+  for (let i = message.content.length - 1; i >= 0; i -= 1) {
+    const key = rowKey(message.id, i);
+    if (runIndexByRow.has(key)) return key;
+    if (message.content[i]!.type !== "tool_result") return null;
+  }
+  return null;
+}

--- a/web/src/conversation/useRowExpansion.ts
+++ b/web/src/conversation/useRowExpansion.ts
@@ -1,0 +1,46 @@
+import { useCallback, useMemo, useState } from "react";
+
+/** Whether each skim-layer row is open, and how to flip one. */
+export interface RowExpansion {
+  isExpanded: (messageId: string, blockIndex: number) => boolean;
+  toggle: (messageId: string, blockIndex: number) => void;
+}
+
+function key(messageId: string, blockIndex: number): string {
+  return `${messageId}:${blockIndex}`;
+}
+
+/**
+ * Which rows the reader has opened in this Chat, held above the rows themselves.
+ *
+ * Kept per chat rather than per row because the virtualizer keys rows by list
+ * position: a row scrolled out of view, or a message arriving above one, hands
+ * the row's component instance to different content, and state living in that
+ * instance would silently follow the position instead of the row (#236). Keyed
+ * by message id and block index, the two things that actually identify a row.
+ */
+export function useRowExpansion(chatId: string | undefined): RowExpansion {
+  const [openRows, setOpenRows] = useState<ReadonlySet<string>>(new Set());
+  // A different chat is a different set of rows, so nothing carries over.
+  const [seenChatId, setSeenChatId] = useState(chatId);
+  if (seenChatId !== chatId) {
+    setSeenChatId(chatId);
+    setOpenRows(new Set());
+  }
+
+  const isExpanded = useCallback(
+    (messageId: string, blockIndex: number) =>
+      openRows.has(key(messageId, blockIndex)),
+    [openRows]
+  );
+  const toggle = useCallback((messageId: string, blockIndex: number) => {
+    setOpenRows((current) => {
+      const next = new Set(current);
+      const rowKey = key(messageId, blockIndex);
+      if (!next.delete(rowKey)) next.add(rowKey);
+      return next;
+    });
+  }, []);
+
+  return useMemo(() => ({ isExpanded, toggle }), [isExpanded, toggle]);
+}


### PR DESCRIPTION
## Background (Why)

Claude Code records each tool call as its own assistant turn, so a stretch of eight commands rendered as eight separate messages — each paying full message padding and virtualizer spacing, roughly 40px of air between one-line rows. The result read as a column of stranded fragments rather than one burst of activity.

This introduces the **Run** (CONTEXT.md): a consecutive stretch of skim-layer rows — Tool units and thinking — with no message text between them, shown as one tight visual group.

Thinking belongs inside a Run. A stretch of "thinking, three tools, thinking, two tools" is one continuous piece of work to a reader skimming past it, and treating thinking as a boundary would shatter it into five islands.

## Approach (How)

Grouping is a memoized pure function over the rendered messages, never a layout-time measurement. `groupRuns()` walks the blocks and returns each Run as a list of `(messageId, blockIndex)` rows; `planLayout()` turns that into per-message segments plus two seam flags. The seams are what let a Run read as one group even though the Agent recorded it as many turns: the message boundaries inside a Run give up their padding, so the rows sit 2px apart instead of 40.

Expansion state moves out of the individual rows into a per-chat map keyed by message id and block index, and the row components become controlled. That state could not survive where it was: the virtualizer keys rows by list position, so scrolling a row away — or a message arriving above one — handed its component instance to different content and the row silently closed. This map is also the ground the Run summary fold (#199) and remembered collapse state build on.

A `tool_result` block neither starts a row nor breaks a Run: it renders nothing of its own, since the result belongs to the call that produced it.

## Changes (What)

- [x] `runs.ts` — `groupRuns()` and `planLayout()`, pure and memoized in `ConversationView`
- [x] `useRowExpansion.ts` — per-chat expansion map keyed by message id and block index, reset when the chat changes
- [x] `CollapsibleRow` / `CollapsibleThinking` / `CollapsibleToolCall` / `SystemRow` become controlled, and a single row no longer carries its own vertical margin — spacing is the container's job
- [x] `ConversationView` renders by segment: a Run's rows share one container, and the seams drop their padding at both the message and virtual-item level

### Test Verification

- [x] Consecutive Tool units group into one Run; message text ends it
- [x] A Run mixes thinking and Tool units and crosses message boundaries
- [x] Text between blocks of one message splits the Run in two
- [x] A `tool_result` does not split a Run
- [x] An expanded row stays open when a message arrives above it and the virtualizer hands its slot to different content
- [x] Two rows of one turn are remembered separately; a different chat opens with every row closed
- [x] **Measured in a real browser** (Playwright): rows within a Run sit under 8px apart across turns (2px in practice, down from ~40px), and prose keeps more than 16px from the Run that follows

## Additional Notes

The spacing assertions live in `web/e2e/run-grouping.spec.ts` rather than the component tests on purpose: every box measures zero in jsdom, and the component tests were fully green while the real gap was still 12px.

The Run summary fold is deliberately not here — it is #199, and it builds on this expansion map.

## Related Links

- Closes #236
- Unblocks #199, and through it #238