### PR TITLE
feat(web): colour a tool call's input JSON

### DIFF
--- a/web/e2e/code-highlighting.spec.ts
+++ b/web/e2e/code-highlighting.spec.ts
@@ -168,3 +168,37 @@ test("a large read expands as a highlighted, numbered excerpt without stalling",
   await expect(firstRow).toContainText("1");
   await expect(firstRow.locator(".hljs-keyword").first()).toBeVisible();
 });
+
+test("a tool call with no view of its own shows its input as coloured JSON", async ({
+  page,
+}) => {
+  await openChatWith(page, [
+    {
+      type: "tool_use",
+      id: "tool_3",
+      name: "Grep",
+      input: {
+        pattern: "useState",
+        // Long enough that an unwrapped line would stretch the pane if the
+        // block did not scroll on its own.
+        path: `web/src/${"very-long-directory-name/".repeat(20)}index.ts`,
+      },
+    },
+    { type: "tool_result", tool_use_id: "tool_3", content: "No matches found" },
+  ]);
+
+  await page.getByText("Grep", { exact: false }).first().click();
+
+  const input = page.getByTestId("json-input");
+  await expect(input.locator(".hljs-attr").first()).toBeVisible();
+
+  // The long value scrolls inside the block rather than widening it: the block
+  // stays within its column while its content overflows.
+  const box = await input.evaluate((node) => ({
+    scrollWidth: node.scrollWidth,
+    clientWidth: node.clientWidth,
+    parentWidth: (node.parentElement as HTMLElement).clientWidth,
+  }));
+  expect(box.scrollWidth).toBeGreaterThan(box.clientWidth);
+  expect(box.clientWidth).toBeLessThanOrEqual(box.parentWidth);
+});

--- a/web/src/conversation/CollapsibleToolCall.test.tsx
+++ b/web/src/conversation/CollapsibleToolCall.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import type { ContentBlock } from "@/types";
 import type { ToolResultBlock } from "@/conversation/toolUnits";
@@ -150,5 +150,25 @@ describe("CollapsibleToolCall", () => {
     );
 
     expect(screen.queryByTestId("excerpt-line")).toBeNull();
+  });
+
+  it("colours the input of a unit that renders neither diff nor excerpt", async () => {
+    const searchCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t4",
+      name: "Grep",
+      input: { pattern: "useState" },
+    };
+
+    const { container } = render(
+      <CollapsibleToolCall block={searchCall} isExpanded onToggle={() => {}} />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector(".hljs-attr")).not.toBeNull()
+    );
+    expect(container.querySelector(".hljs-attr")?.textContent).toBe(
+      '"pattern"'
+    );
   });
 });

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -4,6 +4,7 @@ import { CollapsibleRow } from "@/conversation/CollapsibleRow";
 import { DiffView } from "@/conversation/DiffView";
 import { FileExcerptView } from "@/conversation/FileExcerptView";
 import { generateToolSummary } from "@/conversation/generateToolSummary";
+import { JsonView } from "@/conversation/JsonView";
 import type { ToolResultBlock } from "@/conversation/toolUnits";
 
 type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
@@ -75,9 +76,7 @@ export function CollapsibleToolCall({
         />
       ) : (
         <>
-          <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
-            {JSON.stringify(block.input, null, 2)}
-          </pre>
+          <JsonView value={block.input} />
           {result && (
             <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
               {formatResultContent(result.content)}

--- a/web/src/conversation/JsonView.test.tsx
+++ b/web/src/conversation/JsonView.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { JsonView } from "./JsonView";
+
+describe("JsonView", () => {
+  it("pretty-prints the value, one line per key", () => {
+    render(<JsonView value={{ pattern: "useState", path: "web/src" }} />);
+
+    const rows = screen.getAllByTestId("json-line");
+    expect(rows).toHaveLength(4);
+    expect(rows[1].textContent).toBe('  "pattern": "useState",');
+    expect(rows[2].textContent).toBe('  "path": "web/src"');
+  });
+
+  it("colours it as JSON, with keys told apart from their values", async () => {
+    const { container } = render(<JsonView value={{ pattern: "useState" }} />);
+
+    await waitFor(() =>
+      expect(container.querySelector(".hljs-attr")).not.toBeNull()
+    );
+    expect(container.querySelector(".hljs-attr")?.textContent).toBe(
+      '"pattern"'
+    );
+    expect(container.querySelector(".hljs-string")?.textContent).toBe(
+      '"useState"'
+    );
+  });
+
+  it("stops colouring past the cap, so the rest still renders", async () => {
+    const { container } = render(
+      <JsonView value={{ a: "one", b: "two", c: "three" }} highlightCap={2} />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelectorAll(".hljs-attr")).toHaveLength(1)
+    );
+    const rows = screen.getAllByTestId("json-line");
+    expect(rows[3].textContent).toBe('  "c": "three"');
+    expect(rows[3].querySelector("[class^='hljs-']")).toBeNull();
+  });
+});

--- a/web/src/conversation/JsonView.tsx
+++ b/web/src/conversation/JsonView.tsx
@@ -1,0 +1,55 @@
+import { useLanguageHighlighter } from "@/conversation/codeHighlight";
+
+interface JsonViewProps {
+  /** The value to show. A tool call's input, in practice. */
+  value: unknown;
+  /**
+   * How many lines get syntax highlighting. Lines past this cap render plain,
+   * so an unusually large input never delays the expansion (#251).
+   */
+  highlightCap?: number;
+}
+
+const DEFAULT_HIGHLIGHT_CAP = 500;
+
+/**
+ * A value serialised as JSON, one line per row.
+ *
+ * The language is not inferred here the way a file's is: the block is produced
+ * by serialising the value, so it is always well-formed JSON (#251).
+ */
+export function JsonView({
+  value,
+  highlightCap = DEFAULT_HIGHLIGHT_CAP,
+}: JsonViewProps) {
+  const lines = JSON.stringify(value, null, 2).split("\n");
+
+  // Null until the lazy highlighter lands — the JSON renders plain until then,
+  // so colour only ever arrives as an improvement.
+  const highlight = useLanguageHighlighter("json");
+
+  return (
+    <div
+      data-testid="json-input"
+      className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground"
+    >
+      {lines.map((line, index) => {
+        const highlighted =
+          highlight && index < highlightCap ? highlight(line) : null;
+
+        return highlighted !== null ? (
+          <div
+            key={index}
+            data-testid="json-line"
+            className="whitespace-pre"
+            dangerouslySetInnerHTML={{ __html: highlighted }}
+          />
+        ) : (
+          <div key={index} data-testid="json-line" className="whitespace-pre">
+            {line}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/conversation/codeHighlight.ts
+++ b/web/src/conversation/codeHighlight.ts
@@ -101,6 +101,19 @@ export function useHighlighter(
   filePath: string
 ): ((text: string) => string) | null {
   const language = useMemo(() => languageForPath(filePath), [filePath]);
+  return useLanguageHighlighter(language);
+}
+
+/**
+ * The same highlighter, for a caller that already knows its language.
+ *
+ * A tool call's input is serialised JSON, so nothing has to be inferred from a
+ * path — the language is known at the call site (#251). Passing `null` keeps
+ * the highlighter unloaded and the caller rendering plain.
+ */
+export function useLanguageHighlighter(
+  language: string | null
+): ((text: string) => string) | null {
   const [hljs, setHljs] = useState<HLJSApi | null>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Background (Why)

Expanding a tool unit that is neither an edit nor a read opened onto its call input, pretty-printed and entirely uncoloured. It was the last plain block left in the pane now that diffs and reads are highlighted (#240), and it is the one a reader meets most often — every search, every fetch, every tool without a view of its own.

## Approach (How)

The language is not inferred here, it is known: the block is produced by serialising the input, so it is always well-formed JSON. That meant the existing entry point — `useHighlighter(filePath)`, which infers a language from an extension — did not fit.

`useLanguageHighlighter(language)` now takes the language directly, and `useHighlighter(filePath)` becomes a thin wrapper over it. Both share the one cached, lazily-loaded highlighter, so a chat that opens no code still fetches nothing, and one that does pays for the highlighter once across diffs, reads, and inputs alike.

Lines are coloured one at a time up to a cap, past which they render plain rather than delaying the expansion — the same trade `DiffView` and `FileExcerptView` already make.

## Changes (What)

- [x] `codeHighlight.ts`: extract `useLanguageHighlighter(language)`; `useHighlighter(filePath)` delegates to it
- [x] New `JsonView` renders a serialised value line by line, highlighted as JSON, with a `highlightCap` (default 500) past which lines render plain
- [x] `CollapsibleToolCall` renders the call input through `JsonView` instead of a raw `<pre>`; the result block and the diff / excerpt branches are untouched
- [x] The block scrolls sideways, so a long path or pattern overflows within its own column instead of stretching the pane

### Test Verification

- [x] `JsonView` pretty-prints the value, one line per key
- [x] Keys and values are told apart — `hljs-attr` on the key, `hljs-string` on the value
- [x] Lines past `highlightCap` render plain, with their text intact
- [x] An expanded unit that renders neither diff nor excerpt colours its input
- [x] A unit that renders a diff or a file excerpt is unaffected (existing suites still green)
- [x] e2e: the input is coloured in a real browser and overflows within its column, not past it
- [x] Full suite: 858 tests pass (api 401, web 457); `typecheck` and `lint` clean

## Additional Notes

The result block below the input stays plain. It is arbitrary tool output with no known language, so there is nothing to key a highlighter off — unlike the input, which is JSON by construction.

Highlighting a line at a time drops multi-line context, the same limitation the diff and the read excerpt carry. For pretty-printed JSON this costs almost nothing: its tokens do not span lines.

## Related Links

- Closes #251