### PR TITLE
feat: render an expanded edit as a diff

### DIFF
--- a/api/src/ingestion/renormalize.ts
+++ b/api/src/ingestion/renormalize.ts
@@ -77,9 +77,11 @@ export function renormalizeFromRaw({
  * chips in chats archived before the rule existed: version 6. #234 captures the
  * per-message reasoning `effort`, backfilling it onto archived rows: version 7.
  * #235 carries an edit's `filePath` and `patch` into the tool result, so
- * archived edits can summarise as a diff: version 8.
+ * archived edits can summarise as a diff: version 8. #237 synthesizes an all-add
+ * patch for a new-file Write, which records none, so archived creates render as
+ * a diff instead of raw JSON: version 9.
  */
-export const NORMALIZE_VERSION = 8;
+export const NORMALIZE_VERSION = 9;
 
 export interface RunRenormalizeIfStaleOptions {
   plugins: readonly AgentPlugin[];

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -412,6 +412,52 @@ describe("ClaudeCodePlugin.normalize", () => {
     ]);
   });
 
+  it("synthesizes an all-add patch for a new-file Write, which records none", () => {
+    // A create records the whole file in `content` and leaves `structuredPatch`
+    // empty — Claude Code does not diff a new file into hunks. The patch is
+    // synthesized from the content so the UI can render it like any other edit.
+    const result = plugin.normalize(
+      rawRecord({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "tool-2", content: "ok" },
+          ],
+        },
+        toolUseResult: {
+          type: "create",
+          filePath: "/repo/new.ts",
+          content: "one\ntwo\n",
+          structuredPatch: [],
+          originalFile: "",
+        },
+        isMeta: false,
+        isSidechain: false,
+        uuid: "msg-10b",
+        timestamp: "2024-01-01T00:00:10Z",
+      })
+    );
+
+    expect(result?.blocks).toEqual([
+      {
+        type: "tool_result",
+        toolUseId: "tool-2",
+        content: "ok",
+        filePath: "/repo/new.ts",
+        patch: [
+          {
+            oldStart: 0,
+            oldLines: 0,
+            newStart: 1,
+            newLines: 2,
+            lines: ["+one", "+two"],
+          },
+        ],
+      },
+    ]);
+  });
+
   it("leaves both fields off a result that edited no file", () => {
     const result = plugin.normalize(
       rawRecord({

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -427,6 +427,11 @@ function normalizeBlock(
 // the file they touched and the unified-diff hunks they produced. Every other
 // tool records something else, so the shape itself is the test — no tool-name
 // table to keep in step with the Agent.
+//
+// A new-file Write is the exception: it records the whole file in `content` and
+// leaves `structuredPatch` empty, since there is nothing to diff against. The
+// patch is synthesized from that content as one all-add hunk so the file reads
+// as a diff like every other edit, rather than falling back to raw JSON.
 function editedFile(
   toolUseResult: unknown
 ): { filePath: string; patch: PatchHunk[] } | Record<string, never> {
@@ -434,9 +439,26 @@ function editedFile(
   const r = toolUseResult as Record<string, unknown>;
   if (typeof r.filePath !== "string" || !r.filePath) return {};
   if (!Array.isArray(r.structuredPatch)) return {};
+
   const patch = r.structuredPatch.filter(isPatchHunk);
-  if (patch.length === 0) return {};
-  return { filePath: r.filePath, patch };
+  if (patch.length > 0) return { filePath: r.filePath, patch };
+
+  const created = createdFilePatch(r);
+  if (created) return { filePath: r.filePath, patch: created };
+  return {};
+}
+
+// One all-add hunk built from a created file's content, numbered from line 1.
+// `@@ -0,0 +1,N @@` in unified-diff terms — the header a new file always gets.
+function createdFilePatch(r: Record<string, unknown>): PatchHunk[] | null {
+  if (r.type !== "create" || typeof r.content !== "string" || !r.content) {
+    return null;
+  }
+  const content = r.content.endsWith("\n") ? r.content.slice(0, -1) : r.content;
+  const lines = content.split("\n").map((line) => `+${line}`);
+  return [
+    { oldStart: 0, oldLines: 0, newStart: 1, newLines: lines.length, lines },
+  ];
 }
 
 function isPatchHunk(hunk: unknown): hunk is PatchHunk {

--- a/web/src/conversation/CollapsibleToolCall.test.tsx
+++ b/web/src/conversation/CollapsibleToolCall.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import type { ContentBlock } from "@/types";
+import type { ToolResultBlock } from "@/conversation/toolUnits";
+import { CollapsibleToolCall } from "./CollapsibleToolCall";
+
+type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
+
+const editCall: ToolUseBlock = {
+  type: "tool_use",
+  id: "t1",
+  name: "Edit",
+  input: { file_path: "a.tsx", old_string: "x", new_string: "y" },
+};
+
+describe("CollapsibleToolCall", () => {
+  it("renders an expanded edit result as a diff, not raw JSON", () => {
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t1",
+      content: "The file a.tsx has been updated.",
+      file_path: "src/a.tsx",
+      patch: [
+        {
+          oldStart: 1,
+          oldLines: 1,
+          newStart: 1,
+          newLines: 1,
+          lines: ["-old", "+new"],
+        },
+      ],
+    };
+
+    render(
+      <CollapsibleToolCall
+        block={editCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    // The diff renders its rows and the applied path...
+    expect(screen.getAllByTestId("diff-line")).toHaveLength(2);
+    expect(screen.getByText("src/a.tsx")).not.toBeNull();
+    // ...and the raw result prose is not dumped as a <pre>.
+    expect(screen.queryByText("The file a.tsx has been updated.")).toBeNull();
+  });
+
+  it("falls back to the raw rendering when the result carries no patch", () => {
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t1",
+      content: "The file a.tsx has been updated.",
+    };
+
+    render(
+      <CollapsibleToolCall
+        block={editCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    expect(screen.queryByTestId("diff-line")).toBeNull();
+    expect(screen.getByText("The file a.tsx has been updated.")).not.toBeNull();
+  });
+});

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -1,6 +1,7 @@
 import { Terminal } from "lucide-react";
 import type { ContentBlock } from "@/types";
 import { CollapsibleRow } from "@/conversation/CollapsibleRow";
+import { DiffView } from "@/conversation/DiffView";
 import { generateToolSummary } from "@/conversation/generateToolSummary";
 import type { ToolResultBlock } from "@/conversation/toolUnits";
 
@@ -30,6 +31,12 @@ export function CollapsibleToolCall({
   isExpanded,
   onToggle,
 }: CollapsibleToolCallProps) {
+  // A file-editing result carries the patch and the path it applied to (#235).
+  // The diff is the whole point of expanding such a unit, so it stands in for
+  // both raw blocks — the call's own old/new strings would only repeat it.
+  const patch = result?.patch;
+  const isDiff = Boolean(result?.file_path && patch && patch.length > 0);
+
   return (
     <CollapsibleRow
       icon={Terminal}
@@ -38,13 +45,19 @@ export function CollapsibleToolCall({
       isExpanded={isExpanded}
       onToggle={onToggle}
     >
-      <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
-        {JSON.stringify(block.input, null, 2)}
-      </pre>
-      {result && (
-        <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
-          {formatResultContent(result.content)}
-        </pre>
+      {isDiff ? (
+        <DiffView filePath={result!.file_path!} patch={patch!} />
+      ) : (
+        <>
+          <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
+            {JSON.stringify(block.input, null, 2)}
+          </pre>
+          {result && (
+            <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
+              {formatResultContent(result.content)}
+            </pre>
+          )}
+        </>
       )}
     </CollapsibleRow>
   );

--- a/web/src/conversation/DiffView.test.tsx
+++ b/web/src/conversation/DiffView.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import type { PatchHunk } from "@/types";
+import { DiffView } from "./DiffView";
+
+const editHunk: PatchHunk = {
+  oldStart: 40,
+  oldLines: 3,
+  newStart: 40,
+  newLines: 3,
+  lines: ["   return (", "-  <pre>", "+  <DiffView />", "   );"],
+};
+
+describe("DiffView", () => {
+  it("shows the file path above the diff", () => {
+    render(
+      <DiffView
+        filePath="web/src/conversation/CollapsibleToolCall.tsx"
+        patch={[editHunk]}
+      />
+    );
+
+    expect(
+      screen.getByText("web/src/conversation/CollapsibleToolCall.tsx")
+    ).not.toBeNull();
+  });
+
+  it("marks each line's kind and its real line numbers", () => {
+    render(<DiffView filePath="a.tsx" patch={[editHunk]} />);
+
+    const rows = screen.getAllByTestId("diff-line");
+    expect(rows.map((r) => r.getAttribute("data-kind"))).toEqual([
+      "context",
+      "remove",
+      "add",
+      "context",
+    ]);
+
+    // The removed line carries its old number and no new one; the added line the reverse.
+    const removed = rows[1];
+    expect(within(removed).getByText("41")).not.toBeNull();
+    const added = rows[2];
+    expect(within(added).getByText("41")).not.toBeNull();
+    expect(within(added).getByText("<DiffView />")).not.toBeNull();
+  });
+
+  it("renders the whole diff with no reveal control when under the cap", () => {
+    render(<DiffView filePath="a.tsx" patch={[editHunk]} lineCap={100} />);
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("keeps both gutters when the diff removes or keeps any line", () => {
+    render(<DiffView filePath="a.tsx" patch={[editHunk]} />);
+
+    expect(screen.getAllByTestId("diff-old-gutter").length).toBeGreaterThan(0);
+  });
+
+  it("drops the old-side gutter for an all-add diff, so a new file is not a dead column", () => {
+    const newFile: PatchHunk = {
+      oldStart: 0,
+      oldLines: 0,
+      newStart: 1,
+      newLines: 2,
+      lines: ["+one", "+two"],
+    };
+
+    render(<DiffView filePath="new.tsx" patch={[newFile]} />);
+
+    expect(screen.queryByTestId("diff-old-gutter")).toBeNull();
+    // The new-side numbers still show — the file just reads on a single gutter.
+    const rows = screen.getAllByTestId("diff-line");
+    expect(within(rows[0]).getByText("1")).not.toBeNull();
+  });
+
+  it("caps a long diff and reveals the rest on demand", async () => {
+    const longHunk: PatchHunk = {
+      oldStart: 1,
+      oldLines: 0,
+      newStart: 1,
+      newLines: 6,
+      lines: ["+one", "+two", "+three", "+four", "+five", "+six"],
+    };
+
+    render(<DiffView filePath="a.tsx" patch={[longHunk]} lineCap={4} />);
+
+    expect(screen.getAllByTestId("diff-line")).toHaveLength(4);
+    expect(screen.queryByText("six")).toBeNull();
+
+    const reveal = screen.getByRole("button");
+    expect(reveal.textContent).toContain("2");
+    await userEvent.click(reveal);
+
+    expect(screen.getAllByTestId("diff-line")).toHaveLength(6);
+    expect(screen.getByText("six")).not.toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});

--- a/web/src/conversation/DiffView.tsx
+++ b/web/src/conversation/DiffView.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import type { PatchHunk } from "@/types";
+import { buildDiff, type DiffLine } from "@/conversation/diffModel";
+
+interface DiffViewProps {
+  filePath: string;
+  patch: PatchHunk[];
+  /**
+   * Most content lines rendered before the rest is folded behind a reveal
+   * control. A long edit is capped so it cannot stall the pane; the reader
+   * opts into the tail (#237).
+   */
+  lineCap?: number;
+}
+
+const DEFAULT_LINE_CAP = 40;
+
+// Both sides tinted, so a row reads as added or removed from its ground alone —
+// the line-number gutters then say where it sits. Context stays untinted and
+// muted: the quiet backdrop the changed lines show against.
+const KIND_ROW_CLASS: Record<DiffLine["kind"], string> = {
+  add: "bg-green-500/10",
+  remove: "bg-destructive/10",
+  context: "",
+};
+
+const KIND_SIGN: Record<DiffLine["kind"], string> = {
+  add: "+",
+  remove: "-",
+  context: " ",
+};
+
+function gutter(n: number | null): string {
+  return n === null ? "" : String(n);
+}
+
+export function DiffView({
+  filePath,
+  patch,
+  lineCap = DEFAULT_LINE_CAP,
+}: DiffViewProps) {
+  const [showAll, setShowAll] = useState(false);
+  const { hunks, hiddenLines } = buildDiff(
+    patch,
+    showAll ? Number.POSITIVE_INFINITY : lineCap
+  );
+
+  // A new file is all additions, so its old-side gutter is empty on every row.
+  // Dropping it leaves a single new-side gutter rather than a dead column.
+  const hasOldColumn = hunks.some((hunk) =>
+    hunk.lines.some((line) => line.oldLineNumber !== null)
+  );
+
+  return (
+    <div className="overflow-x-auto rounded bg-card font-mono text-xs">
+      <div className="border-b border-border px-2 py-1 text-muted-foreground">
+        {filePath}
+      </div>
+      {hunks.map((hunk, hunkIndex) => (
+        <div
+          key={hunkIndex}
+          // A hairline between hunks stands in for the gap they span in the file,
+          // so two hunks don't read as one continuous stretch.
+          className={hunkIndex > 0 ? "border-t border-border" : undefined}
+        >
+          {hunk.lines.map((line, lineIndex) => (
+            <div
+              key={lineIndex}
+              data-testid="diff-line"
+              data-kind={line.kind}
+              className={`flex ${KIND_ROW_CLASS[line.kind]} ${
+                line.kind === "context"
+                  ? "text-muted-foreground"
+                  : "text-foreground"
+              }`}
+            >
+              {hasOldColumn && (
+                <span
+                  data-testid="diff-old-gutter"
+                  className="w-8 shrink-0 select-none px-1 text-right tabular-nums text-muted-foreground"
+                >
+                  {gutter(line.oldLineNumber)}
+                </span>
+              )}
+              <span className="w-8 shrink-0 select-none px-1 text-right tabular-nums text-muted-foreground">
+                {gutter(line.newLineNumber)}
+              </span>
+              <span className="w-3 shrink-0 select-none text-center text-muted-foreground">
+                {KIND_SIGN[line.kind]}
+              </span>
+              <span className="whitespace-pre pr-2">{line.text}</span>
+            </div>
+          ))}
+        </div>
+      ))}
+      {hiddenLines > 0 && (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="w-full cursor-pointer border-t border-border px-2 py-1 text-left text-muted-foreground transition-colors hover:bg-white/[0.04] hover:text-foreground"
+        >
+          Show {hiddenLines} more {hiddenLines === 1 ? "line" : "lines"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/conversation/diffModel.test.ts
+++ b/web/src/conversation/diffModel.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import type { PatchHunk } from "@/types";
+import { buildDiff } from "./diffModel";
+
+const NO_CAP = Number.POSITIVE_INFINITY;
+
+describe("buildDiff", () => {
+  it("numbers a single hunk from its own starts, tagging each line's kind", () => {
+    const { hunks, hiddenLines } = buildDiff(
+      [
+        {
+          oldStart: 40,
+          oldLines: 3,
+          newStart: 40,
+          newLines: 3,
+          lines: ["   return (", "-  <pre>", "+  <DiffView />", "   );"],
+        },
+      ],
+      NO_CAP
+    );
+
+    expect(hiddenLines).toBe(0);
+    expect(hunks).toHaveLength(1);
+    expect(hunks[0].lines).toEqual([
+      {
+        kind: "context",
+        oldLineNumber: 40,
+        newLineNumber: 40,
+        text: "  return (",
+      },
+      {
+        kind: "remove",
+        oldLineNumber: 41,
+        newLineNumber: null,
+        text: "  <pre>",
+      },
+      {
+        kind: "add",
+        oldLineNumber: null,
+        newLineNumber: 41,
+        text: "  <DiffView />",
+      },
+      { kind: "context", oldLineNumber: 42, newLineNumber: 42, text: "  );" },
+    ]);
+  });
+
+  it("restarts numbering at each hunk's own starts, not running from the first", () => {
+    const { hunks } = buildDiff(
+      [
+        {
+          oldStart: 1,
+          oldLines: 2,
+          newStart: 1,
+          newLines: 2,
+          lines: ["-a", "+b"],
+        },
+        {
+          oldStart: 40,
+          oldLines: 2,
+          newStart: 41,
+          newLines: 3,
+          lines: [" keep", "-c", "+d", "+e"],
+        },
+      ],
+      NO_CAP
+    );
+
+    expect(hunks).toHaveLength(2);
+    // Second hunk numbers from 40/41, not from where the first hunk left off.
+    expect(hunks[1].lines).toEqual([
+      { kind: "context", oldLineNumber: 40, newLineNumber: 41, text: "keep" },
+      { kind: "remove", oldLineNumber: 41, newLineNumber: null, text: "c" },
+      { kind: "add", oldLineNumber: null, newLineNumber: 42, text: "d" },
+      { kind: "add", oldLineNumber: null, newLineNumber: 43, text: "e" },
+    ]);
+  });
+
+  const fiveLineHunk: PatchHunk = {
+    oldStart: 1,
+    oldLines: 3,
+    newStart: 1,
+    newLines: 4,
+    lines: [" a", "-b", "+c", "+d", " e"],
+  };
+
+  it("renders the whole diff when the cap equals the line count", () => {
+    const { hunks, hiddenLines } = buildDiff([fiveLineHunk], 5);
+
+    expect(hiddenLines).toBe(0);
+    expect(hunks[0].lines).toHaveLength(5);
+  });
+
+  it("stops at the cap and reports the remainder as hidden", () => {
+    const { hunks, hiddenLines } = buildDiff([fiveLineHunk], 3);
+
+    expect(hunks[0].lines).toHaveLength(3);
+    expect(hiddenLines).toBe(2);
+    // The kept lines still carry their true numbers up to the cut.
+    expect(hunks[0].lines.map((l) => l.kind)).toEqual([
+      "context",
+      "remove",
+      "add",
+    ]);
+  });
+
+  it("counts the cap across hunks, dropping a whole later hunk past it", () => {
+    const { hunks, hiddenLines } = buildDiff(
+      [
+        fiveLineHunk,
+        {
+          oldStart: 9,
+          oldLines: 1,
+          newStart: 10,
+          newLines: 2,
+          lines: [" f", "+g"],
+        },
+      ],
+      5
+    );
+
+    expect(hunks).toHaveLength(1);
+    expect(hiddenLines).toBe(2);
+  });
+});

--- a/web/src/conversation/diffModel.ts
+++ b/web/src/conversation/diffModel.ts
@@ -1,0 +1,91 @@
+import type { PatchHunk } from "@/types";
+
+export type DiffLineKind = "add" | "remove" | "context";
+
+/**
+ * One rendered diff line, carrying both sides' real line numbers.
+ *
+ * A line absent from one side numbers `null` there: an added line has no old
+ * number, a removed line no new one. Both numbers are kept — not just the side
+ * a unified view shows — so a later side-by-side layout can pair lines by them
+ * without re-deriving the diff (#237).
+ */
+export interface DiffLine {
+  kind: DiffLineKind;
+  oldLineNumber: number | null;
+  newLineNumber: number | null;
+  /** The line's content, with its `+`, `-` or space prefix stripped. */
+  text: string;
+}
+
+export interface DiffHunk {
+  lines: DiffLine[];
+}
+
+export interface DiffModel {
+  hunks: DiffHunk[];
+  /** Content lines dropped past the cap; 0 when the whole diff renders. */
+  hiddenLines: number;
+}
+
+/**
+ * Turn unified-diff hunks into rows with real, per-side line numbers.
+ *
+ * Numbers restart from each hunk's own `oldStart`/`newStart` rather than
+ * running from one, so a multi-hunk patch keeps every line at its true position
+ * in the file. `lineCap` bounds the total content lines rendered; the overflow
+ * is reported as `hiddenLines` so the view can offer to reveal the rest.
+ */
+export function buildDiff(patch: PatchHunk[], lineCap: number): DiffModel {
+  const hunks: DiffHunk[] = [];
+  let rendered = 0;
+  let hiddenLines = 0;
+
+  for (const hunk of patch) {
+    let oldLine = hunk.oldStart;
+    let newLine = hunk.newStart;
+    const lines: DiffLine[] = [];
+
+    for (const raw of hunk.lines) {
+      const marker = raw[0];
+      const text = raw.slice(1);
+
+      if (rendered >= lineCap) {
+        hiddenLines += 1;
+        continue;
+      }
+
+      if (marker === "+") {
+        lines.push({
+          kind: "add",
+          oldLineNumber: null,
+          newLineNumber: newLine,
+          text,
+        });
+        newLine += 1;
+      } else if (marker === "-") {
+        lines.push({
+          kind: "remove",
+          oldLineNumber: oldLine,
+          newLineNumber: null,
+          text,
+        });
+        oldLine += 1;
+      } else {
+        lines.push({
+          kind: "context",
+          oldLineNumber: oldLine,
+          newLineNumber: newLine,
+          text,
+        });
+        oldLine += 1;
+        newLine += 1;
+      }
+      rendered += 1;
+    }
+
+    if (lines.length > 0) hunks.push({ lines });
+  }
+
+  return { hunks, hiddenLines };
+}


### PR DESCRIPTION
## Background (Why)

Expanding a file-editing Tool unit showed two raw `<pre>` blocks — the call input as pretty-printed JSON and the result string. For an edit, that is the worst rendering of the most valuable content in a session: the reader has to parse escaped strings to see what changed.

Investigating a real Write surfaced a second gap. A new-file Write records the whole file in `content` and leaves `structuredPatch` empty — Claude Code does not diff a create into hunks. The plugin required a non-empty patch, so a Write dropped its file path and patch entirely and fell back to the raw rendering.

## Approach (How)

A pure `buildDiff` model turns unified-diff hunks into rows with real, per-side line numbers. Every line carries both `oldLineNumber` and `newLineNumber` (null on the side it does not exist), so the model is split-ready: a later side-by-side layout (#245) can pair lines without re-deriving the diff. Numbers restart from each hunk's own starts, so a multi-hunk patch keeps every line at its true position.

`DiffView` renders the file path, then the hunks — added lines on a green ground, removed on a red one, context quiet. A dual line-number gutter shows old and new side by side; an all-add new file drops its empty old-side gutter to a single column. A diff past a line cap renders truncated with a control to reveal the rest.

For the Write gap, the plugin synthesizes an all-add patch from the created file's content when `structuredPatch` is empty, so a new file reads as a diff like every other edit. `NORMALIZE_VERSION` is bumped so archived creates re-normalize and gain the patch. No syntax highlighting in this slice — deferred to its own issue as the main performance risk on a long diff.

## Changes (What)

- [x] `buildDiff` model: per-side line numbers, per-hunk numbering, line-cap truncation with a hidden-line count
- [x] `DiffView`: file path, dual gutters, green/red grounds, all-add single-gutter, reveal control
- [x] `CollapsibleToolCall` renders a patch-carrying result as a diff; a result with no patch keeps the raw rendering
- [x] Plugin synthesizes an all-add patch for a new-file Write; `NORMALIZE_VERSION` 8 → 9

### Screenshots or Recordings

<img width="880" height="764" alt="截圖 2026-07-23 下午4 12 06" src="https://github.com/user-attachments/assets/9a4bfec1-9f73-4f7f-bc05-4134c449c106" />

### Test Verification

- [x] Model: single/multi-hunk kinds and line numbers, truncation boundary, cross-hunk cap
- [x] DiffView: file path, per-kind rows, dual vs single gutter, reveal control
- [x] CollapsibleToolCall: patch → diff, no-patch → raw fallback
- [x] Plugin: all-add synthesis from a real new-file Write (empty `structuredPatch` + content)
- [x] Full suites green: api 401, web 402; typecheck, build, lint clean

## Related Links

- Closes #237
- Follow-up: #245