### PR TITLE
feat(web): lead filter-panel sections with an accented chevron

### DIFF
--- a/web/src/chat/projects/ProjectsSection.test.tsx
+++ b/web/src/chat/projects/ProjectsSection.test.tsx
@@ -71,6 +71,38 @@ describe("ProjectsSection", () => {
     expect(caption).toHaveAttribute("title", "Sorted by recent activity");
   });
 
+  it("leads the header with the chevron, before the Projects title", () => {
+    renderSection();
+    const header = screen.getByTestId("projects-header");
+    const chevron = header.querySelector(".lucide-chevron-down");
+    const title = within(header).getByText("Projects");
+    expect(chevron).not.toBeNull();
+    // The chevron precedes the title in DOM order (chevron leads the row).
+    expect(
+      chevron!.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it("keeps the order caption free of the chevron", () => {
+    renderSection();
+    const caption = screen.getByTestId("projects-order-caption");
+    expect(caption.querySelector(".lucide-chevron-down")).toBeNull();
+  });
+
+  it("accents the chevron in --primary only while collapsed", async () => {
+    renderSection();
+    const header = screen.getByTestId("projects-header");
+    const chevronClass = () =>
+      header.querySelector(".lucide-chevron-down")!.getAttribute("class") ?? "";
+    // Expanded: muted, no accent, no rotation.
+    expect(chevronClass()).not.toContain("text-primary");
+    expect(chevronClass()).not.toContain("-rotate-90");
+    // Collapsed: accented and rotated.
+    await userEvent.click(header);
+    expect(chevronClass()).toContain("text-primary");
+    expect(chevronClass()).toContain("-rotate-90");
+  });
+
   it("collapses and expands the project list from the header", async () => {
     renderSection();
     expect(screen.getByTestId("project-row-web")).toBeInTheDocument();

--- a/web/src/chat/projects/ProjectsSection.tsx
+++ b/web/src/chat/projects/ProjectsSection.tsx
@@ -35,18 +35,25 @@ export function ProjectsSection({
         aria-expanded={!collapsed}
         className="flex items-center justify-between px-2 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
       >
-        <span>Projects</span>
-        <span
-          data-testid="projects-order-caption"
-          title={ORDER_TOOLTIP}
-          className="flex items-center gap-0.5 text-muted-foreground/80"
-        >
-          {ORDER_CAPTION}
+        <span className="flex items-center gap-1">
+          {/* The chevron leads the row and wears --primary while collapsed —
+              the rare accent that reads as "this opens", spent once expanded
+              (matches CollapsibleRow, #247/#238). */}
           <ChevronDown
             size={12}
             aria-hidden="true"
-            className={`transition-transform ${collapsed ? "-rotate-90" : ""}`}
+            className={`shrink-0 transition-transform ${
+              collapsed ? "-rotate-90 text-primary" : ""
+            }`}
           />
+          <span>Projects</span>
+        </span>
+        <span
+          data-testid="projects-order-caption"
+          title={ORDER_TOOLTIP}
+          className="text-muted-foreground/80"
+        >
+          {ORDER_CAPTION}
         </span>
       </button>
       {!collapsed && (

--- a/web/src/tags/TagsSection.test.tsx
+++ b/web/src/tags/TagsSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { TagsSection } from "./TagsSection";
@@ -51,6 +51,40 @@ describe("TagsSection — Match All/Any control", () => {
     await user.click(screen.getByTestId("tag-match-any"));
 
     expect(props.onTagModeChange).toHaveBeenCalledWith("any");
+  });
+});
+
+describe("TagsSection — collapse chevron", () => {
+  it("leads the header with the chevron, before the Tags title", () => {
+    renderSection();
+    const header = screen.getByTestId("tags-header");
+    const chevron = header.querySelector(".lucide-chevron-down");
+    const title = within(header).getByText("Tags");
+    expect(chevron).not.toBeNull();
+    // The chevron precedes the title in DOM order (chevron leads the row).
+    expect(
+      chevron!.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it("keeps the order caption free of the chevron", () => {
+    renderSection();
+    const caption = screen.getByTestId("tags-order-caption");
+    expect(caption.querySelector(".lucide-chevron-down")).toBeNull();
+  });
+
+  it("accents the chevron in --primary only while collapsed", async () => {
+    renderSection();
+    const header = screen.getByTestId("tags-header");
+    const chevronClass = () =>
+      header.querySelector(".lucide-chevron-down")!.getAttribute("class") ?? "";
+    // Expanded: muted, no accent, no rotation.
+    expect(chevronClass()).not.toContain("text-primary");
+    expect(chevronClass()).not.toContain("-rotate-90");
+    // Collapsed: accented and rotated.
+    await userEvent.click(header);
+    expect(chevronClass()).toContain("text-primary");
+    expect(chevronClass()).toContain("-rotate-90");
   });
 });
 

--- a/web/src/tags/TagsSection.tsx
+++ b/web/src/tags/TagsSection.tsx
@@ -414,11 +414,13 @@ export function TagsSection({
 
   return (
     <div data-testid="tags-section" className="flex flex-col">
-      {/* Header row: "Tags" and the All/Any match control sit together on the
-          left; the "A–Z" order caption stays on the right. Both "Tags" and the
-          A–Z caption are collapse toggles (the caption carries the chevron); the
-          match control is a sibling — never nested — so its buttons don't also
-          collapse the section, and it stays visible while collapsed. */}
+      {/* Header row: the chevron leads the "Tags" toggle, with the All/Any
+          match control beside it on the left; the "A–Z" order caption stays on
+          the right. Both "Tags" and the A–Z caption are collapse toggles; the
+          chevron now leads the "Tags" toggle (matching CollapsibleRow,
+          #247/#238). The match control is a sibling — never nested — so its
+          buttons don't also collapse the section, and it stays visible while
+          collapsed. */}
       <div className="flex items-center justify-between px-2 py-1.5 text-xs font-medium text-muted-foreground">
         <div className="flex items-center gap-2">
           <button
@@ -426,9 +428,18 @@ export function TagsSection({
             data-testid="tags-header"
             onClick={() => setCollapsed((c) => !c)}
             aria-expanded={!collapsed}
-            className="transition-colors hover:text-foreground"
+            className="flex items-center gap-1 transition-colors hover:text-foreground"
           >
-            Tags
+            {/* Accented in --primary while collapsed — the rare "this opens"
+                cue, spent once expanded. */}
+            <ChevronDown
+              size={12}
+              aria-hidden="true"
+              className={`shrink-0 transition-transform ${
+                collapsed ? "-rotate-90 text-primary" : ""
+              }`}
+            />
+            <span>Tags</span>
           </button>
           {sorted.length > 0 && (
             <MatchControl mode={tagMode} onChange={onTagModeChange} />
@@ -440,14 +451,9 @@ export function TagsSection({
           onClick={() => setCollapsed((c) => !c)}
           aria-expanded={!collapsed}
           title="Sorted A–Z"
-          className="flex items-center gap-0.5 text-muted-foreground/80 transition-colors hover:text-foreground"
+          className="text-muted-foreground/80 transition-colors hover:text-foreground"
         >
           A–Z
-          <ChevronDown
-            size={12}
-            aria-hidden="true"
-            className={`transition-transform ${collapsed ? "-rotate-90" : ""}`}
-          />
         </button>
       </div>
       {!collapsed &&


### PR DESCRIPTION
## Background (Why)

The Projects and Tags section headers in the first column collapse from a chevron parked at the far right of the row, tucked inside the order caption. The conversation pane went the other way: `CollapsibleRow` puts the chevron first, so the control that opens a row is the first thing you meet when you scan down it. Two panes, two opposite habits — issue #188 asks us to settle on one.

There is a second half to the same question. #238/#247 gave the conversation pane a colour cue: a collapsed row wears its chevron in `--primary`, so you can see which lines open without decoding the chevron's angle. The filter panel had no such cue at all. If the chevron is going to lead the row, it should carry the same meaning here as it does there.

## Approach (How)

Both section headers move the chevron to the front, immediately left of the title, and the order caption (`Recent` / `A–Z`) stays where it was at the right end — just without the chevron riding along.

The chevron treatment now matches `CollapsibleRow`:

- **collapsed** → `-rotate-90 text-primary`, the rare accent that reads as "this opens"
- **expanded** → muted, the affordance already spent

`ProjectsSection`'s header is a single button, so the chevron and title simply become a flex pair inside it. `TagsSection` is the more delicate one: its header is a row of three parts, and the `Tags` toggle sits beside the `MatchControl`. The chevron goes *inside* the `Tags` toggle, ahead of its text, so clicking it still collapses the section. The match control stays a sibling — never nested — so its buttons don't collapse the section and it remains visible while collapsed, exactly as before.

The title text in both headers is wrapped in its own `span` so the chevron is a sibling of the title rather than its parent. That keeps the DOM order honest — the chevron genuinely precedes the title — instead of merely looking that way.

The chevron stays `aria-hidden`: it is decorative, and `aria-expanded` on the toggle remains the carrier of open/closed state.

## Changes (What)

- [x] `ProjectsSection` leads its header with the chevron; the `Recent` caption keeps the right end and drops the chevron
- [x] `TagsSection` moves the chevron inside the `Tags` toggle ahead of its text; the `A–Z` caption keeps the right end and drops the chevron
- [x] Both chevrons wear `--primary` while collapsed and return to muted when expanded, matching `CollapsibleRow` (#247/#238)
- [x] Rotation on collapse (`-rotate-90`) is unchanged in both sections
- [x] Header titles are wrapped in their own `span` so the chevron is a preceding sibling, not an ancestor

### Screenshots or Recordings

<img width="224" height="133" alt="截圖 2026-07-24 下午1 32 09" src="https://github.com/user-attachments/assets/1044060a-d3d5-4843-8729-fb39ab7d2d24" />

### Test Verification

- [x] `ProjectsSection` renders the chevron before the `Projects` title in DOM order
- [x] `ProjectsSection`'s `Recent` order caption contains no chevron
- [x] `ProjectsSection`'s chevron takes `text-primary` and `-rotate-90` only while collapsed, and neither while expanded
- [x] `TagsSection` renders the chevron before the `Tags` title in DOM order
- [x] `TagsSection`'s `A–Z` order caption contains no chevron
- [x] `TagsSection`'s chevron takes `text-primary` and `-rotate-90` only while collapsed, and neither while expanded
- [x] Existing collapse/expand, order-caption, Match All/Any, and Untagged-dimming tests all still pass
- [x] Full suite green (web 414, api 401), typecheck, lint, build

## Related Links

- Closes #188
- Follows the chevron accent language introduced in #238 / #247