### PR TITLE
feat(web): fold a long Run into one summary row

### DIFF
--- a/web/e2e/run-grouping.spec.ts
+++ b/web/e2e/run-grouping.spec.ts
@@ -95,6 +95,9 @@ test.describe("Run density", () => {
     page,
   }) => {
     await openRunChat(page);
+    // Three calls in a row arrive folded (#199); the density claim is about the
+    // rows themselves, so open them first.
+    await page.getByRole("button", { name: /Read 3 files/ }).click();
 
     const a = await rowTop(page, "/a\\.ts");
     const b = await rowTop(page, "/b\\.ts");
@@ -117,5 +120,26 @@ test.describe("Run density", () => {
       .boundingBox())!;
 
     expect(thinking.y - (prose.y + prose.height)).toBeGreaterThan(16);
+  });
+});
+
+test.describe("Folded Run", () => {
+  test("costs one row's height, with no stray air from the turns it swallows", async ({
+    page,
+  }) => {
+    await openRunChat(page);
+
+    const thinking = (await page
+      .getByRole("button", { name: /Thinking/ })
+      .boundingBox())!;
+    const summary = (await page
+      .getByRole("button", { name: /Read 3 files/ })
+      .boundingBox())!;
+
+    // The three turns behind the summary are skipped outright rather than left
+    // as empty blocks, which would stack up as padding under the fold — the
+    // kind of gap only a real browser can see (#199).
+    expect(summary.y - (thinking.y + thinking.height)).toBeLessThan(8);
+    expect(summary.height).toBeLessThan(32);
   });
 });

--- a/web/src/conversation/CollapsibleRow.tsx
+++ b/web/src/conversation/CollapsibleRow.tsx
@@ -20,6 +20,12 @@ interface CollapsibleRowProps {
    * open onto nothing.
    */
   children?: ReactNode;
+  /**
+   * Forces the toggle on for a row whose detail is drawn outside it. A fold's
+   * units stay with the turns that recorded them, so the summary row opens onto
+   * siblings rather than children (#199).
+   */
+  isExpandable?: boolean;
 }
 
 /**
@@ -36,8 +42,9 @@ export function CollapsibleRow({
   isExpanded,
   onToggle,
   children,
+  isExpandable,
 }: CollapsibleRowProps) {
-  if (!children) {
+  if (!children && !isExpandable) {
     return (
       <div>
         <div className="flex w-full items-center gap-1.5 px-1.5 py-1 text-xs text-muted-foreground">
@@ -79,7 +86,7 @@ export function CollapsibleRow({
           />
         )}
       </button>
-      {isExpanded && (
+      {isExpanded && children && (
         <div
           data-testid="unit-detail"
           // The rule marks the detail's extent, so an expanded unit reads as a

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -1183,6 +1183,82 @@ describe("Run grouping", () => {
   });
 });
 
+describe("Folding a long Run", () => {
+  function ran(id: string, command: string): Message {
+    return {
+      id,
+      role: "assistant",
+      content: [
+        { type: "tool_use", id: `t-${id}`, name: "Bash", input: { command } },
+      ],
+      timestamp: "2024-01-01T00:00:00Z",
+    };
+  }
+
+  const longRun: Message[] = [
+    ran("m-1", "pnpm test"),
+    ran("m-2", "git status"),
+    ran("m-3", "git diff"),
+  ];
+
+  it("shows a long stretch of tool calls as one row that names what happened", async () => {
+    render(<ConversationView chat={chat} messages={longRun} />);
+
+    expect(
+      await screen.findByRole("button", { name: /Ran 3 commands/ })
+    ).toBeTruthy();
+    // The wall is gone: the individual commands wait behind the summary.
+    expect(screen.queryByText(/pnpm test/)).toBeNull();
+  });
+
+  it("opens onto the individual units, each still expandable on its own", async () => {
+    const user = userEvent.setup();
+    render(<ConversationView chat={chat} messages={longRun} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: /Ran 3 commands/ })
+    );
+
+    // Every unit arrives closed — including the first, which the fold is
+    // anchored at and once shared an open/closed key with (#199).
+    expect(screen.getByRole("button", { name: /pnpm test/ })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+    const command = screen.getByRole("button", { name: /git diff/ });
+    expect(command).toHaveAttribute("aria-expanded", "false");
+    await user.click(command);
+    expect(screen.getByRole("button", { name: /git diff/ })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  it("never hides thinking behind the summary", async () => {
+    render(
+      <ConversationView
+        chat={chat}
+        messages={[
+          {
+            id: "m-0",
+            role: "assistant",
+            content: [{ type: "thinking", thinking: "weighing the options" }],
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+          ...longRun,
+        ]}
+      />
+    );
+
+    // A summary reading `Ran 3 commands` would be lying if a paragraph of
+    // reasoning sat behind it, so thinking keeps its own row (#199).
+    expect(
+      await screen.findByRole("button", { name: /Thinking/ })
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Ran 3 commands/ })).toBeTruthy();
+  });
+});
+
 describe("Row expansion", () => {
   function tool(id: string, path: string): Message {
     return {
@@ -1220,7 +1296,14 @@ describe("Row expansion", () => {
       <ConversationView
         chat={chat}
         messages={[
-          tool("m-new", "/new.ts"),
+          // Prose rather than a third tool call: three in a row would fold, and
+          // this is about the shift, not the fold (#199).
+          {
+            id: "m-new",
+            role: "assistant",
+            content: "Starting over.",
+            timestamp: "2024-01-01T00:00:00Z",
+          },
           tool("m-a", "/a.ts"),
           tool("m-b", "/b.ts"),
         ]}
@@ -1233,9 +1316,6 @@ describe("Row expansion", () => {
     // and no neighbour inherited it
     expect(
       screen.getByRole("button", { name: /Read: \/a\.ts/ })
-    ).toHaveAttribute("aria-expanded", "false");
-    expect(
-      screen.getByRole("button", { name: /Read: \/new\.ts/ })
     ).toHaveAttribute("aria-expanded", "false");
   });
   it("remembers each row of a turn separately", async () => {

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { RotateCcw } from "lucide-react";
 import type { Message, ContentBlock, Chat, Tag } from "@/types";
@@ -29,7 +36,12 @@ import {
   collectToolResults,
   type ToolResultBlock,
 } from "@/conversation/toolUnits";
-import { planLayout, type MessageLayout } from "@/conversation/runs";
+import {
+  planLayout,
+  type MessageLayout,
+  type RunEntry,
+} from "@/conversation/folds";
+import { FoldSummaryRow } from "@/conversation/FoldSummaryRow";
 import {
   useRowExpansion,
   type RowExpansion,
@@ -244,16 +256,77 @@ function renderContent(
       // The Run's own container: its rows sit a few pixels apart, where prose
       // around them keeps its breathing room. The contrast is the point (#236).
       <div
-        key={`run-${segment.blockIndices[0]}`}
+        key={`run-${entryKey(segment.entries[0]!)}`}
         data-testid="run"
         className="flex flex-col gap-0.5"
       >
-        {segment.blockIndices.map((blockIndex) =>
-          renderContentBlock(content[blockIndex]!, blockIndex, context)
+        {segment.entries.map((entry) =>
+          renderRunEntry(entry, content, context)
         )}
       </div>
     );
   });
+}
+
+function entryKey(entry: RunEntry): string {
+  return entry.kind === "unit"
+    ? `unit-${entry.blockIndex}`
+    : `fold-${entry.foldId}-${entry.blockIndices[0]}`;
+}
+
+function renderRunEntry(
+  entry: RunEntry,
+  content: ContentBlock[],
+  context: RenderContext
+) {
+  if (entry.kind === "unit") {
+    return renderContentBlock(
+      content[entry.blockIndex]!,
+      entry.blockIndex,
+      context
+    );
+  }
+
+  const isExpanded = context.expansion.isKeyExpanded(entry.foldId);
+  const units =
+    isExpanded &&
+    entry.blockIndices.map((blockIndex) =>
+      renderContentBlock(content[blockIndex]!, blockIndex, context)
+    );
+
+  return (
+    <Fragment key={entryKey(entry)}>
+      {/* Only the turn the fold starts in draws the summary; the turns it
+          swallows draw their units or nothing at all (#199). */}
+      {entry.isAnchor && (
+        <FoldSummaryRow
+          summary={entry.summary}
+          isExpanded={isExpanded}
+          onToggle={() => context.expansion.toggleKey(entry.foldId)}
+        />
+      )}
+      {units}
+    </Fragment>
+  );
+}
+
+/**
+ * Whether a Message has nothing left to draw because a fold anchored in an
+ * earlier turn is holding all of it. Such a turn is skipped outright rather
+ * than left as an empty block, which would stack up as stray padding.
+ */
+function isFoldedAway(layout: MessageLayout, expansion: RowExpansion): boolean {
+  if (layout.segments.length === 0) return false;
+  return layout.segments.every(
+    (segment) =>
+      segment.kind === "run" &&
+      segment.entries.every(
+        (entry) =>
+          entry.kind === "fold" &&
+          !entry.isAnchor &&
+          !expansion.isKeyExpanded(entry.foldId)
+      )
+  );
 }
 
 // An effort is already a readable word, so it needs no id→name table the way a
@@ -289,6 +362,7 @@ function MessageItem({
   chatId: string;
   expansion: RowExpansion;
 }) {
+  if (isFoldedAway(layout, expansion)) return null;
   const copyValue = messageToMarkdown(message);
   // A Run recorded as several turns gives up the padding at its seams, so the
   // stretch reads as one group rather than a column of fragments (#236).

--- a/web/src/conversation/FoldSummaryRow.tsx
+++ b/web/src/conversation/FoldSummaryRow.tsx
@@ -1,0 +1,31 @@
+import { Layers } from "lucide-react";
+import { CollapsibleRow } from "@/conversation/CollapsibleRow";
+
+interface FoldSummaryRowProps {
+  summary: string;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * The one row a folded stretch of Tool units collapses to (#199).
+ *
+ * It carries no detail of its own: opening it puts the units back on screen,
+ * each still opening independently, and those units belong to the turns that
+ * recorded them rather than to this row.
+ */
+export function FoldSummaryRow({
+  summary,
+  isExpanded,
+  onToggle,
+}: FoldSummaryRowProps) {
+  return (
+    <CollapsibleRow
+      icon={Layers}
+      summary={summary}
+      isExpanded={isExpanded}
+      onToggle={onToggle}
+      isExpandable
+    />
+  );
+}

--- a/web/src/conversation/folds.test.ts
+++ b/web/src/conversation/folds.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import type { ContentBlock, Message } from "@/types";
+import { planFolds, planLayout } from "@/conversation/folds";
+
+function message(id: string, content: ContentBlock[]): Message {
+  return { id, role: "assistant", content, timestamp: "2026-07-22T00:00:00Z" };
+}
+
+function tool(id: string, name: string): Message {
+  return message(id, [{ type: "tool_use", id, name, input: {} }]);
+}
+
+function bash(id: string): Message {
+  return tool(id, "Bash");
+}
+
+function summaryOf(messages: Message[]): string | undefined {
+  return planFolds(messages)[0]?.summary;
+}
+
+describe("planFolds", () => {
+  it("folds three consecutive commands recorded as separate turns into one row", () => {
+    const folds = planFolds([bash("t1"), bash("t2"), bash("t3")]);
+
+    expect(folds).toEqual([
+      {
+        rows: [
+          { messageId: "t1", blockIndex: 0 },
+          { messageId: "t2", blockIndex: 0 },
+          { messageId: "t3", blockIndex: 0 },
+        ],
+        summary: "Ran 3 commands",
+      },
+    ]);
+  });
+
+  it("leaves one or two units alone — folding them would only add a click", () => {
+    expect(planFolds([bash("t1")])).toEqual([]);
+    expect(planFolds([bash("t1"), bash("t2")])).toEqual([]);
+  });
+
+  it("breaks the count at thinking, which a summary must never hide", () => {
+    const folds = planFolds([
+      bash("t1"),
+      bash("t2"),
+      message("m3", [{ type: "thinking", thinking: "Now let me check." }]),
+      bash("t3"),
+      bash("t4"),
+      bash("t5"),
+    ]);
+
+    expect(folds).toEqual([
+      {
+        rows: [
+          { messageId: "t3", blockIndex: 0 },
+          { messageId: "t4", blockIndex: 0 },
+          { messageId: "t5", blockIndex: 0 },
+        ],
+        summary: "Ran 3 commands",
+      },
+    ]);
+  });
+
+  it("names what happened, largest group first", () => {
+    const summary = summaryOf([
+      bash("t1"),
+      tool("t2", "Edit"),
+      bash("t3"),
+      bash("t4"),
+      tool("t5", "Edit"),
+      bash("t6"),
+      bash("t7"),
+      bash("t8"),
+    ]);
+
+    expect(summary).toBe("Ran 6 commands, edited 2 files");
+  });
+
+  it("writes a group of one in the singular", () => {
+    const summary = summaryOf([bash("t1"), bash("t2"), tool("t3", "Write")]);
+
+    expect(summary).toBe("Ran 2 commands, wrote 1 file");
+  });
+
+  it("elides everything past the two largest groups", () => {
+    const summary = summaryOf([
+      bash("t1"),
+      bash("t2"),
+      bash("t3"),
+      tool("t4", "Edit"),
+      tool("t5", "Edit"),
+      tool("t6", "Read"),
+      tool("t7", "Write"),
+    ]);
+
+    expect(summary).toBe("Ran 3 commands, edited 2 files, +2 more");
+  });
+
+  it("falls back to a plain count when nothing fits a known group", () => {
+    const summary = summaryOf([
+      tool("t1", "WebFetch"),
+      tool("t2", "TodoWrite"),
+      tool("t3", "WebSearch"),
+    ]);
+
+    expect(summary).toBe("Ran 3 tools");
+  });
+});
+
+describe("planLayout", () => {
+  it("anchors a fold at its first unit, and marks the turns it swallows", () => {
+    const layouts = planLayout([bash("t1"), bash("t2"), bash("t3")]);
+
+    expect(layouts.map((layout) => layout.segments)).toEqual([
+      [
+        {
+          kind: "run",
+          entries: [
+            {
+              kind: "fold",
+              foldId: "fold:t1:0",
+              summary: "Ran 3 commands",
+              blockIndices: [0],
+              isAnchor: true,
+            },
+          ],
+        },
+      ],
+      [
+        {
+          kind: "run",
+          entries: [
+            {
+              kind: "fold",
+              foldId: "fold:t1:0",
+              summary: "Ran 3 commands",
+              blockIndices: [0],
+              isAnchor: false,
+            },
+          ],
+        },
+      ],
+      [
+        {
+          kind: "run",
+          entries: [
+            {
+              kind: "fold",
+              foldId: "fold:t1:0",
+              summary: "Ran 3 commands",
+              blockIndices: [0],
+              isAnchor: false,
+            },
+          ],
+        },
+      ],
+    ]);
+  });
+
+  it("leaves an unfolded unit as a plain entry beside a fold", () => {
+    const layouts = planLayout([
+      message("m1", [
+        { type: "thinking", thinking: "Let me look." },
+        { type: "tool_use", id: "t1", name: "Read", input: {} },
+        { type: "tool_use", id: "t2", name: "Read", input: {} },
+        { type: "tool_use", id: "t3", name: "Read", input: {} },
+      ]),
+    ]);
+
+    expect(layouts[0]!.segments).toEqual([
+      {
+        kind: "run",
+        entries: [
+          { kind: "unit", blockIndex: 0 },
+          {
+            kind: "fold",
+            foldId: "fold:m1:1",
+            summary: "Read 3 files",
+            blockIndices: [1, 2, 3],
+            isAnchor: true,
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/web/src/conversation/folds.ts
+++ b/web/src/conversation/folds.ts
@@ -1,0 +1,252 @@
+import type { ContentBlock, Message } from "@/types";
+import {
+  groupRuns,
+  planRunLayout,
+  rowKeyOf,
+  type RowRef,
+} from "@/conversation/runs";
+
+type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
+
+/**
+ * A stretch of Tool units inside a Run, shown as one summary row (#199).
+ *
+ * A Run of eight commands is a wall. Folded, the reader learns what the stretch
+ * was about without opening it.
+ */
+export interface Fold {
+  rows: RowRef[];
+  summary: string;
+}
+
+// One or two units are already quiet enough on their own, and folding them
+// would only add a click (#199).
+const FOLD_THRESHOLD = 3;
+
+/**
+ * Every Fold in the Chat, in reading order.
+ *
+ * A pure function of the Messages, like the Run grouping it builds on (#236).
+ */
+export function planFolds(messages: Message[]): Fold[] {
+  const blockAt = blockLookup(messages);
+  const folds: Fold[] = [];
+
+  for (const run of groupRuns(messages)) {
+    // Thinking is a boundary even though it sits inside the Run for spacing:
+    // a summary reading `Ran 6 commands` must not be hiding a paragraph of
+    // reasoning behind it, or the label would be lying (#199).
+    for (const stretch of splitOnThinking(run.rows, blockAt)) {
+      if (stretch.length < FOLD_THRESHOLD) continue;
+      folds.push({
+        rows: stretch,
+        summary: foldSummary(
+          stretch.map((row) => blockAt(row) as ToolUseBlock)
+        ),
+      });
+    }
+  }
+  return folds;
+}
+
+/** One thing the view draws inside a Run's container. */
+export type RunEntry =
+  | { kind: "unit"; blockIndex: number }
+  | {
+      kind: "fold";
+      /**
+       * The fold's identity, and the key its open state is remembered under.
+       * Namespaced away from the row keys: a fold is anchored at its first unit
+       * and would otherwise share that unit's key, so opening the summary would
+       * open that one unit along with it (#199).
+       */
+      foldId: string;
+      summary: string;
+      /** The fold's units carried by *this* Message. */
+      blockIndices: number[];
+      /** Whether the summary row itself is drawn here. */
+      isAnchor: boolean;
+    };
+
+export type FoldedSegment =
+  | { kind: "block"; blockIndex: number }
+  | { kind: "run"; entries: RunEntry[] };
+
+export interface MessageLayout {
+  segments: FoldedSegment[];
+  runContinuesBefore: boolean;
+  runContinuesAfter: boolean;
+}
+
+/**
+ * How each Message lays out, in the same order as the Messages given.
+ *
+ * A fold routinely spans turns — an Agent records six commands as six of them —
+ * so the summary row is anchored at the fold's first unit and the turns after
+ * it carry the same `foldId` without an anchor. Collapsed, those turns draw
+ * nothing; expanded, each draws its own units, which is what keeps a unit
+ * independently expandable inside an open fold (#199).
+ */
+export function planLayout(messages: Message[]): MessageLayout[] {
+  const foldByRow = new Map<string, Fold>();
+  for (const fold of planFolds(messages)) {
+    for (const row of fold.rows) foldByRow.set(rowKeyOf(row), fold);
+  }
+
+  const runLayouts = planRunLayout(messages);
+  return messages.map((message, index) => {
+    const runLayout = runLayouts[index]!;
+    return {
+      runContinuesBefore: runLayout.runContinuesBefore,
+      runContinuesAfter: runLayout.runContinuesAfter,
+      segments: runLayout.segments.map((segment) => {
+        if (segment.kind === "block") return segment;
+        return {
+          kind: "run",
+          entries: foldEntries(message, segment.blockIndices, foldByRow),
+        };
+      }),
+    };
+  });
+}
+
+function foldEntries(
+  message: Message,
+  blockIndices: number[],
+  foldByRow: Map<string, Fold>
+): RunEntry[] {
+  const entries: RunEntry[] = [];
+
+  for (const blockIndex of blockIndices) {
+    const rowKey = rowKeyOf({ messageId: message.id, blockIndex });
+    const fold = foldByRow.get(rowKey);
+    if (!fold) {
+      entries.push({ kind: "unit", blockIndex });
+      continue;
+    }
+    const anchor = rowKeyOf(fold.rows[0]!);
+    const foldId = `fold:${anchor}`;
+    const last = entries[entries.length - 1];
+    if (last?.kind === "fold" && last.foldId === foldId) {
+      last.blockIndices.push(blockIndex);
+      continue;
+    }
+    entries.push({
+      kind: "fold",
+      foldId,
+      summary: fold.summary,
+      blockIndices: [blockIndex],
+      isAnchor: anchor === rowKey,
+    });
+  }
+  return entries;
+}
+
+/** What a tool did, in the reader's terms rather than the tool's name. */
+interface Action {
+  verb: string;
+  noun: string;
+}
+
+// Grouped by what the tool did, not by which tool ran: a reader skimming a
+// folded stretch wants to know it was six commands, not six Bashes. Reading and
+// searching land in one group — both are the Agent looking things up (#199).
+//
+// `wrote` rather than `created` because Write covers both a new file and an
+// overwrite, and the summary sits one click above rows that already say
+// `Wrote foo.ts +12 -0`. One act, one word, at both densities.
+const ACTIONS: Record<string, Action> = {
+  Bash: { verb: "ran", noun: "command" },
+  Edit: { verb: "edited", noun: "file" },
+  MultiEdit: { verb: "edited", noun: "file" },
+  Write: { verb: "wrote", noun: "file" },
+  Read: { verb: "read", noun: "file" },
+  Grep: { verb: "read", noun: "file" },
+  Glob: { verb: "read", noun: "file" },
+};
+
+// Two groups is what a one-line summary carries before it stops being skimmable.
+const MAX_NAMED_GROUPS = 2;
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function capitalize(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+/**
+ * What a folded stretch of Tool units did, in one line.
+ *
+ * A pure function of the units, so the row can be planned before layout.
+ */
+export function foldSummary(blocks: ToolUseBlock[]): string {
+  const groups = new Map<string, { action: Action; count: number }>();
+  // A tool that fits no group still happened, so it is counted in the
+  // remainder rather than dropped — the summary would otherwise hide it.
+  let unknown = 0;
+  for (const block of blocks) {
+    const action = ACTIONS[block.name];
+    if (!action) {
+      unknown += 1;
+      continue;
+    }
+    const key = `${action.verb} ${action.noun}`;
+    const group = groups.get(key);
+    if (group) group.count += 1;
+    else groups.set(key, { action, count: 1 });
+  }
+
+  // Largest first, and insertion order breaks a tie, so equal groups read in
+  // the order they happened.
+  const ranked = [...groups.values()].sort((a, b) => b.count - a.count);
+  // Nothing to name: say how much happened rather than nothing at all.
+  if (ranked.length === 0) return capitalize(`ran ${plural(unknown, "tool")}`);
+  const named = ranked.slice(0, MAX_NAMED_GROUPS);
+
+  const phrases = named.map(
+    ({ action, count }) => `${action.verb} ${plural(count, action.noun)}`
+  );
+
+  const remainder =
+    unknown +
+    ranked
+      .slice(MAX_NAMED_GROUPS)
+      .reduce((total, group) => total + group.count, 0);
+  if (remainder > 0) phrases.push(`+${remainder} more`);
+
+  return capitalize(phrases.join(", "));
+}
+
+function blockLookup(
+  messages: Message[]
+): (row: RowRef) => ContentBlock | undefined {
+  const byId = new Map<string, Message>();
+  for (const message of messages) byId.set(message.id, message);
+  return (row) => {
+    const content = byId.get(row.messageId)?.content;
+    if (!content || typeof content === "string") return undefined;
+    return content[row.blockIndex];
+  };
+}
+
+/** The Run's rows, cut into runs of Tool units wherever thinking interrupts. */
+function splitOnThinking(
+  rows: RowRef[],
+  blockAt: (row: RowRef) => ContentBlock | undefined
+): RowRef[][] {
+  const stretches: RowRef[][] = [];
+  let current: RowRef[] = [];
+  for (const row of rows) {
+    const block = blockAt(row);
+    if (block?.type === "tool_use") {
+      current.push(row);
+      continue;
+    }
+    if (current.length > 0) stretches.push(current);
+    current = [];
+  }
+  if (current.length > 0) stretches.push(current);
+  return stretches;
+}

--- a/web/src/conversation/runs.ts
+++ b/web/src/conversation/runs.ts
@@ -24,6 +24,10 @@ function isSkimRow(block: ContentBlock): boolean {
  * A pure function of the rendered Messages, so grouping is decided before
  * layout rather than measured after it (#236).
  */
+export function rowKeyOf(row: RowRef): string {
+  return rowKey(row.messageId, row.blockIndex);
+}
+
 export function groupRuns(messages: Message[]): Run[] {
   const runs: Run[] = [];
   let current: RowRef[] = [];
@@ -57,7 +61,7 @@ export type Segment =
   | { kind: "run"; blockIndices: number[] }
   | { kind: "block"; blockIndex: number };
 
-export interface MessageLayout {
+export interface RunLayout {
   segments: Segment[];
   /** The message opens inside a Run that started in an earlier turn. */
   runContinuesBefore: boolean;
@@ -66,13 +70,14 @@ export interface MessageLayout {
 }
 
 /**
- * How each Message lays out, in the same order as the Messages given.
+ * How each Message lays out once Runs are grouped, in the order given.
  *
  * The seam flags are what let a Run read as one group even though the Agent
  * recorded it as many turns: the message boundaries inside a Run give up their
- * spacing, so the rows sit a few pixels apart instead of forty (#236).
+ * spacing, so the rows sit a few pixels apart instead of forty (#236). The
+ * folding pass refines this into what the view renders (see `folds.ts`).
  */
-export function planLayout(messages: Message[]): MessageLayout[] {
+export function planRunLayout(messages: Message[]): RunLayout[] {
   const runs = groupRuns(messages);
   // Which run each row belongs to, so a message can tell a seam from an end.
   const runIndexByRow = new Map<string, number>();

--- a/web/src/conversation/useRowExpansion.ts
+++ b/web/src/conversation/useRowExpansion.ts
@@ -4,6 +4,13 @@ import { useCallback, useMemo, useState } from "react";
 export interface RowExpansion {
   isExpanded: (messageId: string, blockIndex: number) => boolean;
   toggle: (messageId: string, blockIndex: number) => void;
+  /**
+   * The same two questions, asked with a row key already in hand. A fold is
+   * identified by the key of the unit it is anchored at, and that key travels
+   * through the layout rather than being taken apart again (#199).
+   */
+  isKeyExpanded: (rowKey: string) => boolean;
+  toggleKey: (rowKey: string) => void;
 }
 
 function key(messageId: string, blockIndex: number): string {
@@ -28,19 +35,31 @@ export function useRowExpansion(chatId: string | undefined): RowExpansion {
     setOpenRows(new Set());
   }
 
-  const isExpanded = useCallback(
-    (messageId: string, blockIndex: number) =>
-      openRows.has(key(messageId, blockIndex)),
+  const isKeyExpanded = useCallback(
+    (rowKey: string) => openRows.has(rowKey),
     [openRows]
   );
-  const toggle = useCallback((messageId: string, blockIndex: number) => {
+  const toggleKey = useCallback((rowKey: string) => {
     setOpenRows((current) => {
       const next = new Set(current);
-      const rowKey = key(messageId, blockIndex);
       if (!next.delete(rowKey)) next.add(rowKey);
       return next;
     });
   }, []);
 
-  return useMemo(() => ({ isExpanded, toggle }), [isExpanded, toggle]);
+  const isExpanded = useCallback(
+    (messageId: string, blockIndex: number) =>
+      isKeyExpanded(key(messageId, blockIndex)),
+    [isKeyExpanded]
+  );
+  const toggle = useCallback(
+    (messageId: string, blockIndex: number) =>
+      toggleKey(key(messageId, blockIndex)),
+    [toggleKey]
+  );
+
+  return useMemo(
+    () => ({ isExpanded, toggle, isKeyExpanded, toggleKey }),
+    [isExpanded, toggle, isKeyExpanded, toggleKey]
+  );
 }


### PR DESCRIPTION
## Background (Why)

A Run of eight consecutive commands is a wall. Grouping them (#236) pulled the rows together, but a long stretch of tool traffic still costs the reader a screen of scrolling to get past something they never wanted to read. Folding was originally deferred pending evidence that long tool runs are noisy; that evidence arrived.

## Approach (How)

The fold is planned, not measured — a pure function of the Messages, layered on top of the Run grouping the same way the Run grouping is layered on the Messages.

A fold routinely spans turns, because an Agent records six commands as six of them. So the summary row is anchored at the fold's first unit, and the turns it swallows carry the same `foldId` without an anchor. Collapsed, those turns draw nothing at all (the `MessageItem` returns `null`, so they leave no stray padding under the fold). Expanded, each draws its own units — which is what keeps every unit independently expandable inside an open fold, with no state moved out of the rows that own it.

Thinking is a boundary. It sits inside a Run for spacing, but a summary reading `Ran 6 commands` must not be hiding a paragraph of reasoning behind it, or the label would be lying.

`runs.ts` keeps its job (Run structure, seam flags) under the name `planRunLayout`; the new `folds.ts` refines that into what the view renders.

## Changes (What)

- [ ] `folds.ts` — `planFolds` groups three or more consecutive Tool units within a Run, breaking at thinking; `foldSummary` names the two largest action groups in plain language; `planLayout` turns Run segments into entries the view can draw
- [ ] Tools are grouped by what they did, not which tool ran: commands run, files edited, files written, files read or searched. `Write` reads as "wrote" rather than "created" — it covers both a new file and an overwrite, and the row one click below already says `Wrote foo.ts +12 -0`
- [ ] `FoldSummaryRow` — the collapsed row, sharing `CollapsibleRow`'s visual language so the fold cannot drift from the units it hides
- [ ] `CollapsibleRow` gains `isExpandable`, for a row whose detail is drawn outside it; `useRowExpansion` gains a key-based pair, since a fold is identified by a key rather than a message and index
- [ ] Fold keys are namespaced (`fold:<rowKey>`) away from row keys — without this a fold shares its anchor unit's key, and opening the summary silently opens that one unit too

### Test Verification

- [ ] Threshold boundary: three units fold, one or two render as individual rows
- [ ] The summary names the two largest groups, largest first, singular for a group of one
- [ ] Everything past the two largest groups elides to `+N more`, including tools that fit no group
- [ ] A stretch matching no known group falls back to `Ran N tools`
- [ ] Thinking splits the Tool units around it into separately-counted folds
- [ ] A fold spanning three turns anchors at the first and marks the rest
- [ ] Expanding reveals the units, each still independently expandable — and every one arrives closed, including the anchor
- [ ] e2e (measured in a real browser): a folded Run costs one row's height with no stray air from the turns it swallows; the Run density claim from #236 still holds once the fold is open

## Additional Notes

The Run density e2e from #236 now opens the fold before measuring, since its three calls arrive folded. One component test that relied on three consecutive tool turns was changed to use prose instead — its subject is the virtualizer shift, not the fold.

The anchor-key collision was found by the e2e, not by the component tests: jsdom measures every box at zero, so the extra 70px of an unintentionally-open unit was invisible there.

`Write` could in principle be split into created vs overwritten (`structuredPatch` carries `oldLines`), but that would cost the summary its purity, and a stretch doing both would spend two named slots on one distinction the reader does not need at skim density.

## Related Links

- Closes #199
- Builds on #236 (Run grouping)