### PR TITLE
feat(web): accent a folded Run summary chevron

### DIFF
--- a/web/src/conversation/CollapsibleRow.test.tsx
+++ b/web/src/conversation/CollapsibleRow.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Layers } from "lucide-react";
+import { CollapsibleRow } from "./CollapsibleRow";
+
+describe("CollapsibleRow chevron treatment", () => {
+  it("accents the chevron on a folded summary row", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary="12 tool calls"
+        isExpanded={false}
+        onToggle={() => {}}
+        isExpandable
+        isSummary
+      />
+    );
+
+    // The bare accent, not the hover-only group-hover:text-primary.
+    const chevron = screen.getByTestId("row-chevron");
+    expect(chevron.getAttribute("class")).toMatch(/(?<!hover:)text-primary/);
+  });
+
+  it("keeps a collapsed individual row muted, accenting only on hover", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary="Read a.tsx"
+        isExpanded={false}
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    const chevron = screen.getByTestId("row-chevron");
+    const cls = chevron.getAttribute("class") ?? "";
+    expect(cls).not.toMatch(/(?<!hover:)text-primary/);
+    expect(cls).toMatch(/group-hover:text-primary/);
+  });
+
+  it("mutes the chevron on an expanded summary row", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary="12 tool calls"
+        isExpanded
+        onToggle={() => {}}
+        isExpandable
+        isSummary
+      />
+    );
+
+    const cls = screen.getByTestId("row-chevron").getAttribute("class") ?? "";
+    expect(cls).not.toMatch(/text-primary/);
+  });
+
+  it("mutes an expanded individual row, dropping the hover accent too", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary="Read a.tsx"
+        isExpanded
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    const cls = screen.getByTestId("row-chevron").getAttribute("class") ?? "";
+    expect(cls).not.toMatch(/text-primary/);
+  });
+
+  it("leaves the error dot its own colour under the accent rules", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary="Bash"
+        hasError
+        isExpanded={false}
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    const dot = screen.getByTestId("row-error");
+    expect(dot.getAttribute("class") ?? "").toMatch(/bg-destructive/);
+  });
+});

--- a/web/src/conversation/CollapsibleRow.tsx
+++ b/web/src/conversation/CollapsibleRow.tsx
@@ -26,6 +26,13 @@ interface CollapsibleRowProps {
    * siblings rather than children (#199).
    */
   isExpandable?: boolean;
+  /**
+   * Marks the one row a folded Run collapses to. While closed it wears its
+   * chevron in --primary — the colour cue that these lines open (#238). Spent
+   * once the row is open, and never worn by the individual rows inside it, so
+   * the accent stays rare enough to read as a cue rather than decoration.
+   */
+  isSummary?: boolean;
 }
 
 /**
@@ -43,6 +50,7 @@ export function CollapsibleRow({
   onToggle,
   children,
   isExpandable,
+  isSummary,
 }: CollapsibleRowProps) {
   if (!children && !isExpandable) {
     return (
@@ -58,6 +66,17 @@ export function CollapsibleRow({
     );
   }
 
+  // The chevron carries the "this opens" cue in colour, spent once open (#238):
+  //   folded summary row  → --primary, the rare accent that reads as a cue
+  //   collapsed individual → muted, taking the accent only on hover, where it
+  //                          answers a question the reader is actively asking
+  //   any expanded row     → muted, the affordance already spent
+  const chevronColour = isExpanded
+    ? ""
+    : isSummary
+      ? "text-primary"
+      : "group-hover:text-primary";
+
   return (
     <div>
       <button
@@ -66,13 +85,13 @@ export function CollapsibleRow({
         aria-expanded={isExpanded}
         // Muted and a size down from body text: these rows are the parts of a
         // session the reader scans past, not the prose they came to read.
-        className="flex w-full cursor-pointer items-center gap-1.5 rounded px-1.5 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-white/[0.04] hover:text-foreground"
+        className="group flex w-full cursor-pointer items-center gap-1.5 rounded px-1.5 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-white/[0.04] hover:text-foreground"
       >
         <ChevronDown
           data-testid="row-chevron"
           size={12}
           aria-hidden="true"
-          className={`shrink-0 transition-transform ${
+          className={`shrink-0 transition-transform ${chevronColour} ${
             isExpanded ? "" : "-rotate-90"
           }`}
         />

--- a/web/src/conversation/FoldSummaryRow.test.tsx
+++ b/web/src/conversation/FoldSummaryRow.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { FoldSummaryRow } from "./FoldSummaryRow";
+
+describe("FoldSummaryRow", () => {
+  it("accents its chevron while folded — the cue that the Run opens", () => {
+    render(
+      <FoldSummaryRow
+        summary="12 tool calls"
+        isExpanded={false}
+        onToggle={() => {}}
+      />
+    );
+
+    // The bare accent, not the hover-only group-hover:text-primary of a plain
+    // collapsible row — the fold summary wears the colour while merely folded.
+    const chevron = screen.getByTestId("row-chevron");
+    expect(chevron.getAttribute("class")).toMatch(/(?<!hover:)text-primary/);
+  });
+});

--- a/web/src/conversation/FoldSummaryRow.tsx
+++ b/web/src/conversation/FoldSummaryRow.tsx
@@ -26,6 +26,7 @@ export function FoldSummaryRow({
       isExpanded={isExpanded}
       onToggle={onToggle}
       isExpandable
+      isSummary
     />
   );
 }


### PR DESCRIPTION
## Background (Why)

A collapsed row gives no colour cue that it holds anything, so a reader skimming a session has to learn from the chevron shape alone that these lines open. Issue #238 asks us to spend the product accent on that cue: a folded Run summary row should carry its chevron in `--primary`.

The accent has to stay rare. Every collapsed row wearing teal would put a column of accent dots down the pane and dilute the byline, which already uses `--primary`. The cue works precisely because it appears rarely.

## Approach (How)

The chevron lives in the shared `CollapsibleRow`, so the treatment is decided there from two facts it already knows — whether the row is expanded, and (new) whether it is the fold summary row:

- **folded summary row** → `text-primary`, the rare accent that reads as a cue
- **collapsed individual row** → muted, taking `group-hover:text-primary` only on hover, where the colour answers a question the reader is actively asking
- **any expanded row** → muted, the affordance already spent

A new `isSummary` prop marks the one row a folded Run collapses to; `FoldSummaryRow` passes it. The button becomes a `group` so the chevron can take its hover accent independently of the row text (which still goes to `foreground`). The error dot keeps its own `bg-destructive` colour and is untouched.

The chevron stays `aria-hidden` — it is decorative, not the sole carrier of open/closed state (that is `aria-expanded` on the button), so the contrast question in #218 does not apply here.

## Changes (What)

- [x] `CollapsibleRow` gains an `isSummary` prop and a three-state chevron colour: accent while a summary row is folded, hover-only accent on collapsed individual rows, muted once expanded
- [x] `CollapsibleRow`'s toggle button is now a `group` so the chevron's hover accent is independent of the row text
- [x] `FoldSummaryRow` passes `isSummary` so a folded Run wears the accent

### Screenshots or Recordings

<img width="884" height="102" alt="截圖 2026-07-23 下午4 53 09" src="https://github.com/user-attachments/assets/f947cc22-3df0-435a-900d-381873de7c97" />

### Test Verification

- [x] A folded summary row renders its chevron with the bare `--primary` accent
- [x] A collapsed individual row stays muted and carries only `group-hover:text-primary`
- [x] An expanded summary row renders its chevron muted
- [x] An expanded individual row renders muted, dropping the hover accent too
- [x] The error dot keeps `bg-destructive` under the accent rules
- [x] `FoldSummaryRow` accents its chevron while folded
- [x] Full suite green (web 408, api 401), typecheck, build, lint

## Additional Notes

Hover cannot be truly triggered in jsdom, so the hover behaviour is verified by asserting the `group-hover:text-primary` class is present — the same class-assertion idiom the existing suite uses for `text-primary`.

## Related Links

- Closes #238