### PR TITLE
perf(web): ship one copy of the syntax grammars

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,6 @@ importers:
       react-resizable-panels:
         specifier: ^4.7.6
         version: 4.7.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      rehype-highlight:
-        specifier: ^7.0.2
-        version: 7.0.2
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
@@ -4300,22 +4297,10 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  hast-util-is-element@3.0.0:
-    resolution:
-      {
-        integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==,
-      }
-
   hast-util-to-jsx-runtime@2.3.6:
     resolution:
       {
         integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==,
-      }
-
-  hast-util-to-text@4.0.2:
-    resolution:
-      {
-        integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==,
       }
 
   hast-util-whitespace@3.0.0:
@@ -5081,12 +5066,6 @@ packages:
     resolution:
       {
         integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
-      }
-
-  lowlight@3.3.0:
-    resolution:
-      {
-        integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==,
       }
 
   lru-cache@11.2.7:
@@ -6185,12 +6164,6 @@ packages:
       }
     engines: { node: ">=12" }
 
-  rehype-highlight@7.0.2:
-    resolution:
-      {
-        integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==,
-      }
-
   remark-breaks@4.0.0:
     resolution:
       {
@@ -7152,12 +7125,6 @@ packages:
     resolution:
       {
         integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==,
-      }
-
-  unist-util-find-after@5.0.0:
-    resolution:
-      {
-        integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==,
       }
 
   unist-util-is@6.0.1:
@@ -9957,10 +9924,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hast-util-is-element@3.0.0:
-    dependencies:
-      "@types/hast": 3.0.5
-
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       "@types/estree": 1.0.8
@@ -9980,13 +9943,6 @@ snapshots:
       vfile-message: 4.0.3
     transitivePeerDependencies:
       - supports-color
-
-  hast-util-to-text@4.0.2:
-    dependencies:
-      "@types/hast": 3.0.5
-      "@types/unist": 3.0.3
-      hast-util-is-element: 3.0.0
-      unist-util-find-after: 5.0.0
 
   hast-util-whitespace@3.0.0:
     dependencies:
@@ -10339,12 +10295,6 @@ snapshots:
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
-
-  lowlight@3.3.0:
-    dependencies:
-      "@types/hast": 3.0.5
-      devlop: 1.1.0
-      highlight.js: 11.11.1
 
   lru-cache@11.2.7: {}
 
@@ -11214,14 +11164,6 @@ snapshots:
     dependencies:
       rc: 1.2.8
 
-  rehype-highlight@7.0.2:
-    dependencies:
-      "@types/hast": 3.0.5
-      hast-util-to-text: 4.0.2
-      lowlight: 3.3.0
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-
   remark-breaks@4.0.0:
     dependencies:
       "@types/mdast": 4.0.4
@@ -11873,11 +11815,6 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
-
-  unist-util-find-after@5.0.0:
-    dependencies:
-      "@types/unist": 3.0.3
-      unist-util-is: 6.0.1
 
   unist-util-is@6.0.1:
     dependencies:

--- a/web/e2e/code-highlighting.spec.ts
+++ b/web/e2e/code-highlighting.spec.ts
@@ -78,6 +78,33 @@ async function openChatWith(
   await page.getByText("Code conversation").click();
 }
 
+// The highlight.js package's own modules, however the server names them: the
+// dev server serves its pre-bundled dependency as `highlight__js_...`, a build
+// serves it from the package path. Matching the package rather than the word
+// keeps the app's own `codeHighlight.ts` — and any directory that happens to be
+// named after a highlighter — out of the count.
+const GRAMMAR_MODULE = /highlight__js|highlight\.js\/lib|lowlight/;
+
+/**
+ * Every request for the syntax grammars, collected from now on.
+ *
+ * The stylesheet that colours the tokens is filtered out: the theme is a few kB
+ * of CSS that ships with the app either way, and it is the grammars that #253
+ * is keeping off a code-free read.
+ *
+ * Attach this before navigating, or the initial load's requests are missed.
+ */
+function trackGrammarRequests(page: import("@playwright/test").Page): string[] {
+  const urls: string[] = [];
+  page.on("request", (request) => {
+    const url = request.url();
+    if (GRAMMAR_MODULE.test(url) && !/\.css(\?|$)/.test(url)) {
+      urls.push(url);
+    }
+  });
+  return urls;
+}
+
 test("a large diff expands and highlights in a real browser without stalling", async ({
   page,
 }) => {
@@ -201,4 +228,44 @@ test("a tool call with no view of its own shows its input as coloured JSON", asy
   }));
   expect(box.scrollWidth).toBeGreaterThan(box.clientWidth);
   expect(box.clientWidth).toBeLessThanOrEqual(box.parentWidth);
+});
+
+test("a chat with no code of any kind fetches no grammars", async ({
+  page,
+}) => {
+  const grammars = trackGrammarRequests(page);
+
+  await openChatWith(page, [
+    { type: "text", text: "No code here — just a note about the plan." },
+  ]);
+
+  await expect(
+    page.getByText("No code here — just a note about the plan.")
+  ).toBeVisible();
+
+  // The grammars load on demand, so give a late fetch a chance to show up
+  // before concluding that none was made.
+  await page.waitForTimeout(500);
+
+  expect(grammars).toEqual([]);
+});
+
+test("a markdown code block is coloured by the same grammars a diff uses", async ({
+  page,
+}) => {
+  const grammars = trackGrammarRequests(page);
+
+  await openChatWith(page, [
+    { type: "text", text: "```ts\nconst total = items.length;\n```" },
+  ]);
+
+  // The block is coloured, and its source is intact under the token markup.
+  await expect(page.locator(".hljs-keyword").first()).toBeVisible();
+  await expect(page.locator("code.hljs")).toContainText(
+    "const total = items.length;"
+  );
+
+  // One highlighter, fetched once: markdown pulls the same grammars the diff
+  // and read views do, rather than a second copy of its own (#253).
+  expect(new Set(grammars).size).toBe(1);
 });

--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,6 @@
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.7.6",
-    "rehype-highlight": "^7.0.2",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.0",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1459,7 +1459,7 @@ describe("Conversation view", () => {
     expect(linkEl).toHaveAttribute("href", "https://example.com");
 
     // Assistant message has a syntax-highlighted code block
-    // rehype-highlight splits tokens into spans, so use a function matcher
+    // Highlighting splits tokens into spans, so use a function matcher
     const codeBlock = screen.getByText((_content, element) => {
       return (
         element?.tagName === "CODE" &&

--- a/web/src/conversation/MarkdownText.test.tsx
+++ b/web/src/conversation/MarkdownText.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MarkdownText } from "@/conversation/MarkdownText";
@@ -67,6 +67,36 @@ describe("MarkdownText code block copying", () => {
     render(<MarkdownText>{"use the `id` field"}</MarkdownText>);
 
     expect(screen.queryByRole("button", { name: "Copy code" })).toBeNull();
+  });
+});
+
+describe("MarkdownText code block highlighting", () => {
+  it("colours a fenced block's keywords", async () => {
+    const { container } = render(
+      <MarkdownText>{"```ts\nconst x = 1;\nreturn x;\n```"}</MarkdownText>
+    );
+
+    // The tokens are what the reader sees as colour; the surface they sit on is
+    // the `.hljs` block the theme paints.
+    await waitFor(() => {
+      expect(container.querySelector(".hljs-keyword")).not.toBeNull();
+    });
+    expect(container.querySelector("code.hljs")).not.toBeNull();
+    expect(container.textContent).toContain("const x = 1;");
+  });
+
+  it("still shows the code for a language it cannot colour", async () => {
+    // A fence carries whatever word its writer typed, and the bundle carries a
+    // common set. The block has to stay readable either way.
+    const { container } = render(
+      <MarkdownText>{"```mermaid\ngraph TD;\nA-->B;\n```"}</MarkdownText>
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("code.hljs")).not.toBeNull();
+    });
+    expect(container.textContent).toContain("graph TD;");
+    expect(container.querySelector(".hljs-keyword")).toBeNull();
   });
 });
 

--- a/web/src/conversation/MarkdownText.tsx
+++ b/web/src/conversation/MarkdownText.tsx
@@ -1,13 +1,10 @@
-import Markdown, {
-  defaultUrlTransform,
-  type Components,
-} from "react-markdown";
+import Markdown, { defaultUrlTransform, type Components } from "react-markdown";
 import type { Element, ElementContent } from "hast";
-import rehypeHighlight from "rehype-highlight";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { CopyButton } from "@/shared/CopyButton";
 import { FileChip } from "@/conversation/FileChip";
+import { useLanguageHighlighter } from "@/conversation/codeHighlight";
 
 // The code as written, read off the syntax tree rather than the rendered
 // output: highlighting has already wrapped keywords in spans by the time this
@@ -23,6 +20,55 @@ function nodeText(node: ElementContent): string {
 function codeSource(node: Element | undefined): string {
   if (!node) return "";
   return node.children.map(nodeText).join("").replace(/\n$/, "");
+}
+
+// The word the writer typed after the opening backticks. react-markdown leaves
+// it on the `code` child as `language-<token>`; it is passed through as written,
+// because highlight.js resolves its own aliases (`ts`, `sh`, `yml`) and answers
+// for anything it does not carry.
+function fenceLanguage(node: Element | undefined): string | null {
+  const code = node?.children.find(
+    (child): child is Element =>
+      child.type === "element" && child.tagName === "code"
+  );
+  const classes = code?.properties.className;
+  if (!Array.isArray(classes)) return null;
+  for (const name of classes) {
+    if (typeof name === "string" && name.startsWith("language-")) {
+      return name.slice("language-".length);
+    }
+  }
+  return null;
+}
+
+/**
+ * A fenced block, coloured by the one shared highlighter (#253).
+ *
+ * The `hljs` class is on the block from first paint, so the theme's surface is
+ * there immediately and only the token colours wait on the lazy load. A fence
+ * with no language, or one the bundle does not carry, simply stays plain — the
+ * same way a diff does for a file type we do not recognise.
+ */
+function CodeBlock({
+  source,
+  language,
+}: {
+  source: string;
+  language: string | null;
+}) {
+  const highlight = useLanguageHighlighter(language);
+  const highlighted = highlight ? highlight(source) : null;
+
+  return (
+    <pre>
+      <code
+        className={language ? `hljs language-${language}` : "hljs"}
+        {...(highlighted !== null
+          ? { dangerouslySetInnerHTML: { __html: highlighted } }
+          : { children: source })}
+      />
+    </pre>
+  );
 }
 
 const markdownComponents: Components = {
@@ -48,16 +94,22 @@ const markdownComponents: Components = {
   // Only fenced blocks get a copy button — inline code is a word inside a
   // sentence, not something to take away. `group` scopes the hover reveal to
   // this block, so one button appears at a time.
-  pre: ({ children, node, ...props }) => (
-    <div className="group relative">
-      <pre {...props}>{children}</pre>
-      <CopyButton
-        value={codeSource(node)}
-        label="Copy code"
-        className="absolute right-2 top-2 bg-[#002b36]/80"
-      />
-    </div>
-  ),
+  pre: ({ node }) => {
+    // Rebuilt from the syntax tree rather than passed through, so the block and
+    // the copy button read the same source: one string, highlighted for the eye
+    // and copied as written.
+    const source = codeSource(node);
+    return (
+      <div className="group relative">
+        <CodeBlock source={source} language={fenceLanguage(node)} />
+        <CopyButton
+          value={source}
+          label="Copy code"
+          className="absolute right-2 top-2 bg-[#002b36]/80"
+        />
+      </div>
+    );
+  },
 };
 
 // prose-sm keeps chat turns tighter than prose's article-scale defaults.
@@ -88,7 +140,6 @@ export function MarkdownText({ children }: { children: string }) {
         // spaces silently reflows what they actually wrote. Structure (lists,
         // tables, code) still parses normally.
         remarkPlugins={[remarkGfm, remarkBreaks]}
-        rehypePlugins={[rehypeHighlight]}
         // react-markdown drops `file:` URLs by default, as a defence against
         // links a page might navigate to. These never navigate — the chip
         // copies the path instead — so the URL has to survive to be read.

--- a/web/src/conversation/codeHighlight.test.ts
+++ b/web/src/conversation/codeHighlight.test.ts
@@ -1,5 +1,10 @@
+import { act, renderHook } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
-import { languageForPath } from "./codeHighlight";
+import {
+  languageForPath,
+  loadHighlighter,
+  useLanguageHighlighter,
+} from "./codeHighlight";
 
 describe("languageForPath", () => {
   it("infers the highlight language from a file's extension", () => {
@@ -10,5 +15,21 @@ describe("languageForPath", () => {
 
   it("returns null for an unrecognised extension, so the diff renders plain", () => {
     expect(languageForPath("notes/journal.xyz")).toBeNull();
+  });
+});
+
+describe("useLanguageHighlighter", () => {
+  it("renders plain for a language the bundle does not carry", async () => {
+    // A markdown fence carries whatever word the writer typed after the
+    // backticks. `mermaid` is a real one, and not a language the common bundle
+    // registers — asking the highlighter for it must leave the block plain,
+    // the same as an unrecognised file extension, rather than throw.
+    const { result } = renderHook(() => useLanguageHighlighter("mermaid"));
+
+    await act(async () => {
+      await loadHighlighter();
+    });
+
+    expect(result.current).toBeNull();
   });
 });

--- a/web/src/conversation/codeHighlight.ts
+++ b/web/src/conversation/codeHighlight.ts
@@ -129,6 +129,10 @@ export function useLanguageHighlighter(
 
   return useMemo(() => {
     if (!language || !hljs) return null;
+    // The bundle carries the common languages, not every one a caller can name:
+    // a markdown fence says whatever word its writer typed. An unregistered one
+    // stays null, so the block renders plain instead of throwing.
+    if (!hljs.getLanguage(language)) return null;
     return (text: string) =>
       hljs.highlight(text, { language, ignoreIllegals: true }).value;
   }, [language, hljs]);


### PR DESCRIPTION
## Background (Why)

Two copies of the syntax grammars shipped. Markdown code blocks went through `rehype-highlight`, which pulled its own copy into the initial bundle eagerly; the diff and file views added in #240 lazily loaded a second copy in a chunk of their own.

So a reader who opened a diff downloaded 131 kB of grammars the main bundle already contained — and a chat with no code of any kind still paid for the eager copy, because it sat in the entry chunk.

## Approach (How)

Markdown now uses the same lazy `useLanguageHighlighter` the diff, read, and JSON views use, and `rehype-highlight` is gone.

`MarkdownText` rebuilds the fenced block from the syntax tree rather than passing it through: one source string, highlighted for the eye and copied as written. The fence's language token is passed to highlight.js as the writer typed it — hljs resolves its own aliases (`ts`, `sh`, `yml`), so no second mapping table is needed.

That widened the set of languages a caller can name from a closed extension map to anything a writer types after three backticks, so `useLanguageHighlighter` now asks `hljs.getLanguage()` first and stays `null` for one the bundle does not carry, instead of throwing.

**The first-paint trade, taken deliberately:** a markdown block now paints plain for a moment before its colours arrive, where it used to be coloured on first paint. The `.hljs` class is on the block from the start, so the theme's dark surface is there immediately and only the token colours wait. This is the behaviour a diff already has, so the pane is now consistent with itself — and it buys the numbers below.

## Changes (What)

- [x] Markdown code blocks render through the shared lazy highlighter; `rehype-highlight` removed as a dependency
- [x] `useLanguageHighlighter` leaves a language the bundle lacks unhighlighted rather than throwing
- [x] One copy of the grammars ships, shared by markdown, diffs, file excerpts, and tool-call JSON
- [x] A chat with no code fetches no grammars at all

### Test Verification

Measured with `pnpm build`

| | before | after | delta |
| --- | --- | --- | --- |
| `index.js` (initial) | 811.58 kB / gzip 253.86 | 645.06 kB / gzip 200.82 | **−166.52 kB / −53.04 kB** |
| `common.js` (lazy) | 131.78 kB / gzip 44.32 | 152.02 kB / gzip 51.98 | +20.24 kB |
| total JS | 943.36 kB | 797.08 kB | −146.28 kB |

- [x] A chat with no code of any kind issues zero requests for grammar modules (e2e, network-level)
- [x] A markdown code block is coloured, and its grammars are fetched exactly once (e2e)
- [x] A fenced block's keywords are coloured and its `.hljs` surface is present
- [x] A fence naming a language the bundle lacks (`mermaid`) still shows its code, uncoloured
- [x] The copy button still yields the source without highlighting markup
- [x] Diff, read, and tool-call JSON highlighting unchanged (existing e2e)
- [x] Full suite: 861 unit tests, 21 e2e, `pnpm typecheck` and `pnpm build` clean

## Additional Notes

The lazy chunk grew 20.24 kB. The likely cause is that the entry chunk previously held hljs code shared with lowlight's copy, which the lazy chunk could then omit; with nothing left in the entry, the lazy chunk carries the whole set. Not investigated further — the number that matters is what a reader downloads, and both the initial load and the total went down.

## Related Links

- Closes #253