### PR TITLE
feat(web): render a Bash unit's command as shell

### DIFF
--- a/web/src/conversation/CollapsibleToolCall.test.tsx
+++ b/web/src/conversation/CollapsibleToolCall.test.tsx
@@ -152,6 +152,136 @@ describe("CollapsibleToolCall", () => {
     expect(screen.queryByTestId("excerpt-line")).toBeNull();
   });
 
+  it("renders an expanded Bash unit's command as shell, not raw JSON", async () => {
+    const bashCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t5",
+      name: "Bash",
+      input: { command: 'echo "hi"', description: "Say hi" },
+    };
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t5",
+      content: "hi",
+    };
+
+    const { container } = render(
+      <CollapsibleToolCall
+        block={bashCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    // The command stands on its own, with the call's input no longer repeated
+    // as JSON above it.
+    expect(screen.queryByTestId("json-input")).toBeNull();
+    expect(screen.getByTestId("command-line").textContent).toBe('echo "hi"');
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-testid="command-line"] .hljs-string')
+      ).not.toBeNull()
+    );
+  });
+
+  it("renders a Bash unit's output beneath the command, with no language guessed", async () => {
+    const bashCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t6",
+      name: "Bash",
+      input: { command: 'echo "hi"' },
+    };
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t6",
+      // Reads like shell, but it is only what the command printed.
+      content: 'export FOO="hi"',
+    };
+
+    const { container } = render(
+      <CollapsibleToolCall
+        block={bashCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    const commandBlock = screen.getByTestId("command");
+    const output = screen.getByTestId("command-output");
+    expect(output.textContent).toContain('export FOO="hi"');
+    expect(
+      commandBlock.compareDocumentPosition(output) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+
+    // Once the highlighter has landed for the command, the output beside it is
+    // still untouched — nothing was guessed for it.
+    await waitFor(() =>
+      expect(commandBlock.querySelector('[class*="hljs-"]')).not.toBeNull()
+    );
+    expect(output.querySelector('[class*="hljs-"]')).toBeNull();
+    expect(container.querySelector("[data-testid='json-input']")).toBeNull();
+  });
+
+  it("renders a Bash unit that printed nothing as the command alone", () => {
+    const bashCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t7",
+      name: "Bash",
+      input: { command: "git add ." },
+    };
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t7",
+      content: "",
+    };
+
+    render(
+      <CollapsibleToolCall
+        block={bashCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId("command-line").textContent).toBe("git add .");
+    expect(screen.queryByTestId("command-output")).toBeNull();
+  });
+
+  it("still reads as failed for a Bash unit that reported an error", () => {
+    const bashCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t8",
+      name: "Bash",
+      input: { command: "pnpm test" },
+    };
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t8",
+      content: "1 test failed",
+      is_error: true,
+    };
+
+    render(
+      <CollapsibleToolCall
+        block={bashCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId("row-error")).not.toBeNull();
+    // What it said back is what explains the failure, so it still renders.
+    expect(screen.getByTestId("command-output").textContent).toContain(
+      "1 test failed"
+    );
+  });
+
   it("colours the input of a unit that renders neither diff nor excerpt", async () => {
     const searchCall: ToolUseBlock = {
       type: "tool_use",

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -1,6 +1,7 @@
 import { Terminal } from "lucide-react";
 import type { ContentBlock } from "@/types";
 import { CollapsibleRow } from "@/conversation/CollapsibleRow";
+import { CommandView } from "@/conversation/CommandView";
 import { DiffView } from "@/conversation/DiffView";
 import { FileExcerptView } from "@/conversation/FileExcerptView";
 import { generateToolSummary } from "@/conversation/generateToolSummary";
@@ -25,6 +26,12 @@ function readFilePath(input: unknown): string | undefined {
   if (typeof input !== "object" || input === null) return undefined;
   const { file_path: filePath } = input as { file_path?: unknown };
   return typeof filePath === "string" ? filePath : undefined;
+}
+
+function shellCommand(input: unknown): string | undefined {
+  if (typeof input !== "object" || input === null) return undefined;
+  const { command } = input as { command?: unknown };
+  return typeof command === "string" ? command : undefined;
 }
 
 /**
@@ -56,6 +63,11 @@ export function CollapsibleToolCall({
     !isDiff && readPath && typeof result?.content === "string"
   );
 
+  // A Bash unit is worth expanding for the command it ran and what that command
+  // said back, so the command renders as shell and the call's input is not also
+  // dumped as JSON above it (#252).
+  const command = block.name === "Bash" ? shellCommand(block.input) : undefined;
+
   const { label, diffStat } = generateToolSummary(block, result);
 
   return (
@@ -73,6 +85,11 @@ export function CollapsibleToolCall({
         <FileExcerptView
           filePath={readPath!}
           content={result!.content as string}
+        />
+      ) : command !== undefined ? (
+        <CommandView
+          command={command}
+          output={result ? formatResultContent(result.content) : undefined}
         />
       ) : (
         <>

--- a/web/src/conversation/CommandView.test.tsx
+++ b/web/src/conversation/CommandView.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import { CommandView } from "./CommandView";
+
+describe("CommandView", () => {
+  it("caps long output and reveals the rest on request", async () => {
+    const output = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join(
+      "\n"
+    );
+
+    render(<CommandView command="pnpm test" output={output} lineCap={40} />);
+
+    expect(screen.getAllByTestId("output-line")).toHaveLength(40);
+    expect(screen.queryByText("line 60")).toBeNull();
+
+    await userEvent.click(screen.getByText("Show 20 more lines"));
+
+    expect(screen.getAllByTestId("output-line")).toHaveLength(60);
+    expect(screen.getByText("line 60")).not.toBeNull();
+    expect(screen.queryByText(/Show \d+ more/)).toBeNull();
+  });
+});

--- a/web/src/conversation/CommandView.tsx
+++ b/web/src/conversation/CommandView.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import { useLanguageHighlighter } from "@/conversation/codeHighlight";
+import { capLines } from "@/conversation/commandOutput";
+
+interface CommandViewProps {
+  /** The shell command the unit ran. */
+  command: string;
+  /** What the command printed, verbatim. */
+  output?: string;
+  /**
+   * Most output lines rendered before the rest is folded behind a reveal
+   * control. A command that prints thousands of lines is capped so it cannot
+   * stall the pane; the reader opts into the tail, as with a long diff (#252).
+   */
+  lineCap?: number;
+}
+
+const DEFAULT_LINE_CAP = 40;
+
+/**
+ * A Bash unit: the command that ran, as shell, and what it said back.
+ *
+ * The command's language is known at the call site rather than inferred from a
+ * path — a Bash unit's command is always shell. The output gets no language at
+ * all: it is whatever the command happened to print, and guessing would only
+ * guess wrong (#252).
+ */
+export function CommandView({
+  command,
+  output,
+  lineCap = DEFAULT_LINE_CAP,
+}: CommandViewProps) {
+  const [showAll, setShowAll] = useState(false);
+
+  // Null until the lazy highlighter lands — the command renders plain until
+  // then, so colour only ever arrives as an improvement.
+  const highlight = useLanguageHighlighter("bash");
+
+  // A command that printed nothing gets no block at all, rather than an empty
+  // one below the command — the same reason a read drops a dead gutter (#252).
+  const printed = output?.trim() ? output : undefined;
+
+  const { lines: outputLines, hiddenLines } = capLines(
+    printed ?? "",
+    showAll ? Number.POSITIVE_INFINITY : lineCap
+  );
+
+  return (
+    <>
+      <div
+        data-testid="command"
+        className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-foreground"
+      >
+        {command.split("\n").map((line, index) => {
+          const highlighted = highlight ? highlight(line) : null;
+
+          return highlighted !== null ? (
+            <div
+              key={index}
+              data-testid="command-line"
+              className="whitespace-pre"
+              dangerouslySetInnerHTML={{ __html: highlighted }}
+            />
+          ) : (
+            <div
+              key={index}
+              data-testid="command-line"
+              className="whitespace-pre"
+            >
+              {line}
+            </div>
+          );
+        })}
+      </div>
+      {printed !== undefined && (
+        <div
+          data-testid="command-output"
+          className="overflow-x-auto rounded bg-card py-1 font-mono text-xs text-muted-foreground"
+        >
+          {outputLines.map((line, index) => (
+            <div
+              key={index}
+              data-testid="output-line"
+              className="whitespace-pre px-2"
+            >
+              {line}
+            </div>
+          ))}
+          {hiddenLines > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowAll(true)}
+              className="w-full cursor-pointer border-t border-border px-2 py-1 text-left transition-colors hover:bg-white/[0.04] hover:text-foreground"
+            >
+              Show {hiddenLines} more {hiddenLines === 1 ? "line" : "lines"}
+            </button>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/conversation/commandOutput.test.ts
+++ b/web/src/conversation/commandOutput.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { capLines } from "./commandOutput";
+
+describe("capLines", () => {
+  it("keeps only the first lines and reports how many it held back", () => {
+    const output = ["one", "two", "three", "four"].join("\n");
+
+    expect(capLines(output, 2)).toEqual({
+      lines: ["one", "two"],
+      hiddenLines: 2,
+    });
+  });
+});

--- a/web/src/conversation/commandOutput.ts
+++ b/web/src/conversation/commandOutput.ts
@@ -1,0 +1,18 @@
+export interface CappedOutput {
+  lines: string[];
+  /** Lines held back past the cap; 0 when the whole output renders. */
+  hiddenLines: number;
+}
+
+/**
+ * Bound a block of plain output to a number of lines.
+ *
+ * What a command printed carries no structure to lift out — no line numbers, no
+ * added/removed sides — so unlike a file excerpt this only counts. The overflow
+ * comes back as `hiddenLines` so the view can offer to reveal the rest (#252).
+ */
+export function capLines(output: string, lineCap: number): CappedOutput {
+  const all = output.split("\n");
+  const lines = all.slice(0, lineCap);
+  return { lines, hiddenLines: all.length - lines.length };
+}

--- a/web/src/conversation/fileExcerpt.ts
+++ b/web/src/conversation/fileExcerpt.ts
@@ -1,3 +1,5 @@
+import { capLines } from "@/conversation/commandOutput";
+
 /**
  * One line of a file as a Read tool reported it.
  *
@@ -31,15 +33,14 @@ const NUMBERED_LINE = /^(\d+)\t(.*)$/;
  * view can offer to reveal the rest — the same bargain a long diff strikes.
  */
 export function buildExcerpt(content: string, lineCap: number): FileExcerpt {
-  const rawLines = content.split("\n");
-  const numbered = NUMBERED_LINE.test(rawLines[0] ?? "");
+  const { lines: kept, hiddenLines } = capLines(content, lineCap);
+  const numbered = NUMBERED_LINE.test(kept[0] ?? "");
 
-  const kept = rawLines.slice(0, lineCap);
   const lines = kept.map((raw) => {
     const match = numbered ? NUMBERED_LINE.exec(raw) : null;
     if (!match) return { lineNumber: null, text: raw };
     return { lineNumber: Number(match[1]), text: match[2] };
   });
 
-  return { lines, hiddenLines: Math.max(0, rawLines.length - kept.length) };
+  return { lines, hiddenLines };
 }


### PR DESCRIPTION
## Background (Why)

A Bash unit buried the one thing worth reading — the command that ran — inside a serialised JSON blob, beside the output it produced. The reader had to pick a shell line out of quoted JSON to see what the session actually did.

Edits and reads already earned their own treatment (#235, #240). A Bash unit is worth expanding for the command and what it said back; neither needs the call input repeated as JSON above the thing itself.

## Approach (How)

A new `CommandView` renders the command on its own, as shell, coloured through `useLanguageHighlighter("bash")` — the language is known at the call site, so nothing is inferred from a path. The output follows beneath it, plain: it is whatever the command printed, and guessing a language would only guess wrong.

`CollapsibleToolCall` gains a Bash branch that routes to `CommandView` instead of `JsonView` + a raw `<pre>`. Failure still rides on the row's error mark, so a failed unit reads as failed without any new plumbing.

The length cap is factored into a pure `capLines`, and `buildExcerpt` now shares that one truncation path.

## Changes (What)

- [x] Add `CommandView` — command as highlighted shell, output plain beneath it, long output capped behind a reveal
- [x] Add `capLines` (`commandOutput.ts`) as the shared line-cap primitive
- [x] Route Bash units through `CommandView` in `CollapsibleToolCall`, dropping the raw JSON + `<pre>` fallback for them
- [x] A command with no output renders alone, with no empty block beneath it
- [x] `buildExcerpt` reuses `capLines` so truncation lives in one place

### Test Verification

- [x] An expanded Bash unit renders its command as highlighted shell, above the output
- [x] The output renders plain, with no language guessed for it
- [x] Long output is capped and a reveal control shows the rest
- [x] The call input is not also dumped as raw JSON
- [x] A Bash unit that recorded no output renders the command alone
- [x] A unit reporting a failure still reads as failed
- [x] `capLines` keeps the first lines and reports the held-back count
- [x] Full suite green (864 tests) and typecheck clean

## Related Links

- Closes #252