### PR TITLE
feat(web): give an edit's line counts their own place and colour

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -35,6 +35,8 @@ New colors enter `web/src/index.css` as a CSS variable wired through `@theme inl
 
 Text of any size clears 4.5:1 against the surface it renders on. Measure against the actual surface (`--card` for the batch bar, `--background` for the sidebar), not a guess. Known debt: `--primary` itself sits at 4.12:1 — tracked as a palette-level issue, don't fix it per-button.
 
+An edit's diff stat, measured against `--background` #002b36 and a row's hover ground #0a333e (#250): `--diff-add` 6.59:1 / 5.92:1 and `--diff-remove` 5.48:1 / 4.93:1 both clear the floor. `--destructive` does not clear it as text — 3.25:1 — which is why the removed count has its own lifted tone rather than reusing it. Known debt: the muted pair the counts rest in, `--diff-add-muted` 3.06:1 and `--diff-remove-muted` 3.42:1, sits under the floor. Both are above the `--muted-foreground` label they sit beside (2.79:1), so they are no quieter than the row already is — the whole muted skim layer is what #219 is auditing, and this pair belongs to that decision rather than a separate one.
+
 ## Tokens
 
 The action-facing subset of `web/src/index.css` (Solarized dark):

--- a/web/e2e/code-highlighting.spec.ts
+++ b/web/e2e/code-highlighting.spec.ts
@@ -99,8 +99,9 @@ test("a large diff expands and highlights in a real browser without stalling", a
 
   // The collapsed tool unit summarises the write; the full path shows once the
   // diff is expanded.
-  const summary = page.getByText("Wrote constants.ts +200 -0");
+  const summary = page.getByText("Wrote constants.ts");
   await expect(summary).toBeVisible();
+  await expect(page.getByTestId("row-diff-stat")).toHaveText("+200 -0");
 
   const start = Date.now();
   await summary.click();

--- a/web/e2e/diff-stat.spec.ts
+++ b/web/e2e/diff-stat.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from "@playwright/test";
+
+// The row names the file by its basename, so what has to give way is a long
+// name in a narrow pane — the case that used to eat the counts (#250).
+const LONG_NAME =
+  "CollapsibleToolCallSummaryRowWithAVeryLongDescriptiveFileName.test.tsx";
+const LONG_PATH = `web/src/conversation/${LONG_NAME}`;
+
+// The tokens, as the browser reports them.
+const AT_REST_ADDED = "rgb(79, 122, 94)"; // --diff-add-muted #4f7a5e
+const AT_REST_REMOVED = "rgb(158, 107, 110)"; // --diff-remove-muted #9e6b6e
+const RESOLVED_ADDED = "rgb(34, 197, 94)"; // --diff-add #22c55e
+const RESOLVED_REMOVED = "rgb(255, 110, 100)"; // --diff-remove #ff6e64
+
+/** Mount a one-turn chat whose assistant message carries `blocks`. */
+async function openChatWith(
+  page: import("@playwright/test").Page,
+  blocks: unknown[]
+) {
+  // Benign empty SSE stream so the live-update EventSource connects cleanly.
+  await page.route(/\/api\/chats\/stream(\?|$)/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: ":ok\n\n",
+    })
+  );
+  await page.route(/\/api\/chats\/counts(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1, projects: [], tags: [], untagged: 1 } })
+  );
+  await page.route(/\/api\/chats\/list-total(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1 } })
+  );
+  await page.route(/\/api\/chats(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        chats: [
+          {
+            id: "clog_stat1",
+            sourceId: "stat-chat",
+            agent: "claude-code",
+            title: "Edit conversation",
+            project: "/test/project",
+            sourceFilePath: null,
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      },
+    })
+  );
+  await page.route(/\/api\/chats\/clog_stat1(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        messages: [
+          {
+            role: "assistant",
+            content: blocks,
+            timestamp: "2023-11-14T22:13:20.000Z",
+          },
+        ],
+      },
+    })
+  );
+
+  await page.goto("/");
+  await page.getByText("Edit conversation").click();
+}
+
+/** The one collapsed row carrying a diff stat. */
+function statRow(page: import("@playwright/test").Page) {
+  return page
+    .locator("button")
+    .filter({ has: page.getByTestId("row-diff-stat") });
+}
+
+function editOf(filePath: string, added: number, removed: number) {
+  const lines = [
+    ...Array.from({ length: removed }, (_, i) => `-old${i}`),
+    ...Array.from({ length: added }, (_, i) => `+new${i}`),
+  ];
+  return [
+    {
+      type: "tool_use",
+      id: "tool_1",
+      name: "Edit",
+      input: { file_path: filePath },
+    },
+    {
+      type: "tool_result",
+      tool_use_id: "tool_1",
+      content: "File updated",
+      file_path: filePath,
+      patch: [
+        {
+          oldStart: 1,
+          oldLines: removed,
+          newStart: 1,
+          newLines: added,
+          lines,
+        },
+      ],
+    },
+  ];
+}
+
+test("the counts survive a name long enough to truncate", async ({ page }) => {
+  // A narrow window squeezes the third pane, so the name has to give way.
+  await page.setViewportSize({ width: 760, height: 700 });
+  await openChatWith(page, editOf(LONG_PATH, 39, 2));
+
+  const stat = page.getByTestId("row-diff-stat");
+  await expect(stat).toHaveText("+39 -2");
+
+  const label = page.getByText(`Edited ${LONG_NAME}`);
+  const truncated = await label.evaluate(
+    (el) => el.scrollWidth > el.clientWidth
+  );
+  const statBox = await stat.boundingBox();
+  const rowBox = await statRow(page).boundingBox();
+
+  // The row is genuinely out of room — and the counts are still on it, drawn at
+  // its trailing edge rather than pushed past it.
+  expect(truncated).toBe(true);
+  expect(statBox).not.toBeNull();
+  expect(statBox!.width).toBeGreaterThan(0);
+  expect(statBox!.x + statBox!.width).toBeLessThanOrEqual(
+    rowBox!.x + rowBox!.width + 1
+  );
+});
+
+test("the counts rest near the label and resolve on hover and on opening", async ({
+  page,
+}) => {
+  await openChatWith(page, editOf("web/src/App.tsx", 39, 2));
+
+  const added = page.getByTestId("row-diff-added");
+  const removed = page.getByTestId("row-diff-removed");
+  await expect(added).toHaveCSS("color", AT_REST_ADDED);
+  await expect(removed).toHaveCSS("color", AT_REST_REMOVED);
+
+  const row = statRow(page);
+  await row.hover();
+  await expect(added).toHaveCSS("color", RESOLVED_ADDED);
+  await expect(removed).toHaveCSS("color", RESOLVED_REMOVED);
+
+  // Opening the row keeps them resolved, so the collapsed line and the diff it
+  // opened onto say the same thing in the same colours.
+  await row.click();
+  await page.mouse.move(0, 0);
+  await expect(page.getByTestId("diff-line").first()).toBeVisible();
+  await expect(added).toHaveCSS("color", RESOLVED_ADDED);
+  await expect(removed).toHaveCSS("color", RESOLVED_REMOVED);
+});
+
+test("a zero side dims instead of disappearing", async ({ page }) => {
+  await openChatWith(page, editOf("web/src/App.tsx", 12, 0));
+
+  const removed = page.getByTestId("row-diff-removed");
+  await expect(removed).toBeVisible();
+  await expect(removed).toHaveText("-0");
+  await expect(removed).toHaveCSS("opacity", "0.5");
+  await expect(page.getByTestId("row-diff-added")).toHaveCSS("opacity", "1");
+});

--- a/web/src/conversation/CollapsibleRow.test.tsx
+++ b/web/src/conversation/CollapsibleRow.test.tsx
@@ -88,3 +88,131 @@ describe("CollapsibleRow chevron treatment", () => {
     expect(dot.getAttribute("class") ?? "").toMatch(/bg-destructive/);
   });
 });
+
+describe("CollapsibleRow diff stat", () => {
+  const LONG_PATH = "Edited web/src/conversation/CollapsibleToolCall.tsx";
+
+  it("keeps the counts out of the truncating label, at the row's trailing edge", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary={LONG_PATH}
+        diffStat={{ added: 39, removed: 2 }}
+        isExpanded={false}
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    const stat = screen.getByTestId("row-diff-stat");
+    expect(stat.textContent).toBe("+39 -2");
+    // Whatever the path does, the stat is not inside what truncates it.
+    expect(stat.closest(".truncate")).toBeNull();
+    expect(stat.getAttribute("class") ?? "").toMatch(/shrink-0/);
+  });
+
+  it("keeps each side's sign attached, so colour is never the only cue", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary={LONG_PATH}
+        diffStat={{ added: 39, removed: 2 }}
+        isExpanded={false}
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    const added = screen.getByTestId("row-diff-added");
+    const removed = screen.getByTestId("row-diff-removed");
+    expect(added.textContent).toBe("+39");
+    expect(removed.textContent).toBe("-2");
+    expect(added.getAttribute("class") ?? "").toMatch(/diff-add/);
+    expect(removed.getAttribute("class") ?? "").toMatch(/diff-remove/);
+  });
+
+  it("dims a zero side rather than dropping it, keeping the row's shape", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary="Wrote README.md"
+        diffStat={{ added: 12, removed: 0 }}
+        isExpanded={false}
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    expect(screen.getByTestId("row-diff-stat").textContent).toBe("+12 -0");
+    expect(
+      screen.getByTestId("row-diff-removed").getAttribute("class")
+    ).toMatch(/opacity-50/);
+    expect(
+      screen.getByTestId("row-diff-added").getAttribute("class")
+    ).not.toMatch(/opacity-50/);
+  });
+
+  it("rests near the muted label, resolving to full colour on hover", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary={LONG_PATH}
+        diffStat={{ added: 39, removed: 2 }}
+        isExpanded={false}
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    const added =
+      screen.getByTestId("row-diff-added").getAttribute("class") ?? "";
+    const removed =
+      screen.getByTestId("row-diff-removed").getAttribute("class") ?? "";
+    expect(added).toMatch(/(?<!hover:)text-diff-add-muted/);
+    expect(removed).toMatch(/(?<!hover:)text-diff-remove-muted/);
+    expect(added).toMatch(/group-hover:text-diff-add(?!-muted)/);
+    expect(removed).toMatch(/group-hover:text-diff-remove(?!-muted)/);
+  });
+
+  it("wears the diff's own colours once the row is open", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary={LONG_PATH}
+        diffStat={{ added: 39, removed: 2 }}
+        isExpanded
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    const added =
+      screen.getByTestId("row-diff-added").getAttribute("class") ?? "";
+    const removed =
+      screen.getByTestId("row-diff-removed").getAttribute("class") ?? "";
+    expect(added).toMatch(/(?<!hover:)text-diff-add(?!-muted)/);
+    expect(removed).toMatch(/(?<!hover:)text-diff-remove(?!-muted)/);
+    expect(added).not.toMatch(/-muted/);
+    expect(removed).not.toMatch(/-muted/);
+  });
+
+  it("leaves a row that carries no stat alone", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary="Bash: pnpm test"
+        isExpanded={false}
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    expect(screen.queryByTestId("row-diff-stat")).toBeNull();
+  });
+});

--- a/web/src/conversation/CollapsibleRow.tsx
+++ b/web/src/conversation/CollapsibleRow.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react";
 import { ChevronDown, type LucideIcon } from "lucide-react";
+import type { DiffStat } from "@/conversation/generateToolSummary";
 
 interface CollapsibleRowProps {
   /** The kind marker — a terminal for tool units, a brain for thinking. */
@@ -8,6 +9,11 @@ interface CollapsibleRowProps {
   summary: string;
   /** Marks the row as reporting a failure. */
   hasError?: boolean;
+  /**
+   * How big an edit was. Given its own place at the row's trailing edge, so a
+   * long path truncates instead of pushing the counts off the end (#250).
+   */
+  diffStat?: DiffStat;
   /**
    * Whether the row is open. Controlled from above, because the virtualizer
    * recycles rows by position and state kept here would not survive it (#236).
@@ -35,6 +41,12 @@ interface CollapsibleRowProps {
   isSummary?: boolean;
 }
 
+// A side that changed nothing dims rather than disappears, so a purely additive
+// edit reads at a glance without the row changing shape.
+function zero(count: number): string {
+  return count === 0 ? "opacity-50" : "";
+}
+
 /**
  * One collapsed line that opens into its detail.
  *
@@ -46,6 +58,7 @@ export function CollapsibleRow({
   icon: Icon,
   summary,
   hasError,
+  diffStat,
   isExpanded,
   onToggle,
   children,
@@ -77,6 +90,17 @@ export function CollapsibleRow({
       ? "text-primary"
       : "group-hover:text-primary";
 
+  // The counts sit close to the muted label at rest — enough to tell an edit
+  // that mostly added from one that mostly removed while scanning — and resolve
+  // to the colours of the diff they open onto when the row is hovered or open
+  // (#250). Full saturation on every row would out-compete the prose.
+  const addedColour = isExpanded
+    ? "text-diff-add"
+    : "text-diff-add-muted group-hover:text-diff-add";
+  const removedColour = isExpanded
+    ? "text-diff-remove"
+    : "text-diff-remove-muted group-hover:text-diff-remove";
+
   return (
     <div>
       <button
@@ -103,6 +127,29 @@ export function CollapsibleRow({
             aria-label="Failed"
             className="ml-1 size-1.5 shrink-0 rounded-full bg-destructive"
           />
+        )}
+        {diffStat && (
+          <span
+            data-testid="row-diff-stat"
+            className="ml-auto shrink-0 pl-2 font-mono tabular-nums"
+          >
+            <span
+              data-testid="row-diff-added"
+              className={`transition-colors ${addedColour} ${zero(
+                diffStat.added
+              )}`}
+            >
+              +{diffStat.added}
+            </span>{" "}
+            <span
+              data-testid="row-diff-removed"
+              className={`transition-colors ${removedColour} ${zero(
+                diffStat.removed
+              )}`}
+            >
+              -{diffStat.removed}
+            </span>
+          </span>
         )}
       </button>
       {isExpanded && children && (

--- a/web/src/conversation/CollapsibleToolCall.test.tsx
+++ b/web/src/conversation/CollapsibleToolCall.test.tsx
@@ -47,6 +47,36 @@ describe("CollapsibleToolCall", () => {
     expect(screen.queryByText("The file a.tsx has been updated.")).toBeNull();
   });
 
+  it("gives an edit's counts the row's trailing edge, not its label", () => {
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t1",
+      content: "updated",
+      file_path: "web/src/conversation/CollapsibleToolCall.tsx",
+      patch: [
+        {
+          oldStart: 3,
+          oldLines: 4,
+          newStart: 3,
+          newLines: 6,
+          lines: [" keep", "-gone", "+one", "+two", "+three"],
+        },
+      ],
+    };
+
+    render(
+      <CollapsibleToolCall
+        block={editCall}
+        result={result}
+        isExpanded={false}
+        onToggle={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId("row-diff-stat").textContent).toBe("+3 -1");
+    expect(screen.getByText("Edited CollapsibleToolCall.tsx")).not.toBeNull();
+  });
+
   it("falls back to the raw rendering when the result carries no patch", () => {
     const result: ToolResultBlock = {
       type: "tool_result",

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -55,10 +55,13 @@ export function CollapsibleToolCall({
     !isDiff && readPath && typeof result?.content === "string"
   );
 
+  const { label, diffStat } = generateToolSummary(block, result);
+
   return (
     <CollapsibleRow
       icon={Terminal}
-      summary={generateToolSummary(block, result)}
+      summary={label}
+      diffStat={diffStat}
       hasError={result?.is_error}
       isExpanded={isExpanded}
       onToggle={onToggle}

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -677,7 +677,11 @@ describe("Conversation tool units", () => {
       />
     );
 
-    expect(await screen.findByText("Edited App.tsx +3 -1")).not.toBeNull();
+    expect(await screen.findByText("Edited App.tsx")).not.toBeNull();
+    // The counts keep their own place at the row's trailing edge (#250).
+    expect((await screen.findByTestId("row-diff-stat")).textContent).toBe(
+      "+3 -1"
+    );
   });
 
   it("shows input and output under one left rule marking the unit's extent", async () => {

--- a/web/src/conversation/generateToolSummary.test.ts
+++ b/web/src/conversation/generateToolSummary.test.ts
@@ -10,7 +10,7 @@ describe("generateToolSummary", () => {
         name: "Read",
         input: { file_path: "src/index.ts" },
       })
-    ).toBe("Read: src/index.ts");
+    ).toEqual({ label: "Read: src/index.ts" });
   });
 
   it("summarizes Bash tool with command", () => {
@@ -21,7 +21,7 @@ describe("generateToolSummary", () => {
         name: "Bash",
         input: { command: "npm test" },
       })
-    ).toBe("Bash: npm test");
+    ).toEqual({ label: "Bash: npm test" });
   });
 
   it("truncates long Bash commands", () => {
@@ -32,10 +32,10 @@ describe("generateToolSummary", () => {
       name: "Bash",
       input: { command: longCommand },
     });
-    expect(result.length).toBeLessThanOrEqual(
+    expect(result.label.length).toBeLessThanOrEqual(
       100 + "Bash: ".length + "…".length
     );
-    expect(result).toMatch(/^Bash: a+…$/);
+    expect(result.label).toMatch(/^Bash: a+…$/);
   });
 
   it("summarizes Edit tool with file path", () => {
@@ -50,7 +50,7 @@ describe("generateToolSummary", () => {
           new_string: "bar",
         },
       })
-    ).toBe("Edit: src/app.ts");
+    ).toEqual({ label: "Edit: src/app.ts" });
   });
 
   it("summarizes Write tool with file path", () => {
@@ -61,10 +61,10 @@ describe("generateToolSummary", () => {
         name: "Write",
         input: { file_path: "README.md", content: "hello" },
       })
-    ).toBe("Write: README.md");
+    ).toEqual({ label: "Write: README.md" });
   });
 
-  it("summarizes an Edit that carries a patch as a diff line", () => {
+  it("hands an Edit's counts out separately from its label", () => {
     expect(
       generateToolSummary(
         {
@@ -89,7 +89,10 @@ describe("generateToolSummary", () => {
           ],
         }
       )
-    ).toBe("Edited CollapsibleToolCall.tsx +3 -1");
+    ).toEqual({
+      label: "Edited CollapsibleToolCall.tsx",
+      diffStat: { added: 3, removed: 1 },
+    });
   });
 
   it("summarizes a Write as written, counting a whole new file as added", () => {
@@ -117,7 +120,10 @@ describe("generateToolSummary", () => {
           ],
         }
       )
-    ).toBe("Wrote README.md +2 -0");
+    ).toEqual({
+      label: "Wrote README.md",
+      diffStat: { added: 2, removed: 0 },
+    });
   });
 
   it("sums a MultiEdit's hunks into one pair of counts", () => {
@@ -152,7 +158,10 @@ describe("generateToolSummary", () => {
           ],
         }
       )
-    ).toBe("Edited app.ts +3 -2");
+    ).toEqual({
+      label: "Edited app.ts",
+      diffStat: { added: 3, removed: 2 },
+    });
   });
 
   it("keeps the plain summary for an edit whose result carries no patch", () => {
@@ -166,7 +175,7 @@ describe("generateToolSummary", () => {
         },
         { type: "tool_result", tool_use_id: "t7", content: "updated" }
       )
-    ).toBe("Edit: src/app.ts");
+    ).toEqual({ label: "Edit: src/app.ts" });
   });
 
   it("summarizes Glob tool with pattern", () => {
@@ -177,7 +186,7 @@ describe("generateToolSummary", () => {
         name: "Glob",
         input: { pattern: "**/*.ts" },
       })
-    ).toBe("Glob: **/*.ts");
+    ).toEqual({ label: "Glob: **/*.ts" });
   });
 
   it("summarizes Grep tool with pattern", () => {
@@ -188,7 +197,7 @@ describe("generateToolSummary", () => {
         name: "Grep",
         input: { pattern: "TODO" },
       })
-    ).toBe("Grep: TODO");
+    ).toEqual({ label: "Grep: TODO" });
   });
 
   it("falls back to tool name for unknown tools", () => {
@@ -199,6 +208,6 @@ describe("generateToolSummary", () => {
         name: "CustomTool",
         input: { foo: "bar" },
       })
-    ).toBe("CustomTool");
+    ).toEqual({ label: "CustomTool" });
   });
 });

--- a/web/src/conversation/generateToolSummary.ts
+++ b/web/src/conversation/generateToolSummary.ts
@@ -13,7 +13,23 @@ const EDIT_VERBS: Record<string, string> = {
   Write: "Wrote",
 };
 
-function countLines(patch: PatchHunk[]): { added: number; removed: number } {
+/** How big an edit was, in lines. */
+export interface DiffStat {
+  added: number;
+  removed: number;
+}
+
+export interface ToolSummary {
+  /** The one-line description: the verb and what it applied to. */
+  label: string;
+  /**
+   * The counts, kept out of the label so the row can place them at its trailing
+   * edge — where a truncating path cannot push them off the end (#250).
+   */
+  diffStat?: DiffStat;
+}
+
+function countLines(patch: PatchHunk[]): DiffStat {
   let added = 0;
   let removed = 0;
   for (const hunk of patch) {
@@ -51,24 +67,26 @@ function getString(value: unknown): string | undefined {
 export function generateToolSummary(
   block: ToolUseBlock,
   result?: ToolResultBlock
-): string {
+): ToolSummary {
   const { name } = block;
   const input = getInput(block.input);
 
   const verb = EDIT_VERBS[name];
   if (verb && result?.file_path && result.patch?.length) {
-    const { added, removed } = countLines(result.patch);
-    return `${verb} ${basename(result.file_path)} +${added} -${removed}`;
+    return {
+      label: `${verb} ${basename(result.file_path)}`,
+      diffStat: countLines(result.patch),
+    };
   }
 
   const filePath = getString(input.file_path);
-  if (filePath) return `${name}: ${filePath}`;
+  if (filePath) return { label: `${name}: ${filePath}` };
 
   const command = getString(input.command);
-  if (command) return `${name}: ${truncate(command)}`;
+  if (command) return { label: `${name}: ${truncate(command)}` };
 
   const pattern = getString(input.pattern);
-  if (pattern) return `${name}: ${pattern}`;
+  if (pattern) return { label: `${name}: ${pattern}` };
 
-  return name;
+  return { label: name };
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -28,6 +28,10 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-diff-add: var(--diff-add);
+  --color-diff-remove: var(--diff-remove);
+  --color-diff-add-muted: var(--diff-add-muted);
+  --color-diff-remove-muted: var(--diff-remove-muted);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -86,6 +90,25 @@
   --accent-foreground: #93a1a1;
   /* Solarized red */
   --destructive: #dc322f;
+  /* An edit's line counts, added and removed (#250). Measured against
+     --background #002b36 and against a row's hover ground #0a333e (white/4%
+     laid over it):
+       --diff-add          6.59:1 / 5.92:1 — clears the 4.5:1 AA text floor
+       --diff-remove       5.48:1 / 4.93:1 — clears it as well. Solarized red
+                           itself (--destructive) is only 3.25:1 as text, so
+                           the text tone is the lifted red; the diff's 10%
+                           ground keeps --destructive, where no text floor
+                           applies.
+       --diff-add-muted    3.06:1 / 2.75:1
+       --diff-remove-muted 3.42:1 / 3.07:1
+     The muted pair is what the counts wear at rest, next to a
+     --muted-foreground label sitting at 2.79:1 — quiet enough that a long
+     session's rows don't out-shout the prose, and never quieter than the
+     label beside them. They resolve to the full pair on hover or expansion. */
+  --diff-add: #22c55e;
+  --diff-remove: #ff6e64;
+  --diff-add-muted: #4f7a5e;
+  --diff-remove-muted: #9e6b6e;
   --border: #073642;
   --input: #073642;
   /* Solarized cyan */
@@ -125,6 +148,10 @@
   --accent: #073642;
   --accent-foreground: #93a1a1;
   --destructive: #dc322f;
+  --diff-add: #22c55e;
+  --diff-remove: #ff6e64;
+  --diff-add-muted: #4f7a5e;
+  --diff-remove-muted: #9e6b6e;
   --border: #073642;
   --input: #073642;
   --ring: #2aa198;


### PR DESCRIPTION
## Background (Why)

An edit's collapsed row ends in `+39 -2`, added by #235. That stat was baked into the same string as the verb and the file name, and rendered inside a truncating span — so a long file name pushed the counts off the end and they vanished. The one number on the row that says how big the edit was was the first thing to go.

The stat also had no colour. Every editor that shows it colours the numbers — GitHub, GitLens, Zed's git panel, gitsigns — additions green, deletions red, the sign always attached.

## Approach (How)

`generateToolSummary` now returns `{ label, diffStat }` instead of one string, so the row can place the counts itself. `CollapsibleRow` draws them at its trailing edge with `ml-auto shrink-0`, outside the span that truncates. Truncation then shortens the name, which is what it should do.

On colour, the restraint is the design. These rows are the skim layer — muted, a size down from body text, and there are many of them in a long session. Full-saturation red and green on every row would out-compete the prose. So the counts rest in a muted pair and resolve to the diff's own green and red on hover or expansion: the collapsed row and the diff it opens onto then say the same thing in the same colours. The `+` and `-` signs stay, so colour is never the only cue.

Four tokens carry this, per DESIGN.md's "colours are tokens" rule. One measurement drove a decision: `--destructive` is only 3.25:1 against `--background` as text, so the removed count uses a lifted red rather than reusing it. The diff's 10% ground keeps `--destructive`, where no text floor applies.

## Changes (What)

- [x] `generateToolSummary` returns `{ label, diffStat }`; the counts leave the label string
- [x] `CollapsibleRow` takes an optional `diffStat` and renders it at the row's trailing edge, outside the truncating span
- [x] Added and removed are separate elements with their own tones and their signs attached; a zero side dims (`opacity-50`) rather than disappearing
- [x] At rest the counts wear `--diff-add-muted` / `--diff-remove-muted`; on `group-hover` or expansion they resolve to `--diff-add` / `--diff-remove`
- [x] Four new tokens in `web/src/index.css`, wired through `@theme inline`, with the contrast measurements in a comment
- [x] `docs/DESIGN.md` records the numbers under the contrast rule, including the sub-floor muted pair as debt pointing at #219
- [x] New `web/e2e/diff-stat.spec.ts` measures the things jsdom cannot

### Screenshots or Recordings

<img width="859" height="76" alt="截圖 2026-07-24 下午6 52 27" src="https://github.com/user-attachments/assets/23c7585a-2497-4a06-b80e-17990eb897e0" />

### Test Verification

Unit (854 passed) and e2e (18 passed), plus typecheck and build.

- [x] An edit's label carries no counts; the counts come back as `diffStat`
- [x] A non-edit tool call returns no `diffStat`, and its label is unchanged
- [x] `Write` on a new file returns `removed: 0` rather than omitting the side
- [x] The stat renders outside the truncating span, at the row's trailing edge
- [x] Each side keeps its sign, in its own element, with its own tone
- [x] A zero side is dimmed, and the stat still reads `+12 -0`
- [x] Collapsed rests muted with a `group-hover` resolve; expanded is resolved outright
- [x] A row with no stat renders exactly as before
- [x] **Real browser:** at 760px the file name genuinely truncates (`scrollWidth > clientWidth`) and the stat is still drawn inside the row's box
- [x] **Real browser:** computed colour is the muted pair at rest, the full pair on hover, and still the full pair once open
- [x] **Real browser:** the zero side computes to `opacity: 0.5` while the other side stays at `1`

## Additional Notes

Two things a reviewer should weigh:

1. **The muted pair sits under the 4.5:1 floor** — `--diff-add-muted` 3.06:1 and `--diff-remove-muted` 3.42:1. Both are above the `--muted-foreground` label they sit beside (2.79:1), so the counts are never quieter than the row already is. Recorded as debt pointing at #219, which is auditing the whole muted skim layer, rather than settled here as a one-off. Forcing AA at rest would mean giving up telling "mostly additions" from "mostly deletions" while scanning, which #250 explicitly asks for.
2. **`code-highlighting.spec.ts` needed a fix.** It asserted the old combined string `"Wrote constants.ts +200 -0"`. `pnpm test` does not run e2e, so this only surfaced when the e2e suite ran — worth knowing for the next change to a row summary.

Also worth recording: because the row names the file by its basename, the truncation case is a long *name*, not a long path. Rows that do carry a full path (`Read: …`) have no stat. The e2e spec uses a long basename in a narrow viewport to reproduce real truncation.

Not doing, per the issue: GitHub's proportion bar (spends horizontal space on a row that already truncates, to restate the numbers) and VS Code's status-coloured file name (encodes add/modify/delete, a distinction these rows don't have — every one is an edit).

## Related Links

- Closes #250