### PR TITLE
feat(web): reopen a chat where you left it

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -143,7 +143,7 @@ function App() {
   const handleRenameTitle = (id: string, title: string) => {
     void setTitle(id, title);
   };
-  const { messages, error } = useMessages(selectedId);
+  const { messages, loading: messagesLoading, error } = useMessages(selectedId);
   const { toast, showToast, dismissToast } = useToast();
 
   // Switching views (Chat List <-> Trash) flushes any held-back background order
@@ -648,6 +648,7 @@ function App() {
           <ConversationView
             chat={selectedChat}
             messages={messages}
+            loading={messagesLoading}
             error={error}
             onRestore={handleRestore}
             onRenameTitle={handleRenameTitle}

--- a/web/src/conversation/ConversationView.tsx
+++ b/web/src/conversation/ConversationView.tsx
@@ -46,6 +46,8 @@ import {
   useRowExpansion,
   type RowExpansion,
 } from "@/conversation/useRowExpansion";
+import { useReadingState } from "@/conversation/useReadingState";
+import { pickAnchor, resolveAnchorIndex } from "@/conversation/scrollAnchor";
 import { useScrollShortcuts } from "@/conversation/useScrollShortcuts";
 import { getAgentDisplayName } from "@/agent/agentDisplayName";
 import { getModelDisplayName } from "@/agent/modelDisplayName";
@@ -68,6 +70,12 @@ interface TagControls {
 interface ConversationViewProps extends Partial<TagControls> {
   chat: Chat | null;
   messages: Message[];
+  /**
+   * Whether the messages for the current chat are still loading. While true,
+   * `messages` may still hold the previously open chat's turns, so landing and
+   * restore must wait until it settles (#239).
+   */
+  loading?: boolean;
   error?: string | null;
   onRestore?: (id: string) => void;
   onRenameTitle?: (id: string, title: string) => void;
@@ -428,6 +436,7 @@ function MessageItem({
 export function ConversationView({
   chat,
   messages: allMessages,
+  loading = false,
   error,
   onRestore,
   onRenameTitle,
@@ -455,7 +464,14 @@ export function ConversationView({
   // Grouping is decided here, once, as a pure function of what is rendered —
   // never measured at layout time (#236).
   const layouts = useMemo(() => planLayout(messages), [messages]);
-  const expansion = useRowExpansion(chat?.id);
+  // Where the reader left this chat — scroll anchor and open rows — loaded on
+  // open and saved (debounced) as they read. Reading state, so it lives in the
+  // browser, not the Metadata store (#239).
+  const reading = useReadingState(chat?.id);
+  const expansion = useRowExpansion(chat?.id, {
+    initialOpenRows: reading.initial?.openRows,
+    onOpenRowsChange: reading.recordOpenRows,
+  });
   const tagControls: TagControls | undefined =
     allTags && onAssignTag && onRemoveTag && onCreateTag
       ? { allTags, onAssignTag, onRemoveTag, onCreateTag }
@@ -519,6 +535,28 @@ export function ConversationView({
     if (atBottom && firstUnseenIndexRef.current !== null) setPillConsumed(true);
   }, []);
 
+  // Note where the reader is, as a message anchor rather than a pixel offset, so
+  // reopening restores this spot even after estimated heights settle or the
+  // chat gains and loses messages (#239). Read from the rendered rows only, so
+  // it stays cheap on a long chat.
+  const captureAnchor = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const entries = virtualizer
+      .getVirtualItems()
+      .map((item) => ({
+        messageId: messages[item.index]?.id ?? "",
+        start: item.start,
+      }))
+      .filter((entry) => entry.messageId);
+    reading.recordAnchor(pickAnchor({ scrollTop: el.scrollTop, entries }));
+  }, [virtualizer, messages, reading]);
+
+  const handleScroll = useCallback(() => {
+    measurePill();
+    captureAnchor();
+  }, [measurePill, captureAnchor]);
+
   const jumpTop = useCallback(() => {
     // Instant index jump, not a smooth scroll: smooth-scrolling across
     // thousands of virtualized rows is slow and janky.
@@ -558,9 +596,11 @@ export function ConversationView({
       prevLenRef.current = 0;
       return;
     }
-    // Messages load a tick after the chat id is set, so land the moment they
-    // first arrive — not on the initial empty render.
-    if (messages.length === 0) return;
+    // Wait for this chat's own messages before landing: while the fetch is in
+    // flight, `messages` may still be the previously open chat's turns, and
+    // restoring against those would never find this chat's anchor (#239). An
+    // empty list has nothing to land on yet either.
+    if (loading || messages.length === 0) return;
 
     // First arrival for this chat: land at the bottom and reset the live-arrival
     // trackers. Guard by chat id so a later streamed message doesn't re-land.
@@ -569,6 +609,23 @@ export function ConversationView({
       prevLenRef.current = messages.length;
       setFirstUnseenIndex(null);
       setPillConsumed(false);
+      // Restore the remembered spot when there is one and its anchored message
+      // still exists; otherwise — a first visit, or an anchor whose message is
+      // gone — land at the bottom, the right answer for a fresh read (#239).
+      const anchor = reading.initial?.anchor ?? null;
+      const anchorIndex = resolveAnchorIndex(anchor, messages);
+      if (anchor && anchorIndex !== null) {
+        // scrollToIndex re-measures and re-scrolls until the message lands at
+        // the top, which a raw offset cannot do against estimated heights. The
+        // within-message offset is a small nudge applied once the row is there.
+        virtualizer.scrollToIndex(anchorIndex, { align: "start" });
+        const raf = requestAnimationFrame(() => {
+          const el = scrollContainerRef.current;
+          if (el && anchor.offset) el.scrollTop += anchor.offset;
+          measurePill();
+        });
+        return () => cancelAnimationFrame(raf);
+      }
       virtualizer.scrollToIndex(messages.length - 1, { align: "end" });
       // Re-measure after the jump settles so the pill reflects the landed
       // position (at the bottom it offers "back to top").
@@ -596,7 +653,7 @@ export function ConversationView({
       deriveFirstUnseenIndex({ current, action, prevLen })
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatId, messages.length]);
+  }, [chatId, messages.length, loading]);
 
   // Keep the pill correct as content height changes (messages expanding or
   // collapsing) even without a scroll event.
@@ -645,7 +702,7 @@ export function ConversationView({
           <div
             data-testid="conversation-panel"
             ref={scrollContainerRef}
-            onScroll={measurePill}
+            onScroll={handleScroll}
             className="absolute inset-0 overflow-y-auto p-6"
           >
             <div

--- a/web/src/conversation/readingState.test.ts
+++ b/web/src/conversation/readingState.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  loadReadingState,
+  saveReadingState,
+  READING_STATE_LIMIT,
+} from "./readingState";
+
+function anchoredAt(messageId: string): {
+  anchor: { messageId: string; offset: number };
+  openRows: readonly string[];
+} {
+  return { anchor: { messageId, offset: 0 }, openRows: [] };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("readingState", () => {
+  it("round-trips a saved anchor and open rows", () => {
+    saveReadingState("chat-1", {
+      anchor: { messageId: "m-42", offset: 12 },
+      openRows: ["m-1:0", "m-3:2"],
+    });
+
+    const state = loadReadingState("chat-1");
+
+    expect(state).toEqual({
+      anchor: { messageId: "m-42", offset: 12 },
+      openRows: ["m-1:0", "m-3:2"],
+    });
+  });
+
+  it("returns null for a chat with nothing remembered", () => {
+    saveReadingState("chat-1", { anchor: null, openRows: [] });
+
+    expect(loadReadingState("chat-unknown")).toBeNull();
+  });
+
+  it("evicts the oldest chat once past the bound", () => {
+    // One more than the bound: the very first chat written should be dropped.
+    for (let i = 0; i < READING_STATE_LIMIT + 1; i++) {
+      saveReadingState(`chat-${i}`, anchoredAt(`m-${i}`));
+    }
+
+    expect(loadReadingState("chat-0")).toBeNull();
+    expect(loadReadingState("chat-1")).toEqual(anchoredAt("m-1"));
+    expect(loadReadingState(`chat-${READING_STATE_LIMIT}`)).toEqual(
+      anchoredAt(`m-${READING_STATE_LIMIT}`)
+    );
+  });
+
+  it("spares a re-read chat from eviction by moving it to the front", () => {
+    saveReadingState("chat-old", anchoredAt("m-old"));
+    // Re-reading it writes again, so it should outlive a full bound of newer
+    // chats rather than being dropped as the oldest.
+    saveReadingState("chat-old", anchoredAt("m-old-again"));
+    for (let i = 0; i < READING_STATE_LIMIT - 1; i++) {
+      saveReadingState(`chat-${i}`, anchoredAt(`m-${i}`));
+    }
+
+    expect(loadReadingState("chat-old")).toEqual(anchoredAt("m-old-again"));
+  });
+});

--- a/web/src/conversation/readingState.ts
+++ b/web/src/conversation/readingState.ts
@@ -1,0 +1,78 @@
+/**
+ * Where the reader left a Chat: the scroll position, as a message anchor, and
+ * which skim-layer rows they had opened. Persisted per chat so reopening lands
+ * where it was last read rather than always at the bottom (#239).
+ *
+ * This is reading state, not something authored about a chat, so it lives in
+ * the browser rather than the Metadata store: losing it costs one landing at
+ * the bottom. Writes are bounded to the most recently read chats.
+ */
+export interface ScrollAnchor {
+  /** Normalized message id of the topmost visible Message. */
+  messageId: string;
+  /** Pixels scrolled past that Message's top edge. */
+  offset: number;
+}
+
+export interface ReadingState {
+  /** null when nothing worth anchoring was recorded (e.g. pinned at bottom). */
+  anchor: ScrollAnchor | null;
+  /** Row keys (messageId:blockIndex, or a fold id) the reader had opened. */
+  openRows: readonly string[];
+}
+
+const STORAGE_KEY = "chat-logbook.reading-state";
+const STORAGE_VERSION = 1;
+
+/**
+ * How many recently-read chats keep their reading state. Each entry is tiny, so
+ * this is generous enough to cover "chats I've been reading" while staying well
+ * inside a browser's localStorage budget. Past it, the least-recently-written
+ * chat is dropped — reopening it lands at the bottom, as a first visit would.
+ */
+export const READING_STATE_LIMIT = 50;
+
+interface StoredEntry extends ReadingState {
+  chatId: string;
+}
+
+interface StoredPayload {
+  version: number;
+  /** Most-recently-written first, so the tail is what eviction drops. */
+  chats: StoredEntry[];
+}
+
+function readPayload(): StoredPayload {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw == null) return { version: STORAGE_VERSION, chats: [] };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { version: STORAGE_VERSION, chats: [] };
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return { version: STORAGE_VERSION, chats: [] };
+  }
+  const record = parsed as Record<string, unknown>;
+  if (record.version !== STORAGE_VERSION || !Array.isArray(record.chats)) {
+    return { version: STORAGE_VERSION, chats: [] };
+  }
+  return { version: STORAGE_VERSION, chats: record.chats as StoredEntry[] };
+}
+
+export function loadReadingState(chatId: string): ReadingState | null {
+  const entry = readPayload().chats.find((c) => c.chatId === chatId);
+  if (!entry) return null;
+  return { anchor: entry.anchor, openRows: entry.openRows };
+}
+
+export function saveReadingState(chatId: string, state: ReadingState): void {
+  const previous = readPayload().chats.filter((c) => c.chatId !== chatId);
+  const chats: StoredEntry[] = [{ chatId, ...state }, ...previous].slice(
+    0,
+    READING_STATE_LIMIT
+  );
+  const payload: StoredPayload = { version: STORAGE_VERSION, chats };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}

--- a/web/src/conversation/scrollAnchor.test.ts
+++ b/web/src/conversation/scrollAnchor.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { pickAnchor, resolveAnchorIndex } from "./scrollAnchor";
+
+// Three messages laid out top to bottom at these vertical starts.
+const entries = [
+  { messageId: "m-1", start: 0 },
+  { messageId: "m-2", start: 100 },
+  { messageId: "m-3", start: 260 },
+];
+
+describe("pickAnchor", () => {
+  it("anchors to the topmost visible message and its within-message offset", () => {
+    // Scrolled so the viewport top sits 30px into the second message.
+    const anchor = pickAnchor({ scrollTop: 130, entries });
+
+    expect(anchor).toEqual({ messageId: "m-2", offset: 30 });
+  });
+});
+
+describe("resolveAnchorIndex", () => {
+  const messages = [{ id: "m-1" }, { id: "m-2" }, { id: "m-3" }];
+
+  it("finds the list position of the anchored message", () => {
+    const index = resolveAnchorIndex(
+      { messageId: "m-3", offset: 20 },
+      messages
+    );
+
+    expect(index).toBe(2);
+  });
+
+  it("returns null when the anchored message no longer exists", () => {
+    const index = resolveAnchorIndex(
+      { messageId: "gone", offset: 20 },
+      messages
+    );
+
+    expect(index).toBeNull();
+  });
+
+  it("returns null when there is no anchor", () => {
+    expect(resolveAnchorIndex(null, messages)).toBeNull();
+  });
+});

--- a/web/src/conversation/scrollAnchor.ts
+++ b/web/src/conversation/scrollAnchor.ts
@@ -1,0 +1,59 @@
+import type { ScrollAnchor } from "./readingState";
+
+/**
+ * A Message's top edge in the virtualized column, keyed by its Normalized id.
+ * Positions come from the virtualizer, not the DOM, so they mean the same thing
+ * whatever order rows were measured in.
+ */
+export interface AnchorEntry {
+  messageId: string;
+  start: number;
+}
+
+/**
+ * Turn a raw `scrollTop` into a message anchor: the topmost Message still at or
+ * above the viewport top, plus how far into it the viewport has scrolled.
+ *
+ * Stored this way rather than as a pixel `scrollTop` because the pane
+ * virtualizes with estimated heights — a raw offset means something different
+ * on every load depending on measurement order and which rows are open — and an
+ * anchor survives the chat gaining or losing messages between visits (#239).
+ *
+ * Returns null when there is nothing to anchor to (an empty column).
+ */
+export function pickAnchor({
+  scrollTop,
+  entries,
+}: {
+  scrollTop: number;
+  entries: readonly AnchorEntry[];
+}): ScrollAnchor | null {
+  let anchor: AnchorEntry | null = null;
+  for (const entry of entries) {
+    if (entry.start <= scrollTop) anchor = entry;
+    else break;
+  }
+  // Nothing starts at or above the viewport top (e.g. scrolled above the first
+  // row): fall back to the first entry so restore still has a target.
+  if (!anchor) anchor = entries[0] ?? null;
+  if (!anchor) return null;
+  return { messageId: anchor.messageId, offset: scrollTop - anchor.start };
+}
+
+/**
+ * Find the list position of a stored anchor's Message, so restore can scroll to
+ * it by index — the one primitive that re-measures estimated heights until the
+ * row truly lands at the top.
+ *
+ * Returns null when there is no anchor, or when its Message no longer exists —
+ * the chat lost it between visits — so the caller degrades to landing at the
+ * bottom rather than erroring (#239).
+ */
+export function resolveAnchorIndex(
+  anchor: ScrollAnchor | null,
+  messages: readonly { id: string }[]
+): number | null {
+  if (!anchor) return null;
+  const index = messages.findIndex((m) => m.id === anchor.messageId);
+  return index === -1 ? null : index;
+}

--- a/web/src/conversation/useReadingState.test.tsx
+++ b/web/src/conversation/useReadingState.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useReadingState } from "./useReadingState";
+import { loadReadingState, saveReadingState } from "./readingState";
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useReadingState", () => {
+  it("loads the stored state for the chat as its initial value", () => {
+    saveReadingState("chat-1", {
+      anchor: { messageId: "m-5", offset: 8 },
+      openRows: ["m-1:0"],
+    });
+
+    const { result } = renderHook(() => useReadingState("chat-1"));
+
+    expect(result.current.initial).toEqual({
+      anchor: { messageId: "m-5", offset: 8 },
+      openRows: ["m-1:0"],
+    });
+  });
+
+  it("debounces writes, saving once with the latest anchor", () => {
+    const { result } = renderHook(() =>
+      useReadingState("chat-1", { debounceMs: 500 })
+    );
+
+    act(() => {
+      result.current.recordAnchor({ messageId: "m-1", offset: 0 });
+      result.current.recordAnchor({ messageId: "m-2", offset: 40 });
+    });
+
+    // Nothing written until the debounce elapses.
+    expect(loadReadingState("chat-1")).toBeNull();
+
+    act(() => vi.advanceTimersByTime(500));
+
+    expect(loadReadingState("chat-1")?.anchor).toEqual({
+      messageId: "m-2",
+      offset: 40,
+    });
+  });
+
+  it("combines the latest anchor and open rows into one saved state", () => {
+    const { result } = renderHook(() =>
+      useReadingState("chat-1", { debounceMs: 500 })
+    );
+
+    act(() => {
+      result.current.recordAnchor({ messageId: "m-2", offset: 40 });
+      result.current.recordOpenRows(["m-2:1"]);
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(loadReadingState("chat-1")).toEqual({
+      anchor: { messageId: "m-2", offset: 40 },
+      openRows: ["m-2:1"],
+    });
+  });
+});

--- a/web/src/conversation/useReadingState.ts
+++ b/web/src/conversation/useReadingState.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  loadReadingState,
+  saveReadingState,
+  type ReadingState,
+  type ScrollAnchor,
+} from "./readingState";
+
+/** Loads a chat's reading state on open and persists changes, debounced. */
+export interface ReadingStateController {
+  /** What was remembered for this chat, or null on a first visit. */
+  initial: ReadingState | null;
+  /** Note the current scroll anchor; the write is debounced. */
+  recordAnchor: (anchor: ScrollAnchor | null) => void;
+  /** Note the current open rows; the write is debounced. */
+  recordOpenRows: (openRows: readonly string[]) => void;
+  /** Write any pending change immediately (chat change, unmount). */
+  flush: () => void;
+}
+
+const DEFAULT_DEBOUNCE_MS = 500;
+
+const EMPTY: ReadingState = { anchor: null, openRows: [] };
+
+/**
+ * Ties a chat to its browser-stored reading state (#239): loads where the
+ * reader left off when the chat opens, and saves the scroll anchor and open
+ * rows as they change — debounced, so a scroll or a burst of toggles writes
+ * once, and flushed on chat change so switching away never drops the last edit.
+ */
+export function useReadingState(
+  chatId: string | undefined,
+  { debounceMs = DEFAULT_DEBOUNCE_MS }: { debounceMs?: number } = {}
+): ReadingStateController {
+  const initial = useMemo(
+    () => (chatId ? loadReadingState(chatId) : null),
+    [chatId]
+  );
+
+  // The state we would write next, tagged with the chat it belongs to so a
+  // pending write always lands on the right chat even as the reader switches.
+  // Seeded from what was loaded so an early save (before any scroll) preserves
+  // the restored anchor rather than blanking it.
+  const latest = useRef<{ chatId: string | undefined; state: ReadingState }>({
+    chatId,
+    state: initial ?? EMPTY,
+  });
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flush = useCallback(() => {
+    if (timer.current !== null) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+    const { chatId: id, state } = latest.current;
+    if (id) saveReadingState(id, state);
+  }, []);
+
+  const schedule = useCallback(() => {
+    if (timer.current !== null) clearTimeout(timer.current);
+    timer.current = setTimeout(flush, debounceMs);
+  }, [flush, debounceMs]);
+
+  const recordAnchor = useCallback(
+    (anchor: ScrollAnchor | null) => {
+      latest.current = {
+        chatId: latest.current.chatId,
+        state: { ...latest.current.state, anchor },
+      };
+      schedule();
+    },
+    [schedule]
+  );
+  const recordOpenRows = useCallback(
+    (openRows: readonly string[]) => {
+      latest.current = {
+        chatId: latest.current.chatId,
+        state: { ...latest.current.state, openRows },
+      };
+      schedule();
+    },
+    [schedule]
+  );
+
+  // Flush the outgoing chat's pending write when the chat changes or the pane
+  // unmounts. Cleanup runs before the adopt-new effect below and reads `latest`
+  // while it still holds the outgoing chat, so nothing is lost or misfiled.
+  useEffect(() => flush, [chatId, flush]);
+
+  // Adopt the new chat's loaded state as the next write's baseline.
+  useEffect(() => {
+    latest.current = { chatId, state: initial ?? EMPTY };
+  }, [chatId, initial]);
+
+  return useMemo(
+    () => ({ initial, recordAnchor, recordOpenRows, flush }),
+    [initial, recordAnchor, recordOpenRows, flush]
+  );
+}

--- a/web/src/conversation/useRowExpansion.test.tsx
+++ b/web/src/conversation/useRowExpansion.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useRowExpansion } from "./useRowExpansion";
+
+describe("useRowExpansion", () => {
+  it("opens the rows it is seeded with", () => {
+    const { result } = renderHook(() =>
+      useRowExpansion("chat-1", { initialOpenRows: ["m-1:0"] })
+    );
+
+    expect(result.current.isKeyExpanded("m-1:0")).toBe(true);
+    expect(result.current.isKeyExpanded("m-2:0")).toBe(false);
+  });
+
+  it("re-seeds from the new chat's rows when the chat changes", () => {
+    const { result, rerender } = renderHook(
+      ({ chatId, seed }) => useRowExpansion(chatId, { initialOpenRows: seed }),
+      { initialProps: { chatId: "chat-1", seed: ["m-1:0"] } }
+    );
+
+    expect(result.current.isKeyExpanded("m-1:0")).toBe(true);
+
+    rerender({ chatId: "chat-2", seed: ["m-9:0"] });
+
+    expect(result.current.isKeyExpanded("m-1:0")).toBe(false);
+    expect(result.current.isKeyExpanded("m-9:0")).toBe(true);
+  });
+
+  it("reports the open rows after a toggle", () => {
+    const onOpenRowsChange = vi.fn();
+    const { result } = renderHook(() =>
+      useRowExpansion("chat-1", { onOpenRowsChange })
+    );
+
+    act(() => result.current.toggleKey("m-1:0"));
+
+    expect(onOpenRowsChange).toHaveBeenLastCalledWith(["m-1:0"]);
+  });
+});

--- a/web/src/conversation/useRowExpansion.ts
+++ b/web/src/conversation/useRowExpansion.ts
@@ -1,4 +1,13 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/** Seeds this chat's open rows and hears about changes, so reading state can be
+ * restored on open and persisted on toggle (#239). */
+export interface RowExpansionOptions {
+  /** Rows to open when the chat is first shown, from stored reading state. */
+  initialOpenRows?: readonly string[];
+  /** Called with the full open-row set whenever it changes. */
+  onOpenRowsChange?: (openRows: string[]) => void;
+}
 
 /** Whether each skim-layer row is open, and how to flip one. */
 export interface RowExpansion {
@@ -26,14 +35,27 @@ function key(messageId: string, blockIndex: number): string {
  * instance would silently follow the position instead of the row (#236). Keyed
  * by message id and block index, the two things that actually identify a row.
  */
-export function useRowExpansion(chatId: string | undefined): RowExpansion {
-  const [openRows, setOpenRows] = useState<ReadonlySet<string>>(new Set());
-  // A different chat is a different set of rows, so nothing carries over.
+export function useRowExpansion(
+  chatId: string | undefined,
+  { initialOpenRows, onOpenRowsChange }: RowExpansionOptions = {}
+): RowExpansion {
+  const [openRows, setOpenRows] = useState<ReadonlySet<string>>(
+    () => new Set(initialOpenRows)
+  );
+  // A different chat is a different set of rows: nothing carries over, and the
+  // new chat opens with whatever its reading state remembered (#239).
   const [seenChatId, setSeenChatId] = useState(chatId);
   if (seenChatId !== chatId) {
     setSeenChatId(chatId);
-    setOpenRows(new Set());
+    setOpenRows(new Set(initialOpenRows));
   }
+
+  // Held in a ref so a toggle can report the new set without re-subscribing the
+  // callback on every change. Synced in an effect, never during render.
+  const onChangeRef = useRef(onOpenRowsChange);
+  useEffect(() => {
+    onChangeRef.current = onOpenRowsChange;
+  });
 
   const isKeyExpanded = useCallback(
     (rowKey: string) => openRows.has(rowKey),
@@ -43,6 +65,7 @@ export function useRowExpansion(chatId: string | undefined): RowExpansion {
     setOpenRows((current) => {
       const next = new Set(current);
       if (!next.delete(rowKey)) next.add(rowKey);
+      onChangeRef.current?.([...next]);
       return next;
     });
   }, []);


### PR DESCRIPTION
## Background (Why)

Reopening a chat threw away everything about how you were reading it: which units you had opened, and where you had scrolled to. Every visit started at the bottom with everything closed — right the first time, wrong every time after.

## Approach (How)

Reading state is remembered per chat, in the browser rather than the Metadata store. This is not something you authored about a chat, so losing it should cost one landing at the bottom, nothing more.

Scroll position is stored as a **message anchor** — the topmost visible message plus an offset into it — never a raw `scrollTop`. The pane virtualizes with estimated heights, so a pixel offset means something different on every load depending on measurement order and which rows are open. An anchor also survives the chat gaining or losing messages between visits.

Restore scrolls **by index**: `scrollToIndex` re-measures and re-scrolls until the anchored message truly lands at the top, which a raw offset cannot do against estimated heights.

The logic lives in small pure modules with the DOM/virtualizer wiring kept thin, so the parts worth testing are testable and the parts jsdom cannot measure stay small.

## Changes (What)

- [x] `readingState.ts` — versioned localStorage store, debounced writes, bounded to the 50 most recently read chats with LRU eviction
- [x] `scrollAnchor.ts` — `pickAnchor` (topmost visible message + offset) and `resolveAnchorIndex` (null when the anchored message is gone)
- [x] `useReadingState.ts` — loads on open, debounces writes (500ms), flushes on chat switch and unmount so a pending write always lands on the right chat
- [x] `useRowExpansion` — seeds from stored open rows instead of always starting closed, and reports changes for persistence
- [x] `ConversationView` — restores anchor + open rows on open, captures the anchor on scroll, falls back to the bottom when there is nothing remembered
- [x] Landing now waits for the open chat's own messages (`loading` threaded from `useMessages`)

### Test Verification

- [x] Restore: reopening a chat returns to the remembered scroll position (verified in a real browser across three switch-away-and-back rounds, landing at the same offset each time)
- [x] Restore: a row expanded before switching away is still expanded on return
- [x] No-state fallback: a chat with nothing remembered lands at the bottom, as today
- [x] Missing-anchor fallback: `resolveAnchorIndex` returns null when the anchored message no longer exists, so the pane lands at the bottom rather than erroring
- [x] Eviction: writing past the bound drops the least-recently-written chat; re-reading a chat spares it
- [x] Debounce: a burst of scrolls writes once, with the latest anchor, combined with the latest open rows
- [x] Live-arrival following and the unread divider unchanged (existing `liveArrival` / `firstUnseenIndex` / `ConversationView` suites still green)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm build` clean; full suite green (web 416, api 401)

## Additional Notes

While wiring this up I found a real bug worth calling out: during a chat switch, `useMessages` keeps returning the **previous** chat's messages until the new fetch settles. The landing effect fired against those stale turns, never found this chat's anchor, and fell back to the bottom every single time. Landing is now gated on `loading`, so it only runs once the fetch for the current chat has settled. Any future effect keying on `[chatId, messages.length]` needs the same care.

Two known limitations, both deliberate:

- The within-message offset is a nudge applied after `scrollToIndex`; the virtualizer's own re-measure retry can override it, so restore lands at the anchored message's top rather than exactly mid-message. Landing on the right message is the part that matters.
- Opening a chat and immediately leaving still writes an entry. That is intended — the store is "chats you have recently read".

## Related Links

- Closes #239
- Follows #236 (Run grouping + lifted expansion state), which this builds on for the open-row keys