### PR TITLE
feat: colour the code in diffs and reads, from one lazily-loaded highlighter

### DIFF
--- a/web/e2e/code-highlighting.spec.ts
+++ b/web/e2e/code-highlighting.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect } from "@playwright/test";
+
+// Large enough that colouring every line has a real cost, so an expansion is a
+// genuine measurement rather than a toy.
+const LINE_COUNT = 200;
+
+function largePatch() {
+  const lines: string[] = [];
+  for (let i = 0; i < LINE_COUNT; i += 1) {
+    lines.push(`+const value${i} = ${i} as const;`);
+  }
+  return [
+    { oldStart: 1, oldLines: 0, newStart: 1, newLines: LINE_COUNT, lines },
+  ];
+}
+
+// A Read result as the tool writes it: `<line number>\t<content>`.
+function largeReadResult() {
+  const lines: string[] = [];
+  for (let i = 1; i <= LINE_COUNT; i += 1) {
+    lines.push(`${i}\tconst value${i} = ${i} as const;`);
+  }
+  return lines.join("\n");
+}
+
+/** Mount a one-turn chat whose assistant message carries `blocks`. */
+async function openChatWith(
+  page: import("@playwright/test").Page,
+  blocks: unknown[]
+) {
+  // Benign empty SSE stream so the live-update EventSource connects cleanly.
+  await page.route(/\/api\/chats\/stream(\?|$)/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: ":ok\n\n",
+    })
+  );
+  await page.route(/\/api\/chats\/counts(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1, projects: [], tags: [], untagged: 1 } })
+  );
+  await page.route(/\/api\/chats\/list-total(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1 } })
+  );
+  await page.route(/\/api\/chats(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        chats: [
+          {
+            id: "clog_code1",
+            sourceId: "code-chat",
+            agent: "claude-code",
+            title: "Code conversation",
+            project: "/test/project",
+            sourceFilePath: null,
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      },
+    })
+  );
+  await page.route(/\/api\/chats\/clog_code1(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        messages: [
+          {
+            role: "assistant",
+            content: blocks,
+            timestamp: "2023-11-14T22:13:20.000Z",
+          },
+        ],
+      },
+    })
+  );
+
+  await page.goto("/");
+  await page.getByText("Code conversation").click();
+}
+
+test("a large diff expands and highlights in a real browser without stalling", async ({
+  page,
+}) => {
+  await openChatWith(page, [
+    {
+      type: "tool_use",
+      id: "tool_1",
+      name: "Write",
+      input: { file_path: "web/src/constants.ts" },
+    },
+    {
+      type: "tool_result",
+      tool_use_id: "tool_1",
+      content: "File written",
+      file_path: "web/src/constants.ts",
+      patch: largePatch(),
+    },
+  ]);
+
+  // The collapsed tool unit summarises the write; the full path shows once the
+  // diff is expanded.
+  const summary = page.getByText("Wrote constants.ts +200 -0");
+  await expect(summary).toBeVisible();
+
+  const start = Date.now();
+  await summary.click();
+  await expect(page.getByText("web/src/constants.ts")).toBeVisible();
+
+  // Highlighting arrives after the lazy highlighter load — the keyword tokens
+  // appear, proving the language was inferred and applied.
+  await expect(page.locator(".hljs-keyword").first()).toBeVisible();
+  const elapsed = Date.now() - start;
+
+  // The default line cap folds the tail behind a reveal, so the first view is
+  // never the whole 200 lines — the expansion cannot stall on them.
+  await expect(
+    page.getByRole("button", { name: /Show \d+ more/ })
+  ).toBeVisible();
+
+  // Generous bound: this only fails if expansion genuinely blocks, not on
+  // ordinary render jitter.
+  expect(elapsed).toBeLessThan(3000);
+
+  // The added ground survives under the token colours: rows are still tinted.
+  const addedRow = page
+    .locator('[data-testid="diff-line"][data-kind="add"]')
+    .first();
+  await expect(addedRow).toHaveClass(/bg-green-500\/10/);
+  await expect(addedRow.locator(".hljs-keyword").first()).toBeVisible();
+});
+
+test("a large read expands as a highlighted, numbered excerpt without stalling", async ({
+  page,
+}) => {
+  await openChatWith(page, [
+    {
+      type: "tool_use",
+      id: "tool_2",
+      name: "Read",
+      input: { file_path: "web/src/constants.ts" },
+    },
+    {
+      type: "tool_result",
+      tool_use_id: "tool_2",
+      content: largeReadResult(),
+    },
+  ]);
+
+  const summary = page.getByText("Read: web/src/constants.ts");
+  await expect(summary).toBeVisible();
+
+  const start = Date.now();
+  await summary.click();
+
+  await expect(page.locator(".hljs-keyword").first()).toBeVisible();
+  const elapsed = Date.now() - start;
+
+  // The cap folds the tail, so a whole file read into the pane cannot stall it.
+  await expect(
+    page.getByRole("button", { name: /Show \d+ more/ })
+  ).toBeVisible();
+  expect(elapsed).toBeLessThan(3000);
+
+  // The numbers were lifted into a gutter: the first row shows line 1 beside
+  // its code, not the raw `1\t…` the tool wrote.
+  const firstRow = page.locator('[data-testid="excerpt-line"]').first();
+  await expect(firstRow).toContainText("1");
+  await expect(firstRow.locator(".hljs-keyword").first()).toBeVisible();
+});

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1480,11 +1480,11 @@ describe("Tool call rendering", () => {
     // Tool call summary should be visible
     expect(await screen.findByText("Read: src/utils.ts")).toBeInTheDocument();
 
-    // Full tool input should NOT be visible when collapsed
-    expect(screen.queryByText(/"file_path"/)).not.toBeInTheDocument();
+    // The file it read should NOT be visible when collapsed
+    expect(screen.queryByTestId("excerpt-line")).not.toBeInTheDocument();
   });
 
-  it("expands tool call to show full input when clicked", async () => {
+  it("expands tool call to show the file it read when clicked", async () => {
     const user = userEvent.setup();
     render(<App />);
 
@@ -1494,8 +1494,9 @@ describe("Tool call rendering", () => {
     // Click to expand
     await user.click(summary);
 
-    // Should show the tool input details
-    expect(screen.getByText(/"file_path"/)).toBeInTheDocument();
+    // A read opens onto the file itself, not the call's raw JSON (#240).
+    const row = screen.getByTestId("excerpt-line");
+    expect(row.textContent).toContain("export function add(a, b)");
   });
 
   it("collapses tool call back when clicked again", async () => {
@@ -1507,10 +1508,10 @@ describe("Tool call rendering", () => {
 
     // Expand then collapse
     await user.click(summary);
-    expect(screen.getByText(/"file_path"/)).toBeInTheDocument();
+    expect(screen.getByTestId("excerpt-line")).toBeInTheDocument();
 
     await user.click(summary);
-    expect(screen.queryByText(/"file_path"/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("excerpt-line")).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/conversation/CollapsibleToolCall.test.tsx
+++ b/web/src/conversation/CollapsibleToolCall.test.tsx
@@ -66,4 +66,59 @@ describe("CollapsibleToolCall", () => {
     expect(screen.queryByTestId("diff-line")).toBeNull();
     expect(screen.getByText("The file a.tsx has been updated.")).not.toBeNull();
   });
+
+  it("renders an expanded read as a numbered file excerpt, not raw output", () => {
+    const readCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t2",
+      name: "Read",
+      input: { file_path: "src/answer.ts" },
+    };
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t2",
+      content: "40\tconst answer = 42;\n41\treturn answer;",
+    };
+
+    render(
+      <CollapsibleToolCall
+        block={readCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    const rows = screen.getAllByTestId("excerpt-line");
+    expect(rows).toHaveLength(2);
+    expect(screen.getByText("src/answer.ts")).not.toBeNull();
+    // The numbers are lifted into the gutter, so the raw `40\t…` never shows.
+    expect(screen.getByText("const answer = 42;")).not.toBeNull();
+    expect(screen.queryByText(/40\tconst answer = 42;/)).toBeNull();
+  });
+
+  it("falls back to the raw rendering for a read whose result is not text", () => {
+    const readCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t3",
+      name: "Read",
+      input: { file_path: "shot.png" },
+    };
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t3",
+      content: [{ type: "image", source: "…" }],
+    };
+
+    render(
+      <CollapsibleToolCall
+        block={readCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    expect(screen.queryByTestId("excerpt-line")).toBeNull();
+  });
 });

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -2,6 +2,7 @@ import { Terminal } from "lucide-react";
 import type { ContentBlock } from "@/types";
 import { CollapsibleRow } from "@/conversation/CollapsibleRow";
 import { DiffView } from "@/conversation/DiffView";
+import { FileExcerptView } from "@/conversation/FileExcerptView";
 import { generateToolSummary } from "@/conversation/generateToolSummary";
 import type { ToolResultBlock } from "@/conversation/toolUnits";
 
@@ -17,6 +18,12 @@ interface CollapsibleToolCallProps {
 function formatResultContent(content: unknown): string {
   if (typeof content === "string") return content;
   return JSON.stringify(content, null, 2);
+}
+
+function readFilePath(input: unknown): string | undefined {
+  if (typeof input !== "object" || input === null) return undefined;
+  const { file_path: filePath } = input as { file_path?: unknown };
+  return typeof filePath === "string" ? filePath : undefined;
 }
 
 /**
@@ -37,6 +44,17 @@ export function CollapsibleToolCall({
   const patch = result?.patch;
   const isDiff = Boolean(result?.file_path && patch && patch.length > 0);
 
+  // A read's whole value is the file it returned, so it gets the same treatment
+  // as an edit: the path, the file's own line numbers, and its code coloured.
+  // The path comes from the call — a read result carries only the text (#240).
+  // A non-text result (an image the tool returned) has no lines to number and
+  // keeps the raw rendering.
+  const readPath =
+    block.name === "Read" ? readFilePath(block.input) : undefined;
+  const isExcerpt = Boolean(
+    !isDiff && readPath && typeof result?.content === "string"
+  );
+
   return (
     <CollapsibleRow
       icon={Terminal}
@@ -47,6 +65,11 @@ export function CollapsibleToolCall({
     >
       {isDiff ? (
         <DiffView filePath={result!.file_path!} patch={patch!} />
+      ) : isExcerpt ? (
+        <FileExcerptView
+          filePath={readPath!}
+          content={result!.content as string}
+        />
       ) : (
         <>
           <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -584,7 +584,10 @@ describe("Conversation tool units", () => {
 
     await user.click(await screen.findByText("Read: /tmp/a.ts"));
 
-    expect(await screen.findByText(/export const answer = 42;/)).not.toBeNull();
+    // Highlighting splits the code into token spans, so match on the row's
+    // whole text rather than a single node's (#240).
+    const row = await screen.findByTestId("excerpt-line");
+    expect(row.textContent).toContain("export const answer = 42;");
   });
 
   it("pairs a call with a result recorded in the next turn", async () => {

--- a/web/src/conversation/DiffView.test.tsx
+++ b/web/src/conversation/DiffView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
 import type { PatchHunk } from "@/types";
@@ -95,5 +95,92 @@ describe("DiffView", () => {
     expect(screen.getAllByTestId("diff-line")).toHaveLength(6);
     expect(screen.getByText("six")).not.toBeNull();
     expect(screen.queryByRole("button")).toBeNull();
+  });
+});
+
+const tsHunk: PatchHunk = {
+  oldStart: 1,
+  oldLines: 0,
+  newStart: 1,
+  newLines: 1,
+  lines: ["+const answer = 42;"],
+};
+
+describe("DiffView syntax highlighting", () => {
+  it("highlights the code, with the language taken from the file path", async () => {
+    const { container } = render(
+      <DiffView filePath="answer.ts" patch={[tsHunk]} />
+    );
+
+    // The highlighter loads after mount, so the keyword span appears async.
+    await waitFor(() =>
+      expect(container.querySelector(".hljs-keyword")).not.toBeNull()
+    );
+    expect(container.querySelector(".hljs-keyword")?.textContent).toBe("const");
+  });
+
+  it("renders plain, with no token markup, for an unrecognised language", async () => {
+    const { container } = render(
+      <DiffView filePath="notes/journal.xyz" patch={[tsHunk]} />
+    );
+
+    // Give any stray highlighter load a chance to resolve; it must not — the
+    // text stays a single plain node.
+    await Promise.resolve();
+    expect(container.querySelector("[class^='hljs-']")).toBeNull();
+    expect(screen.getByText("const answer = 42;")).not.toBeNull();
+  });
+
+  it("stops highlighting past the cap, so the rest renders plain", async () => {
+    const twoLines: PatchHunk = {
+      oldStart: 1,
+      oldLines: 0,
+      newStart: 1,
+      newLines: 2,
+      lines: ["+const first = 1;", "+const second = 2;"],
+    };
+
+    const { container } = render(
+      <DiffView filePath="answer.ts" patch={[twoLines]} highlightCap={1} />
+    );
+
+    // The first line is highlighted; the second, past the cap, stays plain.
+    await waitFor(() =>
+      expect(container.querySelectorAll(".hljs-keyword")).toHaveLength(1)
+    );
+    const rows = screen.getAllByTestId("diff-line");
+    expect(within(rows[0]).queryByText("const")).not.toBeNull();
+    expect(within(rows[1]).getByText("const second = 2;")).not.toBeNull();
+  });
+
+  it("keeps the added/removed ground under the token colours", async () => {
+    const changeHunk: PatchHunk = {
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 1,
+      lines: ["-const old = 1;", "+const now = 2;"],
+    };
+
+    const { container } = render(
+      <DiffView filePath="answer.ts" patch={[changeHunk]} />
+    );
+
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll(".hljs-keyword").length
+      ).toBeGreaterThan(0)
+    );
+
+    // The tint rides on the row, not the token spans — so it survives with
+    // highlighting applied: the diff is still primarily a diff.
+    const rows = screen.getAllByTestId("diff-line");
+    const removed = rows.find((r) => r.getAttribute("data-kind") === "remove");
+    const added = rows.find((r) => r.getAttribute("data-kind") === "add");
+    expect(removed?.className).toContain("bg-destructive/10");
+    expect(added?.className).toContain("bg-green-500/10");
+    // The token colours live inside those same rows.
+    expect(removed?.querySelector(".hljs-keyword")).not.toBeNull();
+    expect(added?.querySelector(".hljs-keyword")).not.toBeNull();
   });
 });

--- a/web/src/conversation/DiffView.tsx
+++ b/web/src/conversation/DiffView.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { PatchHunk } from "@/types";
 import { buildDiff, type DiffLine } from "@/conversation/diffModel";
+import { useHighlighter } from "@/conversation/codeHighlight";
 
 interface DiffViewProps {
   filePath: string;
@@ -11,9 +12,16 @@ interface DiffViewProps {
    * opts into the tail (#237).
    */
   lineCap?: number;
+  /**
+   * How many rendered lines get syntax highlighting. Lines past this cap render
+   * plain, so revealing a very long diff is never blocked on highlighting every
+   * line — the red/green ground still carries them (#240).
+   */
+  highlightCap?: number;
 }
 
 const DEFAULT_LINE_CAP = 40;
+const DEFAULT_HIGHLIGHT_CAP = 500;
 
 // Both sides tinted, so a row reads as added or removed from its ground alone —
 // the line-number gutters then say where it sits. Context stays untinted and
@@ -34,10 +42,24 @@ function gutter(n: number | null): string {
   return n === null ? "" : String(n);
 }
 
+// Where each hunk's lines begin in a count running across the whole diff, so a
+// per-line index can be read without mutating a counter during render. The
+// highlight cap then bounds the diff as a whole, not each hunk on its own.
+function hunkStartIndices(hunks: { lines: unknown[] }[]): number[] {
+  const starts: number[] = [];
+  let total = 0;
+  for (const hunk of hunks) {
+    starts.push(total);
+    total += hunk.lines.length;
+  }
+  return starts;
+}
+
 export function DiffView({
   filePath,
   patch,
   lineCap = DEFAULT_LINE_CAP,
+  highlightCap = DEFAULT_HIGHLIGHT_CAP,
 }: DiffViewProps) {
   const [showAll, setShowAll] = useState(false);
   const { hunks, hiddenLines } = buildDiff(
@@ -45,11 +67,18 @@ export function DiffView({
     showAll ? Number.POSITIVE_INFINITY : lineCap
   );
 
+  // Null until the lazy highlighter lands, and forever for a path whose
+  // language we do not recognise — the diff renders plain in both cases. A diff
+  // only mounts once expanded, so a chat that opens none never loads it (#240).
+  const highlight = useHighlighter(filePath);
+
   // A new file is all additions, so its old-side gutter is empty on every row.
   // Dropping it leaves a single new-side gutter rather than a dead column.
   const hasOldColumn = hunks.some((hunk) =>
     hunk.lines.some((line) => line.oldLineNumber !== null)
   );
+
+  const hunkStart = hunkStartIndices(hunks);
 
   return (
     <div className="overflow-x-auto rounded bg-card font-mono text-xs">
@@ -63,34 +92,54 @@ export function DiffView({
           // so two hunks don't read as one continuous stretch.
           className={hunkIndex > 0 ? "border-t border-border" : undefined}
         >
-          {hunk.lines.map((line, lineIndex) => (
-            <div
-              key={lineIndex}
-              data-testid="diff-line"
-              data-kind={line.kind}
-              className={`flex ${KIND_ROW_CLASS[line.kind]} ${
-                line.kind === "context"
-                  ? "text-muted-foreground"
-                  : "text-foreground"
-              }`}
-            >
-              {hasOldColumn && (
-                <span
-                  data-testid="diff-old-gutter"
-                  className="w-8 shrink-0 select-none px-1 text-right tabular-nums text-muted-foreground"
-                >
-                  {gutter(line.oldLineNumber)}
+          {hunk.lines.map((line, lineIndex) => {
+            // Past the cap the line renders plain, so revealing a very long
+            // diff is never blocked on colouring every one of them. The tint
+            // stays on the row; the tokens colour only the text.
+            const contentIndex = hunkStart[hunkIndex] + lineIndex;
+            const highlighted =
+              highlight && contentIndex < highlightCap
+                ? highlight(line.text)
+                : null;
+
+            return (
+              <div
+                key={lineIndex}
+                data-testid="diff-line"
+                data-kind={line.kind}
+                className={`flex ${KIND_ROW_CLASS[line.kind]} ${
+                  line.kind === "context"
+                    ? "text-muted-foreground"
+                    : "text-foreground"
+                }`}
+              >
+                {hasOldColumn && (
+                  <span
+                    data-testid="diff-old-gutter"
+                    className="w-8 shrink-0 select-none px-1 text-right tabular-nums text-muted-foreground"
+                  >
+                    {gutter(line.oldLineNumber)}
+                  </span>
+                )}
+                <span className="w-8 shrink-0 select-none px-1 text-right tabular-nums text-muted-foreground">
+                  {gutter(line.newLineNumber)}
                 </span>
-              )}
-              <span className="w-8 shrink-0 select-none px-1 text-right tabular-nums text-muted-foreground">
-                {gutter(line.newLineNumber)}
-              </span>
-              <span className="w-3 shrink-0 select-none text-center text-muted-foreground">
-                {KIND_SIGN[line.kind]}
-              </span>
-              <span className="whitespace-pre pr-2">{line.text}</span>
-            </div>
-          ))}
+                <span className="w-3 shrink-0 select-none text-center text-muted-foreground">
+                  {KIND_SIGN[line.kind]}
+                </span>
+                {highlighted !== null ? (
+                  <span
+                    className="whitespace-pre pr-2"
+                    // The token spans carry only colour; the row's tint and the
+                    // reader's text selection are untouched.
+                    dangerouslySetInnerHTML={{ __html: highlighted }}
+                  />
+                ) : (
+                  <span className="whitespace-pre pr-2">{line.text}</span>
+                )}
+              </div>
+            );
+          })}
         </div>
       ))}
       {hiddenLines > 0 && (

--- a/web/src/conversation/FileExcerptView.test.tsx
+++ b/web/src/conversation/FileExcerptView.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import { FileExcerptView } from "./FileExcerptView";
+
+const TS_CONTENT = ["40\tconst answer = 42;", "41\treturn answer;"].join("\n");
+
+describe("FileExcerptView", () => {
+  it("shows the file path above the excerpt, with each line's real number", () => {
+    render(<FileExcerptView filePath="src/answer.ts" content={TS_CONTENT} />);
+
+    expect(screen.getByText("src/answer.ts")).not.toBeNull();
+
+    const rows = screen.getAllByTestId("excerpt-line");
+    expect(within(rows[0]).getByText("40")).not.toBeNull();
+    expect(within(rows[1]).getByText("41")).not.toBeNull();
+    expect(within(rows[1]).getByText("return answer;")).not.toBeNull();
+  });
+
+  it("highlights the code, with the language taken from the file path", async () => {
+    const { container } = render(
+      <FileExcerptView filePath="src/answer.ts" content={TS_CONTENT} />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector(".hljs-keyword")).not.toBeNull()
+    );
+    // The number stays in the gutter, uncoloured — only the code is tokenised.
+    expect(container.querySelector(".hljs-keyword")?.textContent).toBe("const");
+  });
+
+  it("renders plain, with no token markup, for an unrecognised language", async () => {
+    const { container } = render(
+      <FileExcerptView filePath="notes/journal.xyz" content={TS_CONTENT} />
+    );
+
+    await Promise.resolve();
+    expect(container.querySelector("[class^='hljs-']")).toBeNull();
+    expect(screen.getByText("const answer = 42;")).not.toBeNull();
+  });
+
+  it("stops highlighting past the cap, so the rest renders plain", async () => {
+    const { container } = render(
+      <FileExcerptView
+        filePath="src/answer.ts"
+        content={TS_CONTENT}
+        highlightCap={1}
+      />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelectorAll(".hljs-keyword")).toHaveLength(1)
+    );
+    const rows = screen.getAllByTestId("excerpt-line");
+    expect(within(rows[1]).getByText("return answer;")).not.toBeNull();
+  });
+
+  it("caps a long excerpt and reveals the rest on demand", async () => {
+    const content = ["1\ta", "2\tb", "3\tc", "4\td"].join("\n");
+
+    render(<FileExcerptView filePath="a.txt" content={content} lineCap={2} />);
+
+    expect(screen.getAllByTestId("excerpt-line")).toHaveLength(2);
+
+    const reveal = screen.getByRole("button");
+    expect(reveal.textContent).toContain("2");
+    await userEvent.click(reveal);
+
+    expect(screen.getAllByTestId("excerpt-line")).toHaveLength(4);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("drops the gutter for output that carries no line numbers", () => {
+    render(
+      <FileExcerptView filePath="a.ts" content={"plain output\nno numbers"} />
+    );
+
+    const rows = screen.getAllByTestId("excerpt-line");
+    expect(within(rows[0]).getByText("plain output")).not.toBeNull();
+    // One child only: the text. No gutter column was drawn.
+    expect(rows[0].children).toHaveLength(1);
+  });
+});

--- a/web/src/conversation/FileExcerptView.tsx
+++ b/web/src/conversation/FileExcerptView.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { buildExcerpt } from "@/conversation/fileExcerpt";
+import { useHighlighter } from "@/conversation/codeHighlight";
+
+interface FileExcerptViewProps {
+  filePath: string;
+  /** The Read result verbatim, line numbers and all. */
+  content: string;
+  /**
+   * Most lines rendered before the rest is folded behind a reveal control. A
+   * whole file read into the pane is capped so it cannot stall it; the reader
+   * opts into the tail, as with a long diff (#240).
+   */
+  lineCap?: number;
+  /**
+   * How many rendered lines get syntax highlighting. Lines past this cap render
+   * plain, so revealing a very long file is never blocked on colouring all of
+   * it (#240).
+   */
+  highlightCap?: number;
+}
+
+const DEFAULT_LINE_CAP = 40;
+const DEFAULT_HIGHLIGHT_CAP = 500;
+
+function gutter(n: number | null): string {
+  return n === null ? "" : String(n);
+}
+
+/**
+ * A file as a Read tool reported it: the path, then its numbered lines.
+ *
+ * The same shape a diff renders in — path header, line-number gutter, code —
+ * minus the added/removed grounds, which a read has no use for. Sharing the
+ * layout is the point: a file looks like a file wherever the pane shows one.
+ */
+export function FileExcerptView({
+  filePath,
+  content,
+  lineCap = DEFAULT_LINE_CAP,
+  highlightCap = DEFAULT_HIGHLIGHT_CAP,
+}: FileExcerptViewProps) {
+  const [showAll, setShowAll] = useState(false);
+  const { lines, hiddenLines } = buildExcerpt(
+    content,
+    showAll ? Number.POSITIVE_INFINITY : lineCap
+  );
+
+  // Null until the lazy highlighter lands, and forever for a path whose
+  // language we do not recognise — the excerpt renders plain in both cases.
+  const highlight = useHighlighter(filePath);
+
+  // A result with no numbering is not a file excerpt; dropping the gutter
+  // leaves it reading as the plain output it is, rather than a dead column.
+  const hasGutter = lines.some((line) => line.lineNumber !== null);
+
+  return (
+    <div className="overflow-x-auto rounded bg-card font-mono text-xs">
+      <div className="border-b border-border px-2 py-1 text-muted-foreground">
+        {filePath}
+      </div>
+      {lines.map((line, index) => {
+        const highlighted =
+          highlight && index < highlightCap ? highlight(line.text) : null;
+
+        return (
+          <div
+            key={index}
+            data-testid="excerpt-line"
+            className="flex text-foreground"
+          >
+            {hasGutter && (
+              <span className="w-10 shrink-0 select-none px-1 text-right tabular-nums text-muted-foreground">
+                {gutter(line.lineNumber)}
+              </span>
+            )}
+            {highlighted !== null ? (
+              <span
+                className="whitespace-pre pr-2"
+                dangerouslySetInnerHTML={{ __html: highlighted }}
+              />
+            ) : (
+              <span className="whitespace-pre pr-2">{line.text}</span>
+            )}
+          </div>
+        );
+      })}
+      {hiddenLines > 0 && (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="w-full cursor-pointer border-t border-border px-2 py-1 text-left text-muted-foreground transition-colors hover:bg-white/[0.04] hover:text-foreground"
+        >
+          Show {hiddenLines} more {hiddenLines === 1 ? "line" : "lines"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/conversation/codeHighlight.test.ts
+++ b/web/src/conversation/codeHighlight.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { languageForPath } from "./codeHighlight";
+
+describe("languageForPath", () => {
+  it("infers the highlight language from a file's extension", () => {
+    expect(languageForPath("web/src/conversation/DiffView.tsx")).toBe(
+      "typescript"
+    );
+  });
+
+  it("returns null for an unrecognised extension, so the diff renders plain", () => {
+    expect(languageForPath("notes/journal.xyz")).toBeNull();
+  });
+});

--- a/web/src/conversation/codeHighlight.ts
+++ b/web/src/conversation/codeHighlight.ts
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from "react";
+import type { HLJSApi } from "highlight.js";
+
+/**
+ * Map a file extension to a highlight.js language id.
+ *
+ * Only the common set is registered (see `loadHighlighter`), so this maps to
+ * ids that set is known to carry. An extension not listed here resolves to
+ * `null`, and the caller renders the diff plain — the same as today for a file
+ * whose language we do not recognise (#240).
+ */
+const EXTENSION_LANGUAGE: Record<string, string> = {
+  ts: "typescript",
+  tsx: "typescript",
+  mts: "typescript",
+  cts: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  json: "json",
+  css: "css",
+  scss: "scss",
+  less: "less",
+  html: "xml",
+  xml: "xml",
+  svg: "xml",
+  md: "markdown",
+  markdown: "markdown",
+  py: "python",
+  rb: "ruby",
+  go: "go",
+  rs: "rust",
+  java: "java",
+  kt: "kotlin",
+  swift: "swift",
+  c: "c",
+  h: "c",
+  cpp: "cpp",
+  cc: "cpp",
+  hpp: "cpp",
+  cs: "csharp",
+  php: "php",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  yml: "yaml",
+  yaml: "yaml",
+  toml: "ini",
+  ini: "ini",
+  sql: "sql",
+  diff: "diff",
+  dockerfile: "dockerfile",
+};
+
+/**
+ * The highlight.js language for a path, or `null` when its extension is not one
+ * we highlight. Pure, so the mapping is testable without loading the
+ * highlighter — and a `null` result lets the view skip the load entirely.
+ */
+export function languageForPath(path: string): string | null {
+  const name = path.split("/").pop() ?? path;
+  const dot = name.lastIndexOf(".");
+  const ext = dot === -1 ? name : name.slice(dot + 1);
+  return EXTENSION_LANGUAGE[ext.toLowerCase()] ?? null;
+}
+
+// Cached so the highlighter is fetched at most once per session, on whichever
+// code view opens first. Chats that open none never touch this promise, so they
+// never pay for the highlighter (#240).
+let highlighterPromise: Promise<HLJSApi> | null = null;
+
+/**
+ * Load the highlighter, lazily. The common-language bundle is imported on first
+ * call and reused thereafter, so it is code-split out of the initial load and
+ * fetched only when some code view is first expanded.
+ */
+export function loadHighlighter(): Promise<HLJSApi> {
+  if (!highlighterPromise) {
+    highlighterPromise = import("highlight.js/lib/common").then(
+      (module) => module.default
+    );
+  }
+  return highlighterPromise;
+}
+
+/**
+ * A highlighter for one file's lines, or `null` while it cannot colour them.
+ *
+ * `null` covers both cases a view renders plain: a path whose language we do
+ * not recognise — where the highlighter is never even loaded — and the moment
+ * before the lazy load resolves. Callers render `line.text` then, so code is
+ * always readable and highlighting only ever arrives as an improvement.
+ *
+ * Highlighting a line at a time drops multi-line context (a string opened on
+ * one line and closed on the next), which is the trade both a diff and a read
+ * excerpt already make: neither is guaranteed to hold a whole file, and it
+ * keeps each line's markup independent of its neighbours.
+ */
+export function useHighlighter(
+  filePath: string
+): ((text: string) => string) | null {
+  const language = useMemo(() => languageForPath(filePath), [filePath]);
+  const [hljs, setHljs] = useState<HLJSApi | null>(null);
+
+  useEffect(() => {
+    if (!language) return;
+    let active = true;
+    loadHighlighter().then((loaded) => {
+      if (active) setHljs(loaded);
+    });
+    return () => {
+      active = false;
+    };
+  }, [language]);
+
+  return useMemo(() => {
+    if (!language || !hljs) return null;
+    return (text: string) =>
+      hljs.highlight(text, { language, ignoreIllegals: true }).value;
+  }, [language, hljs]);
+}

--- a/web/src/conversation/fileExcerpt.test.ts
+++ b/web/src/conversation/fileExcerpt.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { buildExcerpt } from "./fileExcerpt";
+
+describe("buildExcerpt", () => {
+  it("splits a Read result's line numbers off its content", () => {
+    const excerpt = buildExcerpt("1\tconst a = 1;\n2\tconst b = 2;", 100);
+
+    expect(excerpt.lines).toEqual([
+      { lineNumber: 1, text: "const a = 1;" },
+      { lineNumber: 2, text: "const b = 2;" },
+    ]);
+    expect(excerpt.hiddenLines).toBe(0);
+  });
+
+  it("keeps a file's real numbers, which need not start at one", () => {
+    const excerpt = buildExcerpt("40\tfourty\n41\tfourty-one", 100);
+
+    expect(excerpt.lines.map((l) => l.lineNumber)).toEqual([40, 41]);
+  });
+
+  it("renders content with no number prefix as plain, unnumbered lines", () => {
+    const excerpt = buildExcerpt("just some output\nno numbers here", 100);
+
+    expect(excerpt.lines).toEqual([
+      { lineNumber: null, text: "just some output" },
+      { lineNumber: null, text: "no numbers here" },
+    ]);
+  });
+
+  it("caps a long excerpt and reports what it withheld", () => {
+    const content = ["1\ta", "2\tb", "3\tc", "4\td", "5\te"].join("\n");
+
+    const excerpt = buildExcerpt(content, 3);
+
+    expect(excerpt.lines.map((l) => l.text)).toEqual(["a", "b", "c"]);
+    expect(excerpt.hiddenLines).toBe(2);
+  });
+});

--- a/web/src/conversation/fileExcerpt.ts
+++ b/web/src/conversation/fileExcerpt.ts
@@ -1,0 +1,45 @@
+/**
+ * One line of a file as a Read tool reported it.
+ *
+ * `lineNumber` is the file's own number, taken from the prefix the tool wrote —
+ * not a running count from one, so an excerpt that starts at line 40 says so.
+ * It is `null` when the result carries no numbering at all, which is how a
+ * result that is not a file excerpt still renders (#240).
+ */
+export interface ExcerptLine {
+  lineNumber: number | null;
+  text: string;
+}
+
+export interface FileExcerpt {
+  lines: ExcerptLine[];
+  /** Lines dropped past the cap; 0 when the whole excerpt renders. */
+  hiddenLines: number;
+}
+
+// A Read result numbers each line as `<n>\t<content>`. Anchored to the start of
+// the line, so a tab inside the content itself is left alone.
+const NUMBERED_LINE = /^(\d+)\t(.*)$/;
+
+/**
+ * Turn a Read result into numbered lines, bounded by a cap.
+ *
+ * Whether the result is numbered is decided once, from the first line, rather
+ * than per line: a file whose own text happens to open with digits and a tab
+ * would otherwise have that read as a line number partway down. `lineCap`
+ * bounds the lines rendered and reports the overflow as `hiddenLines`, so the
+ * view can offer to reveal the rest — the same bargain a long diff strikes.
+ */
+export function buildExcerpt(content: string, lineCap: number): FileExcerpt {
+  const rawLines = content.split("\n");
+  const numbered = NUMBERED_LINE.test(rawLines[0] ?? "");
+
+  const kept = rawLines.slice(0, lineCap);
+  const lines = kept.map((raw) => {
+    const match = numbered ? NUMBERED_LINE.exec(raw) : null;
+    if (!match) return { lineNumber: null, text: raw };
+    return { lineNumber: Number(match[1]), text: match[2] };
+  });
+
+  return { lines, hiddenLines: Math.max(0, rawLines.length - kept.length) };
+}


### PR DESCRIPTION
## Background (Why)

The diff rendering shipped in #237 deliberately left out syntax highlighting: line numbers and red/green carried most of the readability, and highlighting was the main performance risk on a long diff. #240 adds it as its own change, where its cost can be measured on its own.

Reading the code also turned up the neighbouring case. A Read result arrives as `<line number>\t<content>` and was dumped whole into a `pre` — numbers and code tangled in one column, uncoloured. It is the same problem the diff had, one tool over.

## Approach (How)

One deep module holds the whole mechanism: `useHighlighter(filePath)` returns a highlight function, or `null` while it cannot colour. That `null` covers both cases a view renders plain — an unrecognised extension, where the highlighter is never even loaded, and the moment before the lazy load resolves. Callers render plain text then, so code is always readable and colour only ever arrives as an improvement.

The highlighter is fetched through a dynamic `import()` and cached, so it is code-split into a chunk of its own and a chat that opens no code fetches nothing. Measured:

```
before:  index.js 806.4 kB   (single chunk)
after:   index.js 808.0 kB + common.js 131.8 kB (lazy)
```

The initial load moves by 1.6 kB. Verified in the built output that the reference is a real `import("./common-*.js")` and that `index.html` does not preload it.

Highlighting runs a line at a time. That drops multi-line context — a string opened on one line and closed on the next — which is the trade both views already make: neither holds a whole file, and it keeps the row tint on the row while the token colours touch only the text. So the added and removed grounds stay legible underneath.

For the read view, whether a result is numbered is decided **once, from the first line**, rather than per line. A file whose own text happens to open with digits and a tab would otherwise have that read as a line number partway down.

Following #237's precedent, both views stand in for the call's raw JSON rather than sitting beside it: the path is in the header and the range is in the gutter, so repeating the input adds nothing. This changes the expanded rendering of a Read, and three existing tests that asserted the old raw-JSON behaviour were updated to match.

## Changes (What)

- [x] `codeHighlight.ts` — `languageForPath` (pure, extension → hljs language, `null` when unrecognised) and `useHighlighter`, which owns the lazy load and caching
- [x] `DiffView` colours its lines, with a `highlightCap` past which lines render plain rather than delaying the expansion
- [x] `fileExcerpt.ts` — `buildExcerpt` splits a Read result's line numbers off its content, bounded by a cap
- [x] `FileExcerptView` — path header, line-number gutter, coloured code; drops the gutter for output carrying no numbering
- [x] `CollapsibleToolCall` routes a Read with a text result to the excerpt view; a non-text result (an image) keeps the raw rendering
- [x] Refactor: the module was `diffHighlight.ts`, renamed since it no longer belongs to the diff alone

### Test Verification

- [x] An expanded diff renders its code highlighted, with the language inferred from the file path
- [x] An unrecognised extension renders plain and never loads the highlighter
- [x] Lines past the highlight cap render unhighlighted rather than delaying the expansion
- [x] Added and removed grounds remain distinguishable with token colours applied
- [x] `buildExcerpt` splits numbers off content, keeps a file's real numbers (not a count from one), and falls back to unnumbered lines for output with no prefix
- [x] The excerpt view caps a long file and reveals the rest on demand; drops the gutter when nothing is numbered
- [x] A Read with a text result renders as an excerpt; one with a non-text result falls back to raw
- [x] Real browser (Chromium, run in CI): a 200-line diff and a 200-line read each expand, colour, keep the tail folded, and do not block
- [x] Bundle: verified the highlighter chunk is a genuine dynamic import and is not preloaded

Full suite green: 446 web tests, plus typecheck, lint and build.

## Additional Notes

Two copies of the grammars now ship. `rehype-highlight` pulls its own into the initial bundle eagerly for markdown code blocks; this change lazily loads a second. Both chunks carry grammar definitions (`beginKeywords` appears 40 times in the main chunk, 35 in the lazy one). The initial load is unaffected, which is what #240 set out to protect, but a reader who opens a diff downloads 131 kB the main bundle substantially already has. #253 tracks putting both on one highlighter.

## Related Links

- Closes #240
- Follow-ups opened from this work: #250, #251, #252, #253