### PR TITLE
feat(web): colour the code the conversation pane shows

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -35,6 +35,8 @@ New colors enter `web/src/index.css` as a CSS variable wired through `@theme inl
 
 Text of any size clears 4.5:1 against the surface it renders on. Measure against the actual surface (`--card` for the batch bar, `--background` for the sidebar), not a guess. Known debt: `--primary` itself sits at 4.12:1 — tracked as a palette-level issue, don't fix it per-button.
 
+An edit's diff stat, measured against `--background` #002b36 and a row's hover ground #0a333e (#250): `--diff-add` 6.59:1 / 5.92:1 and `--diff-remove` 5.48:1 / 4.93:1 both clear the floor. `--destructive` does not clear it as text — 3.25:1 — which is why the removed count has its own lifted tone rather than reusing it. Known debt: the muted pair the counts rest in, `--diff-add-muted` 3.06:1 and `--diff-remove-muted` 3.42:1, sits under the floor. Both are above the `--muted-foreground` label they sit beside (2.79:1), so they are no quieter than the row already is — the whole muted skim layer is what #219 is auditing, and this pair belongs to that decision rather than a separate one.
+
 ## Tokens
 
 The action-facing subset of `web/src/index.css` (Solarized dark):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,6 @@ importers:
       react-resizable-panels:
         specifier: ^4.7.6
         version: 4.7.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      rehype-highlight:
-        specifier: ^7.0.2
-        version: 7.0.2
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
@@ -4300,22 +4297,10 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  hast-util-is-element@3.0.0:
-    resolution:
-      {
-        integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==,
-      }
-
   hast-util-to-jsx-runtime@2.3.6:
     resolution:
       {
         integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==,
-      }
-
-  hast-util-to-text@4.0.2:
-    resolution:
-      {
-        integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==,
       }
 
   hast-util-whitespace@3.0.0:
@@ -5081,12 +5066,6 @@ packages:
     resolution:
       {
         integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
-      }
-
-  lowlight@3.3.0:
-    resolution:
-      {
-        integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==,
       }
 
   lru-cache@11.2.7:
@@ -6185,12 +6164,6 @@ packages:
       }
     engines: { node: ">=12" }
 
-  rehype-highlight@7.0.2:
-    resolution:
-      {
-        integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==,
-      }
-
   remark-breaks@4.0.0:
     resolution:
       {
@@ -7152,12 +7125,6 @@ packages:
     resolution:
       {
         integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==,
-      }
-
-  unist-util-find-after@5.0.0:
-    resolution:
-      {
-        integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==,
       }
 
   unist-util-is@6.0.1:
@@ -9957,10 +9924,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hast-util-is-element@3.0.0:
-    dependencies:
-      "@types/hast": 3.0.5
-
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       "@types/estree": 1.0.8
@@ -9980,13 +9943,6 @@ snapshots:
       vfile-message: 4.0.3
     transitivePeerDependencies:
       - supports-color
-
-  hast-util-to-text@4.0.2:
-    dependencies:
-      "@types/hast": 3.0.5
-      "@types/unist": 3.0.3
-      hast-util-is-element: 3.0.0
-      unist-util-find-after: 5.0.0
 
   hast-util-whitespace@3.0.0:
     dependencies:
@@ -10339,12 +10295,6 @@ snapshots:
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
-
-  lowlight@3.3.0:
-    dependencies:
-      "@types/hast": 3.0.5
-      devlop: 1.1.0
-      highlight.js: 11.11.1
 
   lru-cache@11.2.7: {}
 
@@ -11214,14 +11164,6 @@ snapshots:
     dependencies:
       rc: 1.2.8
 
-  rehype-highlight@7.0.2:
-    dependencies:
-      "@types/hast": 3.0.5
-      hast-util-to-text: 4.0.2
-      lowlight: 3.3.0
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-
   remark-breaks@4.0.0:
     dependencies:
       "@types/mdast": 4.0.4
@@ -11873,11 +11815,6 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
-
-  unist-util-find-after@5.0.0:
-    dependencies:
-      "@types/unist": 3.0.3
-      unist-util-is: 6.0.1
 
   unist-util-is@6.0.1:
     dependencies:

--- a/web/e2e/code-highlighting.spec.ts
+++ b/web/e2e/code-highlighting.spec.ts
@@ -168,3 +168,37 @@ test("a large read expands as a highlighted, numbered excerpt without stalling",
   await expect(firstRow).toContainText("1");
   await expect(firstRow.locator(".hljs-keyword").first()).toBeVisible();
 });
+
+test("a tool call with no view of its own shows its input as coloured JSON", async ({
+  page,
+}) => {
+  await openChatWith(page, [
+    {
+      type: "tool_use",
+      id: "tool_3",
+      name: "Grep",
+      input: {
+        pattern: "useState",
+        // Long enough that an unwrapped line would stretch the pane if the
+        // block did not scroll on its own.
+        path: `web/src/${"very-long-directory-name/".repeat(20)}index.ts`,
+      },
+    },
+    { type: "tool_result", tool_use_id: "tool_3", content: "No matches found" },
+  ]);
+
+  await page.getByText("Grep", { exact: false }).first().click();
+
+  const input = page.getByTestId("json-input");
+  await expect(input.locator(".hljs-attr").first()).toBeVisible();
+
+  // The long value scrolls inside the block rather than widening it: the block
+  // stays within its column while its content overflows.
+  const box = await input.evaluate((node) => ({
+    scrollWidth: node.scrollWidth,
+    clientWidth: node.clientWidth,
+    parentWidth: (node.parentElement as HTMLElement).clientWidth,
+  }));
+  expect(box.scrollWidth).toBeGreaterThan(box.clientWidth);
+  expect(box.clientWidth).toBeLessThanOrEqual(box.parentWidth);
+});

--- a/web/e2e/code-highlighting.spec.ts
+++ b/web/e2e/code-highlighting.spec.ts
@@ -99,8 +99,9 @@ test("a large diff expands and highlights in a real browser without stalling", a
 
   // The collapsed tool unit summarises the write; the full path shows once the
   // diff is expanded.
-  const summary = page.getByText("Wrote constants.ts +200 -0");
+  const summary = page.getByText("Wrote constants.ts");
   await expect(summary).toBeVisible();
+  await expect(page.getByTestId("row-diff-stat")).toHaveText("+200 -0");
 
   const start = Date.now();
   await summary.click();

--- a/web/e2e/code-highlighting.spec.ts
+++ b/web/e2e/code-highlighting.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect } from "@playwright/test";
+
+// Large enough that colouring every line has a real cost, so an expansion is a
+// genuine measurement rather than a toy.
+const LINE_COUNT = 200;
+
+function largePatch() {
+  const lines: string[] = [];
+  for (let i = 0; i < LINE_COUNT; i += 1) {
+    lines.push(`+const value${i} = ${i} as const;`);
+  }
+  return [
+    { oldStart: 1, oldLines: 0, newStart: 1, newLines: LINE_COUNT, lines },
+  ];
+}
+
+// A Read result as the tool writes it: `<line number>\t<content>`.
+function largeReadResult() {
+  const lines: string[] = [];
+  for (let i = 1; i <= LINE_COUNT; i += 1) {
+    lines.push(`${i}\tconst value${i} = ${i} as const;`);
+  }
+  return lines.join("\n");
+}
+
+/** Mount a one-turn chat whose assistant message carries `blocks`. */
+async function openChatWith(
+  page: import("@playwright/test").Page,
+  blocks: unknown[]
+) {
+  // Benign empty SSE stream so the live-update EventSource connects cleanly.
+  await page.route(/\/api\/chats\/stream(\?|$)/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: ":ok\n\n",
+    })
+  );
+  await page.route(/\/api\/chats\/counts(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1, projects: [], tags: [], untagged: 1 } })
+  );
+  await page.route(/\/api\/chats\/list-total(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1 } })
+  );
+  await page.route(/\/api\/chats(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        chats: [
+          {
+            id: "clog_code1",
+            sourceId: "code-chat",
+            agent: "claude-code",
+            title: "Code conversation",
+            project: "/test/project",
+            sourceFilePath: null,
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      },
+    })
+  );
+  await page.route(/\/api\/chats\/clog_code1(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        messages: [
+          {
+            role: "assistant",
+            content: blocks,
+            timestamp: "2023-11-14T22:13:20.000Z",
+          },
+        ],
+      },
+    })
+  );
+
+  await page.goto("/");
+  await page.getByText("Code conversation").click();
+}
+
+test("a large diff expands and highlights in a real browser without stalling", async ({
+  page,
+}) => {
+  await openChatWith(page, [
+    {
+      type: "tool_use",
+      id: "tool_1",
+      name: "Write",
+      input: { file_path: "web/src/constants.ts" },
+    },
+    {
+      type: "tool_result",
+      tool_use_id: "tool_1",
+      content: "File written",
+      file_path: "web/src/constants.ts",
+      patch: largePatch(),
+    },
+  ]);
+
+  // The collapsed tool unit summarises the write; the full path shows once the
+  // diff is expanded.
+  const summary = page.getByText("Wrote constants.ts +200 -0");
+  await expect(summary).toBeVisible();
+
+  const start = Date.now();
+  await summary.click();
+  await expect(page.getByText("web/src/constants.ts")).toBeVisible();
+
+  // Highlighting arrives after the lazy highlighter load — the keyword tokens
+  // appear, proving the language was inferred and applied.
+  await expect(page.locator(".hljs-keyword").first()).toBeVisible();
+  const elapsed = Date.now() - start;
+
+  // The default line cap folds the tail behind a reveal, so the first view is
+  // never the whole 200 lines — the expansion cannot stall on them.
+  await expect(
+    page.getByRole("button", { name: /Show \d+ more/ })
+  ).toBeVisible();
+
+  // Generous bound: this only fails if expansion genuinely blocks, not on
+  // ordinary render jitter.
+  expect(elapsed).toBeLessThan(3000);
+
+  // The added ground survives under the token colours: rows are still tinted.
+  const addedRow = page
+    .locator('[data-testid="diff-line"][data-kind="add"]')
+    .first();
+  await expect(addedRow).toHaveClass(/bg-green-500\/10/);
+  await expect(addedRow.locator(".hljs-keyword").first()).toBeVisible();
+});
+
+test("a large read expands as a highlighted, numbered excerpt without stalling", async ({
+  page,
+}) => {
+  await openChatWith(page, [
+    {
+      type: "tool_use",
+      id: "tool_2",
+      name: "Read",
+      input: { file_path: "web/src/constants.ts" },
+    },
+    {
+      type: "tool_result",
+      tool_use_id: "tool_2",
+      content: largeReadResult(),
+    },
+  ]);
+
+  const summary = page.getByText("Read: web/src/constants.ts");
+  await expect(summary).toBeVisible();
+
+  const start = Date.now();
+  await summary.click();
+
+  await expect(page.locator(".hljs-keyword").first()).toBeVisible();
+  const elapsed = Date.now() - start;
+
+  // The cap folds the tail, so a whole file read into the pane cannot stall it.
+  await expect(
+    page.getByRole("button", { name: /Show \d+ more/ })
+  ).toBeVisible();
+  expect(elapsed).toBeLessThan(3000);
+
+  // The numbers were lifted into a gutter: the first row shows line 1 beside
+  // its code, not the raw `1\t…` the tool wrote.
+  const firstRow = page.locator('[data-testid="excerpt-line"]').first();
+  await expect(firstRow).toContainText("1");
+  await expect(firstRow.locator(".hljs-keyword").first()).toBeVisible();
+});

--- a/web/e2e/code-highlighting.spec.ts
+++ b/web/e2e/code-highlighting.spec.ts
@@ -78,6 +78,33 @@ async function openChatWith(
   await page.getByText("Code conversation").click();
 }
 
+// The highlight.js package's own modules, however the server names them: the
+// dev server serves its pre-bundled dependency as `highlight__js_...`, a build
+// serves it from the package path. Matching the package rather than the word
+// keeps the app's own `codeHighlight.ts` — and any directory that happens to be
+// named after a highlighter — out of the count.
+const GRAMMAR_MODULE = /highlight__js|highlight\.js\/lib|lowlight/;
+
+/**
+ * Every request for the syntax grammars, collected from now on.
+ *
+ * The stylesheet that colours the tokens is filtered out: the theme is a few kB
+ * of CSS that ships with the app either way, and it is the grammars that #253
+ * is keeping off a code-free read.
+ *
+ * Attach this before navigating, or the initial load's requests are missed.
+ */
+function trackGrammarRequests(page: import("@playwright/test").Page): string[] {
+  const urls: string[] = [];
+  page.on("request", (request) => {
+    const url = request.url();
+    if (GRAMMAR_MODULE.test(url) && !/\.css(\?|$)/.test(url)) {
+      urls.push(url);
+    }
+  });
+  return urls;
+}
+
 test("a large diff expands and highlights in a real browser without stalling", async ({
   page,
 }) => {
@@ -201,4 +228,44 @@ test("a tool call with no view of its own shows its input as coloured JSON", asy
   }));
   expect(box.scrollWidth).toBeGreaterThan(box.clientWidth);
   expect(box.clientWidth).toBeLessThanOrEqual(box.parentWidth);
+});
+
+test("a chat with no code of any kind fetches no grammars", async ({
+  page,
+}) => {
+  const grammars = trackGrammarRequests(page);
+
+  await openChatWith(page, [
+    { type: "text", text: "No code here — just a note about the plan." },
+  ]);
+
+  await expect(
+    page.getByText("No code here — just a note about the plan.")
+  ).toBeVisible();
+
+  // The grammars load on demand, so give a late fetch a chance to show up
+  // before concluding that none was made.
+  await page.waitForTimeout(500);
+
+  expect(grammars).toEqual([]);
+});
+
+test("a markdown code block is coloured by the same grammars a diff uses", async ({
+  page,
+}) => {
+  const grammars = trackGrammarRequests(page);
+
+  await openChatWith(page, [
+    { type: "text", text: "```ts\nconst total = items.length;\n```" },
+  ]);
+
+  // The block is coloured, and its source is intact under the token markup.
+  await expect(page.locator(".hljs-keyword").first()).toBeVisible();
+  await expect(page.locator("code.hljs")).toContainText(
+    "const total = items.length;"
+  );
+
+  // One highlighter, fetched once: markdown pulls the same grammars the diff
+  // and read views do, rather than a second copy of its own (#253).
+  expect(new Set(grammars).size).toBe(1);
 });

--- a/web/e2e/diff-stat.spec.ts
+++ b/web/e2e/diff-stat.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from "@playwright/test";
+
+// The row names the file by its basename, so what has to give way is a long
+// name in a narrow pane — the case that used to eat the counts (#250).
+const LONG_NAME =
+  "CollapsibleToolCallSummaryRowWithAVeryLongDescriptiveFileName.test.tsx";
+const LONG_PATH = `web/src/conversation/${LONG_NAME}`;
+
+// The tokens, as the browser reports them.
+const AT_REST_ADDED = "rgb(79, 122, 94)"; // --diff-add-muted #4f7a5e
+const AT_REST_REMOVED = "rgb(158, 107, 110)"; // --diff-remove-muted #9e6b6e
+const RESOLVED_ADDED = "rgb(34, 197, 94)"; // --diff-add #22c55e
+const RESOLVED_REMOVED = "rgb(255, 110, 100)"; // --diff-remove #ff6e64
+
+/** Mount a one-turn chat whose assistant message carries `blocks`. */
+async function openChatWith(
+  page: import("@playwright/test").Page,
+  blocks: unknown[]
+) {
+  // Benign empty SSE stream so the live-update EventSource connects cleanly.
+  await page.route(/\/api\/chats\/stream(\?|$)/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: ":ok\n\n",
+    })
+  );
+  await page.route(/\/api\/chats\/counts(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1, projects: [], tags: [], untagged: 1 } })
+  );
+  await page.route(/\/api\/chats\/list-total(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1 } })
+  );
+  await page.route(/\/api\/chats(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        chats: [
+          {
+            id: "clog_stat1",
+            sourceId: "stat-chat",
+            agent: "claude-code",
+            title: "Edit conversation",
+            project: "/test/project",
+            sourceFilePath: null,
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      },
+    })
+  );
+  await page.route(/\/api\/chats\/clog_stat1(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        messages: [
+          {
+            role: "assistant",
+            content: blocks,
+            timestamp: "2023-11-14T22:13:20.000Z",
+          },
+        ],
+      },
+    })
+  );
+
+  await page.goto("/");
+  await page.getByText("Edit conversation").click();
+}
+
+/** The one collapsed row carrying a diff stat. */
+function statRow(page: import("@playwright/test").Page) {
+  return page
+    .locator("button")
+    .filter({ has: page.getByTestId("row-diff-stat") });
+}
+
+function editOf(filePath: string, added: number, removed: number) {
+  const lines = [
+    ...Array.from({ length: removed }, (_, i) => `-old${i}`),
+    ...Array.from({ length: added }, (_, i) => `+new${i}`),
+  ];
+  return [
+    {
+      type: "tool_use",
+      id: "tool_1",
+      name: "Edit",
+      input: { file_path: filePath },
+    },
+    {
+      type: "tool_result",
+      tool_use_id: "tool_1",
+      content: "File updated",
+      file_path: filePath,
+      patch: [
+        {
+          oldStart: 1,
+          oldLines: removed,
+          newStart: 1,
+          newLines: added,
+          lines,
+        },
+      ],
+    },
+  ];
+}
+
+test("the counts survive a name long enough to truncate", async ({ page }) => {
+  // A narrow window squeezes the third pane, so the name has to give way.
+  await page.setViewportSize({ width: 760, height: 700 });
+  await openChatWith(page, editOf(LONG_PATH, 39, 2));
+
+  const stat = page.getByTestId("row-diff-stat");
+  await expect(stat).toHaveText("+39 -2");
+
+  const label = page.getByText(`Edited ${LONG_NAME}`);
+  const truncated = await label.evaluate(
+    (el) => el.scrollWidth > el.clientWidth
+  );
+  const statBox = await stat.boundingBox();
+  const rowBox = await statRow(page).boundingBox();
+
+  // The row is genuinely out of room — and the counts are still on it, drawn at
+  // its trailing edge rather than pushed past it.
+  expect(truncated).toBe(true);
+  expect(statBox).not.toBeNull();
+  expect(statBox!.width).toBeGreaterThan(0);
+  expect(statBox!.x + statBox!.width).toBeLessThanOrEqual(
+    rowBox!.x + rowBox!.width + 1
+  );
+});
+
+test("the counts rest near the label and resolve on hover and on opening", async ({
+  page,
+}) => {
+  await openChatWith(page, editOf("web/src/App.tsx", 39, 2));
+
+  const added = page.getByTestId("row-diff-added");
+  const removed = page.getByTestId("row-diff-removed");
+  await expect(added).toHaveCSS("color", AT_REST_ADDED);
+  await expect(removed).toHaveCSS("color", AT_REST_REMOVED);
+
+  const row = statRow(page);
+  await row.hover();
+  await expect(added).toHaveCSS("color", RESOLVED_ADDED);
+  await expect(removed).toHaveCSS("color", RESOLVED_REMOVED);
+
+  // Opening the row keeps them resolved, so the collapsed line and the diff it
+  // opened onto say the same thing in the same colours.
+  await row.click();
+  await page.mouse.move(0, 0);
+  await expect(page.getByTestId("diff-line").first()).toBeVisible();
+  await expect(added).toHaveCSS("color", RESOLVED_ADDED);
+  await expect(removed).toHaveCSS("color", RESOLVED_REMOVED);
+});
+
+test("a zero side dims instead of disappearing", async ({ page }) => {
+  await openChatWith(page, editOf("web/src/App.tsx", 12, 0));
+
+  const removed = page.getByTestId("row-diff-removed");
+  await expect(removed).toBeVisible();
+  await expect(removed).toHaveText("-0");
+  await expect(removed).toHaveCSS("opacity", "0.5");
+  await expect(page.getByTestId("row-diff-added")).toHaveCSS("opacity", "1");
+});

--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,6 @@
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.7.6",
-    "rehype-highlight": "^7.0.2",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.0",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1480,11 +1480,11 @@ describe("Tool call rendering", () => {
     // Tool call summary should be visible
     expect(await screen.findByText("Read: src/utils.ts")).toBeInTheDocument();
 
-    // Full tool input should NOT be visible when collapsed
-    expect(screen.queryByText(/"file_path"/)).not.toBeInTheDocument();
+    // The file it read should NOT be visible when collapsed
+    expect(screen.queryByTestId("excerpt-line")).not.toBeInTheDocument();
   });
 
-  it("expands tool call to show full input when clicked", async () => {
+  it("expands tool call to show the file it read when clicked", async () => {
     const user = userEvent.setup();
     render(<App />);
 
@@ -1494,8 +1494,9 @@ describe("Tool call rendering", () => {
     // Click to expand
     await user.click(summary);
 
-    // Should show the tool input details
-    expect(screen.getByText(/"file_path"/)).toBeInTheDocument();
+    // A read opens onto the file itself, not the call's raw JSON (#240).
+    const row = screen.getByTestId("excerpt-line");
+    expect(row.textContent).toContain("export function add(a, b)");
   });
 
   it("collapses tool call back when clicked again", async () => {
@@ -1507,10 +1508,10 @@ describe("Tool call rendering", () => {
 
     // Expand then collapse
     await user.click(summary);
-    expect(screen.getByText(/"file_path"/)).toBeInTheDocument();
+    expect(screen.getByTestId("excerpt-line")).toBeInTheDocument();
 
     await user.click(summary);
-    expect(screen.queryByText(/"file_path"/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("excerpt-line")).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1459,7 +1459,7 @@ describe("Conversation view", () => {
     expect(linkEl).toHaveAttribute("href", "https://example.com");
 
     // Assistant message has a syntax-highlighted code block
-    // rehype-highlight splits tokens into spans, so use a function matcher
+    // Highlighting splits tokens into spans, so use a function matcher
     const codeBlock = screen.getByText((_content, element) => {
       return (
         element?.tagName === "CODE" &&

--- a/web/src/conversation/CollapsibleRow.test.tsx
+++ b/web/src/conversation/CollapsibleRow.test.tsx
@@ -88,3 +88,131 @@ describe("CollapsibleRow chevron treatment", () => {
     expect(dot.getAttribute("class") ?? "").toMatch(/bg-destructive/);
   });
 });
+
+describe("CollapsibleRow diff stat", () => {
+  const LONG_PATH = "Edited web/src/conversation/CollapsibleToolCall.tsx";
+
+  it("keeps the counts out of the truncating label, at the row's trailing edge", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary={LONG_PATH}
+        diffStat={{ added: 39, removed: 2 }}
+        isExpanded={false}
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    const stat = screen.getByTestId("row-diff-stat");
+    expect(stat.textContent).toBe("+39 -2");
+    // Whatever the path does, the stat is not inside what truncates it.
+    expect(stat.closest(".truncate")).toBeNull();
+    expect(stat.getAttribute("class") ?? "").toMatch(/shrink-0/);
+  });
+
+  it("keeps each side's sign attached, so colour is never the only cue", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary={LONG_PATH}
+        diffStat={{ added: 39, removed: 2 }}
+        isExpanded={false}
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    const added = screen.getByTestId("row-diff-added");
+    const removed = screen.getByTestId("row-diff-removed");
+    expect(added.textContent).toBe("+39");
+    expect(removed.textContent).toBe("-2");
+    expect(added.getAttribute("class") ?? "").toMatch(/diff-add/);
+    expect(removed.getAttribute("class") ?? "").toMatch(/diff-remove/);
+  });
+
+  it("dims a zero side rather than dropping it, keeping the row's shape", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary="Wrote README.md"
+        diffStat={{ added: 12, removed: 0 }}
+        isExpanded={false}
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    expect(screen.getByTestId("row-diff-stat").textContent).toBe("+12 -0");
+    expect(
+      screen.getByTestId("row-diff-removed").getAttribute("class")
+    ).toMatch(/opacity-50/);
+    expect(
+      screen.getByTestId("row-diff-added").getAttribute("class")
+    ).not.toMatch(/opacity-50/);
+  });
+
+  it("rests near the muted label, resolving to full colour on hover", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary={LONG_PATH}
+        diffStat={{ added: 39, removed: 2 }}
+        isExpanded={false}
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    const added =
+      screen.getByTestId("row-diff-added").getAttribute("class") ?? "";
+    const removed =
+      screen.getByTestId("row-diff-removed").getAttribute("class") ?? "";
+    expect(added).toMatch(/(?<!hover:)text-diff-add-muted/);
+    expect(removed).toMatch(/(?<!hover:)text-diff-remove-muted/);
+    expect(added).toMatch(/group-hover:text-diff-add(?!-muted)/);
+    expect(removed).toMatch(/group-hover:text-diff-remove(?!-muted)/);
+  });
+
+  it("wears the diff's own colours once the row is open", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary={LONG_PATH}
+        diffStat={{ added: 39, removed: 2 }}
+        isExpanded
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    const added =
+      screen.getByTestId("row-diff-added").getAttribute("class") ?? "";
+    const removed =
+      screen.getByTestId("row-diff-removed").getAttribute("class") ?? "";
+    expect(added).toMatch(/(?<!hover:)text-diff-add(?!-muted)/);
+    expect(removed).toMatch(/(?<!hover:)text-diff-remove(?!-muted)/);
+    expect(added).not.toMatch(/-muted/);
+    expect(removed).not.toMatch(/-muted/);
+  });
+
+  it("leaves a row that carries no stat alone", () => {
+    render(
+      <CollapsibleRow
+        icon={Layers}
+        summary="Bash: pnpm test"
+        isExpanded={false}
+        onToggle={() => {}}
+      >
+        <div>detail</div>
+      </CollapsibleRow>
+    );
+
+    expect(screen.queryByTestId("row-diff-stat")).toBeNull();
+  });
+});

--- a/web/src/conversation/CollapsibleRow.tsx
+++ b/web/src/conversation/CollapsibleRow.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react";
 import { ChevronDown, type LucideIcon } from "lucide-react";
+import type { DiffStat } from "@/conversation/generateToolSummary";
 
 interface CollapsibleRowProps {
   /** The kind marker — a terminal for tool units, a brain for thinking. */
@@ -8,6 +9,11 @@ interface CollapsibleRowProps {
   summary: string;
   /** Marks the row as reporting a failure. */
   hasError?: boolean;
+  /**
+   * How big an edit was. Given its own place at the row's trailing edge, so a
+   * long path truncates instead of pushing the counts off the end (#250).
+   */
+  diffStat?: DiffStat;
   /**
    * Whether the row is open. Controlled from above, because the virtualizer
    * recycles rows by position and state kept here would not survive it (#236).
@@ -35,6 +41,12 @@ interface CollapsibleRowProps {
   isSummary?: boolean;
 }
 
+// A side that changed nothing dims rather than disappears, so a purely additive
+// edit reads at a glance without the row changing shape.
+function zero(count: number): string {
+  return count === 0 ? "opacity-50" : "";
+}
+
 /**
  * One collapsed line that opens into its detail.
  *
@@ -46,6 +58,7 @@ export function CollapsibleRow({
   icon: Icon,
   summary,
   hasError,
+  diffStat,
   isExpanded,
   onToggle,
   children,
@@ -77,6 +90,17 @@ export function CollapsibleRow({
       ? "text-primary"
       : "group-hover:text-primary";
 
+  // The counts sit close to the muted label at rest — enough to tell an edit
+  // that mostly added from one that mostly removed while scanning — and resolve
+  // to the colours of the diff they open onto when the row is hovered or open
+  // (#250). Full saturation on every row would out-compete the prose.
+  const addedColour = isExpanded
+    ? "text-diff-add"
+    : "text-diff-add-muted group-hover:text-diff-add";
+  const removedColour = isExpanded
+    ? "text-diff-remove"
+    : "text-diff-remove-muted group-hover:text-diff-remove";
+
   return (
     <div>
       <button
@@ -103,6 +127,29 @@ export function CollapsibleRow({
             aria-label="Failed"
             className="ml-1 size-1.5 shrink-0 rounded-full bg-destructive"
           />
+        )}
+        {diffStat && (
+          <span
+            data-testid="row-diff-stat"
+            className="ml-auto shrink-0 pl-2 font-mono tabular-nums"
+          >
+            <span
+              data-testid="row-diff-added"
+              className={`transition-colors ${addedColour} ${zero(
+                diffStat.added
+              )}`}
+            >
+              +{diffStat.added}
+            </span>{" "}
+            <span
+              data-testid="row-diff-removed"
+              className={`transition-colors ${removedColour} ${zero(
+                diffStat.removed
+              )}`}
+            >
+              -{diffStat.removed}
+            </span>
+          </span>
         )}
       </button>
       {isExpanded && children && (

--- a/web/src/conversation/CollapsibleToolCall.test.tsx
+++ b/web/src/conversation/CollapsibleToolCall.test.tsx
@@ -47,6 +47,36 @@ describe("CollapsibleToolCall", () => {
     expect(screen.queryByText("The file a.tsx has been updated.")).toBeNull();
   });
 
+  it("gives an edit's counts the row's trailing edge, not its label", () => {
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t1",
+      content: "updated",
+      file_path: "web/src/conversation/CollapsibleToolCall.tsx",
+      patch: [
+        {
+          oldStart: 3,
+          oldLines: 4,
+          newStart: 3,
+          newLines: 6,
+          lines: [" keep", "-gone", "+one", "+two", "+three"],
+        },
+      ],
+    };
+
+    render(
+      <CollapsibleToolCall
+        block={editCall}
+        result={result}
+        isExpanded={false}
+        onToggle={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId("row-diff-stat").textContent).toBe("+3 -1");
+    expect(screen.getByText("Edited CollapsibleToolCall.tsx")).not.toBeNull();
+  });
+
   it("falls back to the raw rendering when the result carries no patch", () => {
     const result: ToolResultBlock = {
       type: "tool_result",

--- a/web/src/conversation/CollapsibleToolCall.test.tsx
+++ b/web/src/conversation/CollapsibleToolCall.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import type { ContentBlock } from "@/types";
 import type { ToolResultBlock } from "@/conversation/toolUnits";
@@ -150,5 +150,25 @@ describe("CollapsibleToolCall", () => {
     );
 
     expect(screen.queryByTestId("excerpt-line")).toBeNull();
+  });
+
+  it("colours the input of a unit that renders neither diff nor excerpt", async () => {
+    const searchCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t4",
+      name: "Grep",
+      input: { pattern: "useState" },
+    };
+
+    const { container } = render(
+      <CollapsibleToolCall block={searchCall} isExpanded onToggle={() => {}} />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector(".hljs-attr")).not.toBeNull()
+    );
+    expect(container.querySelector(".hljs-attr")?.textContent).toBe(
+      '"pattern"'
+    );
   });
 });

--- a/web/src/conversation/CollapsibleToolCall.test.tsx
+++ b/web/src/conversation/CollapsibleToolCall.test.tsx
@@ -66,4 +66,59 @@ describe("CollapsibleToolCall", () => {
     expect(screen.queryByTestId("diff-line")).toBeNull();
     expect(screen.getByText("The file a.tsx has been updated.")).not.toBeNull();
   });
+
+  it("renders an expanded read as a numbered file excerpt, not raw output", () => {
+    const readCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t2",
+      name: "Read",
+      input: { file_path: "src/answer.ts" },
+    };
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t2",
+      content: "40\tconst answer = 42;\n41\treturn answer;",
+    };
+
+    render(
+      <CollapsibleToolCall
+        block={readCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    const rows = screen.getAllByTestId("excerpt-line");
+    expect(rows).toHaveLength(2);
+    expect(screen.getByText("src/answer.ts")).not.toBeNull();
+    // The numbers are lifted into the gutter, so the raw `40\t…` never shows.
+    expect(screen.getByText("const answer = 42;")).not.toBeNull();
+    expect(screen.queryByText(/40\tconst answer = 42;/)).toBeNull();
+  });
+
+  it("falls back to the raw rendering for a read whose result is not text", () => {
+    const readCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t3",
+      name: "Read",
+      input: { file_path: "shot.png" },
+    };
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t3",
+      content: [{ type: "image", source: "…" }],
+    };
+
+    render(
+      <CollapsibleToolCall
+        block={readCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    expect(screen.queryByTestId("excerpt-line")).toBeNull();
+  });
 });

--- a/web/src/conversation/CollapsibleToolCall.test.tsx
+++ b/web/src/conversation/CollapsibleToolCall.test.tsx
@@ -152,6 +152,136 @@ describe("CollapsibleToolCall", () => {
     expect(screen.queryByTestId("excerpt-line")).toBeNull();
   });
 
+  it("renders an expanded Bash unit's command as shell, not raw JSON", async () => {
+    const bashCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t5",
+      name: "Bash",
+      input: { command: 'echo "hi"', description: "Say hi" },
+    };
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t5",
+      content: "hi",
+    };
+
+    const { container } = render(
+      <CollapsibleToolCall
+        block={bashCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    // The command stands on its own, with the call's input no longer repeated
+    // as JSON above it.
+    expect(screen.queryByTestId("json-input")).toBeNull();
+    expect(screen.getByTestId("command-line").textContent).toBe('echo "hi"');
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-testid="command-line"] .hljs-string')
+      ).not.toBeNull()
+    );
+  });
+
+  it("renders a Bash unit's output beneath the command, with no language guessed", async () => {
+    const bashCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t6",
+      name: "Bash",
+      input: { command: 'echo "hi"' },
+    };
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t6",
+      // Reads like shell, but it is only what the command printed.
+      content: 'export FOO="hi"',
+    };
+
+    const { container } = render(
+      <CollapsibleToolCall
+        block={bashCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    const commandBlock = screen.getByTestId("command");
+    const output = screen.getByTestId("command-output");
+    expect(output.textContent).toContain('export FOO="hi"');
+    expect(
+      commandBlock.compareDocumentPosition(output) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+
+    // Once the highlighter has landed for the command, the output beside it is
+    // still untouched — nothing was guessed for it.
+    await waitFor(() =>
+      expect(commandBlock.querySelector('[class*="hljs-"]')).not.toBeNull()
+    );
+    expect(output.querySelector('[class*="hljs-"]')).toBeNull();
+    expect(container.querySelector("[data-testid='json-input']")).toBeNull();
+  });
+
+  it("renders a Bash unit that printed nothing as the command alone", () => {
+    const bashCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t7",
+      name: "Bash",
+      input: { command: "git add ." },
+    };
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t7",
+      content: "",
+    };
+
+    render(
+      <CollapsibleToolCall
+        block={bashCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId("command-line").textContent).toBe("git add .");
+    expect(screen.queryByTestId("command-output")).toBeNull();
+  });
+
+  it("still reads as failed for a Bash unit that reported an error", () => {
+    const bashCall: ToolUseBlock = {
+      type: "tool_use",
+      id: "t8",
+      name: "Bash",
+      input: { command: "pnpm test" },
+    };
+    const result: ToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: "t8",
+      content: "1 test failed",
+      is_error: true,
+    };
+
+    render(
+      <CollapsibleToolCall
+        block={bashCall}
+        result={result}
+        isExpanded
+        onToggle={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId("row-error")).not.toBeNull();
+    // What it said back is what explains the failure, so it still renders.
+    expect(screen.getByTestId("command-output").textContent).toContain(
+      "1 test failed"
+    );
+  });
+
   it("colours the input of a unit that renders neither diff nor excerpt", async () => {
     const searchCall: ToolUseBlock = {
       type: "tool_use",

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -2,6 +2,7 @@ import { Terminal } from "lucide-react";
 import type { ContentBlock } from "@/types";
 import { CollapsibleRow } from "@/conversation/CollapsibleRow";
 import { DiffView } from "@/conversation/DiffView";
+import { FileExcerptView } from "@/conversation/FileExcerptView";
 import { generateToolSummary } from "@/conversation/generateToolSummary";
 import type { ToolResultBlock } from "@/conversation/toolUnits";
 
@@ -17,6 +18,12 @@ interface CollapsibleToolCallProps {
 function formatResultContent(content: unknown): string {
   if (typeof content === "string") return content;
   return JSON.stringify(content, null, 2);
+}
+
+function readFilePath(input: unknown): string | undefined {
+  if (typeof input !== "object" || input === null) return undefined;
+  const { file_path: filePath } = input as { file_path?: unknown };
+  return typeof filePath === "string" ? filePath : undefined;
 }
 
 /**
@@ -37,6 +44,17 @@ export function CollapsibleToolCall({
   const patch = result?.patch;
   const isDiff = Boolean(result?.file_path && patch && patch.length > 0);
 
+  // A read's whole value is the file it returned, so it gets the same treatment
+  // as an edit: the path, the file's own line numbers, and its code coloured.
+  // The path comes from the call — a read result carries only the text (#240).
+  // A non-text result (an image the tool returned) has no lines to number and
+  // keeps the raw rendering.
+  const readPath =
+    block.name === "Read" ? readFilePath(block.input) : undefined;
+  const isExcerpt = Boolean(
+    !isDiff && readPath && typeof result?.content === "string"
+  );
+
   return (
     <CollapsibleRow
       icon={Terminal}
@@ -47,6 +65,11 @@ export function CollapsibleToolCall({
     >
       {isDiff ? (
         <DiffView filePath={result!.file_path!} patch={patch!} />
+      ) : isExcerpt ? (
+        <FileExcerptView
+          filePath={readPath!}
+          content={result!.content as string}
+        />
       ) : (
         <>
           <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -4,6 +4,7 @@ import { CollapsibleRow } from "@/conversation/CollapsibleRow";
 import { DiffView } from "@/conversation/DiffView";
 import { FileExcerptView } from "@/conversation/FileExcerptView";
 import { generateToolSummary } from "@/conversation/generateToolSummary";
+import { JsonView } from "@/conversation/JsonView";
 import type { ToolResultBlock } from "@/conversation/toolUnits";
 
 type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
@@ -75,9 +76,7 @@ export function CollapsibleToolCall({
         />
       ) : (
         <>
-          <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
-            {JSON.stringify(block.input, null, 2)}
-          </pre>
+          <JsonView value={block.input} />
           {result && (
             <pre className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground">
               {formatResultContent(result.content)}

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -55,10 +55,13 @@ export function CollapsibleToolCall({
     !isDiff && readPath && typeof result?.content === "string"
   );
 
+  const { label, diffStat } = generateToolSummary(block, result);
+
   return (
     <CollapsibleRow
       icon={Terminal}
-      summary={generateToolSummary(block, result)}
+      summary={label}
+      diffStat={diffStat}
       hasError={result?.is_error}
       isExpanded={isExpanded}
       onToggle={onToggle}

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -1,6 +1,7 @@
 import { Terminal } from "lucide-react";
 import type { ContentBlock } from "@/types";
 import { CollapsibleRow } from "@/conversation/CollapsibleRow";
+import { CommandView } from "@/conversation/CommandView";
 import { DiffView } from "@/conversation/DiffView";
 import { FileExcerptView } from "@/conversation/FileExcerptView";
 import { generateToolSummary } from "@/conversation/generateToolSummary";
@@ -25,6 +26,12 @@ function readFilePath(input: unknown): string | undefined {
   if (typeof input !== "object" || input === null) return undefined;
   const { file_path: filePath } = input as { file_path?: unknown };
   return typeof filePath === "string" ? filePath : undefined;
+}
+
+function shellCommand(input: unknown): string | undefined {
+  if (typeof input !== "object" || input === null) return undefined;
+  const { command } = input as { command?: unknown };
+  return typeof command === "string" ? command : undefined;
 }
 
 /**
@@ -56,6 +63,11 @@ export function CollapsibleToolCall({
     !isDiff && readPath && typeof result?.content === "string"
   );
 
+  // A Bash unit is worth expanding for the command it ran and what that command
+  // said back, so the command renders as shell and the call's input is not also
+  // dumped as JSON above it (#252).
+  const command = block.name === "Bash" ? shellCommand(block.input) : undefined;
+
   const { label, diffStat } = generateToolSummary(block, result);
 
   return (
@@ -73,6 +85,11 @@ export function CollapsibleToolCall({
         <FileExcerptView
           filePath={readPath!}
           content={result!.content as string}
+        />
+      ) : command !== undefined ? (
+        <CommandView
+          command={command}
+          output={result ? formatResultContent(result.content) : undefined}
         />
       ) : (
         <>

--- a/web/src/conversation/CommandView.test.tsx
+++ b/web/src/conversation/CommandView.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import { CommandView } from "./CommandView";
+
+describe("CommandView", () => {
+  it("caps long output and reveals the rest on request", async () => {
+    const output = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join(
+      "\n"
+    );
+
+    render(<CommandView command="pnpm test" output={output} lineCap={40} />);
+
+    expect(screen.getAllByTestId("output-line")).toHaveLength(40);
+    expect(screen.queryByText("line 60")).toBeNull();
+
+    await userEvent.click(screen.getByText("Show 20 more lines"));
+
+    expect(screen.getAllByTestId("output-line")).toHaveLength(60);
+    expect(screen.getByText("line 60")).not.toBeNull();
+    expect(screen.queryByText(/Show \d+ more/)).toBeNull();
+  });
+});

--- a/web/src/conversation/CommandView.tsx
+++ b/web/src/conversation/CommandView.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import { useLanguageHighlighter } from "@/conversation/codeHighlight";
+import { capLines } from "@/conversation/commandOutput";
+
+interface CommandViewProps {
+  /** The shell command the unit ran. */
+  command: string;
+  /** What the command printed, verbatim. */
+  output?: string;
+  /**
+   * Most output lines rendered before the rest is folded behind a reveal
+   * control. A command that prints thousands of lines is capped so it cannot
+   * stall the pane; the reader opts into the tail, as with a long diff (#252).
+   */
+  lineCap?: number;
+}
+
+const DEFAULT_LINE_CAP = 40;
+
+/**
+ * A Bash unit: the command that ran, as shell, and what it said back.
+ *
+ * The command's language is known at the call site rather than inferred from a
+ * path — a Bash unit's command is always shell. The output gets no language at
+ * all: it is whatever the command happened to print, and guessing would only
+ * guess wrong (#252).
+ */
+export function CommandView({
+  command,
+  output,
+  lineCap = DEFAULT_LINE_CAP,
+}: CommandViewProps) {
+  const [showAll, setShowAll] = useState(false);
+
+  // Null until the lazy highlighter lands — the command renders plain until
+  // then, so colour only ever arrives as an improvement.
+  const highlight = useLanguageHighlighter("bash");
+
+  // A command that printed nothing gets no block at all, rather than an empty
+  // one below the command — the same reason a read drops a dead gutter (#252).
+  const printed = output?.trim() ? output : undefined;
+
+  const { lines: outputLines, hiddenLines } = capLines(
+    printed ?? "",
+    showAll ? Number.POSITIVE_INFINITY : lineCap
+  );
+
+  return (
+    <>
+      <div
+        data-testid="command"
+        className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-foreground"
+      >
+        {command.split("\n").map((line, index) => {
+          const highlighted = highlight ? highlight(line) : null;
+
+          return highlighted !== null ? (
+            <div
+              key={index}
+              data-testid="command-line"
+              className="whitespace-pre"
+              dangerouslySetInnerHTML={{ __html: highlighted }}
+            />
+          ) : (
+            <div
+              key={index}
+              data-testid="command-line"
+              className="whitespace-pre"
+            >
+              {line}
+            </div>
+          );
+        })}
+      </div>
+      {printed !== undefined && (
+        <div
+          data-testid="command-output"
+          className="overflow-x-auto rounded bg-card py-1 font-mono text-xs text-muted-foreground"
+        >
+          {outputLines.map((line, index) => (
+            <div
+              key={index}
+              data-testid="output-line"
+              className="whitespace-pre px-2"
+            >
+              {line}
+            </div>
+          ))}
+          {hiddenLines > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowAll(true)}
+              className="w-full cursor-pointer border-t border-border px-2 py-1 text-left transition-colors hover:bg-white/[0.04] hover:text-foreground"
+            >
+              Show {hiddenLines} more {hiddenLines === 1 ? "line" : "lines"}
+            </button>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -677,7 +677,11 @@ describe("Conversation tool units", () => {
       />
     );
 
-    expect(await screen.findByText("Edited App.tsx +3 -1")).not.toBeNull();
+    expect(await screen.findByText("Edited App.tsx")).not.toBeNull();
+    // The counts keep their own place at the row's trailing edge (#250).
+    expect((await screen.findByTestId("row-diff-stat")).textContent).toBe(
+      "+3 -1"
+    );
   });
 
   it("shows input and output under one left rule marking the unit's extent", async () => {

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -584,7 +584,10 @@ describe("Conversation tool units", () => {
 
     await user.click(await screen.findByText("Read: /tmp/a.ts"));
 
-    expect(await screen.findByText(/export const answer = 42;/)).not.toBeNull();
+    // Highlighting splits the code into token spans, so match on the row's
+    // whole text rather than a single node's (#240).
+    const row = await screen.findByTestId("excerpt-line");
+    expect(row.textContent).toContain("export const answer = 42;");
   });
 
   it("pairs a call with a result recorded in the next turn", async () => {

--- a/web/src/conversation/DiffView.test.tsx
+++ b/web/src/conversation/DiffView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
 import type { PatchHunk } from "@/types";
@@ -95,5 +95,92 @@ describe("DiffView", () => {
     expect(screen.getAllByTestId("diff-line")).toHaveLength(6);
     expect(screen.getByText("six")).not.toBeNull();
     expect(screen.queryByRole("button")).toBeNull();
+  });
+});
+
+const tsHunk: PatchHunk = {
+  oldStart: 1,
+  oldLines: 0,
+  newStart: 1,
+  newLines: 1,
+  lines: ["+const answer = 42;"],
+};
+
+describe("DiffView syntax highlighting", () => {
+  it("highlights the code, with the language taken from the file path", async () => {
+    const { container } = render(
+      <DiffView filePath="answer.ts" patch={[tsHunk]} />
+    );
+
+    // The highlighter loads after mount, so the keyword span appears async.
+    await waitFor(() =>
+      expect(container.querySelector(".hljs-keyword")).not.toBeNull()
+    );
+    expect(container.querySelector(".hljs-keyword")?.textContent).toBe("const");
+  });
+
+  it("renders plain, with no token markup, for an unrecognised language", async () => {
+    const { container } = render(
+      <DiffView filePath="notes/journal.xyz" patch={[tsHunk]} />
+    );
+
+    // Give any stray highlighter load a chance to resolve; it must not — the
+    // text stays a single plain node.
+    await Promise.resolve();
+    expect(container.querySelector("[class^='hljs-']")).toBeNull();
+    expect(screen.getByText("const answer = 42;")).not.toBeNull();
+  });
+
+  it("stops highlighting past the cap, so the rest renders plain", async () => {
+    const twoLines: PatchHunk = {
+      oldStart: 1,
+      oldLines: 0,
+      newStart: 1,
+      newLines: 2,
+      lines: ["+const first = 1;", "+const second = 2;"],
+    };
+
+    const { container } = render(
+      <DiffView filePath="answer.ts" patch={[twoLines]} highlightCap={1} />
+    );
+
+    // The first line is highlighted; the second, past the cap, stays plain.
+    await waitFor(() =>
+      expect(container.querySelectorAll(".hljs-keyword")).toHaveLength(1)
+    );
+    const rows = screen.getAllByTestId("diff-line");
+    expect(within(rows[0]).queryByText("const")).not.toBeNull();
+    expect(within(rows[1]).getByText("const second = 2;")).not.toBeNull();
+  });
+
+  it("keeps the added/removed ground under the token colours", async () => {
+    const changeHunk: PatchHunk = {
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 1,
+      lines: ["-const old = 1;", "+const now = 2;"],
+    };
+
+    const { container } = render(
+      <DiffView filePath="answer.ts" patch={[changeHunk]} />
+    );
+
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll(".hljs-keyword").length
+      ).toBeGreaterThan(0)
+    );
+
+    // The tint rides on the row, not the token spans — so it survives with
+    // highlighting applied: the diff is still primarily a diff.
+    const rows = screen.getAllByTestId("diff-line");
+    const removed = rows.find((r) => r.getAttribute("data-kind") === "remove");
+    const added = rows.find((r) => r.getAttribute("data-kind") === "add");
+    expect(removed?.className).toContain("bg-destructive/10");
+    expect(added?.className).toContain("bg-green-500/10");
+    // The token colours live inside those same rows.
+    expect(removed?.querySelector(".hljs-keyword")).not.toBeNull();
+    expect(added?.querySelector(".hljs-keyword")).not.toBeNull();
   });
 });

--- a/web/src/conversation/DiffView.tsx
+++ b/web/src/conversation/DiffView.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { PatchHunk } from "@/types";
 import { buildDiff, type DiffLine } from "@/conversation/diffModel";
+import { useHighlighter } from "@/conversation/codeHighlight";
 
 interface DiffViewProps {
   filePath: string;
@@ -11,9 +12,16 @@ interface DiffViewProps {
    * opts into the tail (#237).
    */
   lineCap?: number;
+  /**
+   * How many rendered lines get syntax highlighting. Lines past this cap render
+   * plain, so revealing a very long diff is never blocked on highlighting every
+   * line — the red/green ground still carries them (#240).
+   */
+  highlightCap?: number;
 }
 
 const DEFAULT_LINE_CAP = 40;
+const DEFAULT_HIGHLIGHT_CAP = 500;
 
 // Both sides tinted, so a row reads as added or removed from its ground alone —
 // the line-number gutters then say where it sits. Context stays untinted and
@@ -34,10 +42,24 @@ function gutter(n: number | null): string {
   return n === null ? "" : String(n);
 }
 
+// Where each hunk's lines begin in a count running across the whole diff, so a
+// per-line index can be read without mutating a counter during render. The
+// highlight cap then bounds the diff as a whole, not each hunk on its own.
+function hunkStartIndices(hunks: { lines: unknown[] }[]): number[] {
+  const starts: number[] = [];
+  let total = 0;
+  for (const hunk of hunks) {
+    starts.push(total);
+    total += hunk.lines.length;
+  }
+  return starts;
+}
+
 export function DiffView({
   filePath,
   patch,
   lineCap = DEFAULT_LINE_CAP,
+  highlightCap = DEFAULT_HIGHLIGHT_CAP,
 }: DiffViewProps) {
   const [showAll, setShowAll] = useState(false);
   const { hunks, hiddenLines } = buildDiff(
@@ -45,11 +67,18 @@ export function DiffView({
     showAll ? Number.POSITIVE_INFINITY : lineCap
   );
 
+  // Null until the lazy highlighter lands, and forever for a path whose
+  // language we do not recognise — the diff renders plain in both cases. A diff
+  // only mounts once expanded, so a chat that opens none never loads it (#240).
+  const highlight = useHighlighter(filePath);
+
   // A new file is all additions, so its old-side gutter is empty on every row.
   // Dropping it leaves a single new-side gutter rather than a dead column.
   const hasOldColumn = hunks.some((hunk) =>
     hunk.lines.some((line) => line.oldLineNumber !== null)
   );
+
+  const hunkStart = hunkStartIndices(hunks);
 
   return (
     <div className="overflow-x-auto rounded bg-card font-mono text-xs">
@@ -63,34 +92,54 @@ export function DiffView({
           // so two hunks don't read as one continuous stretch.
           className={hunkIndex > 0 ? "border-t border-border" : undefined}
         >
-          {hunk.lines.map((line, lineIndex) => (
-            <div
-              key={lineIndex}
-              data-testid="diff-line"
-              data-kind={line.kind}
-              className={`flex ${KIND_ROW_CLASS[line.kind]} ${
-                line.kind === "context"
-                  ? "text-muted-foreground"
-                  : "text-foreground"
-              }`}
-            >
-              {hasOldColumn && (
-                <span
-                  data-testid="diff-old-gutter"
-                  className="w-8 shrink-0 select-none px-1 text-right tabular-nums text-muted-foreground"
-                >
-                  {gutter(line.oldLineNumber)}
+          {hunk.lines.map((line, lineIndex) => {
+            // Past the cap the line renders plain, so revealing a very long
+            // diff is never blocked on colouring every one of them. The tint
+            // stays on the row; the tokens colour only the text.
+            const contentIndex = hunkStart[hunkIndex] + lineIndex;
+            const highlighted =
+              highlight && contentIndex < highlightCap
+                ? highlight(line.text)
+                : null;
+
+            return (
+              <div
+                key={lineIndex}
+                data-testid="diff-line"
+                data-kind={line.kind}
+                className={`flex ${KIND_ROW_CLASS[line.kind]} ${
+                  line.kind === "context"
+                    ? "text-muted-foreground"
+                    : "text-foreground"
+                }`}
+              >
+                {hasOldColumn && (
+                  <span
+                    data-testid="diff-old-gutter"
+                    className="w-8 shrink-0 select-none px-1 text-right tabular-nums text-muted-foreground"
+                  >
+                    {gutter(line.oldLineNumber)}
+                  </span>
+                )}
+                <span className="w-8 shrink-0 select-none px-1 text-right tabular-nums text-muted-foreground">
+                  {gutter(line.newLineNumber)}
                 </span>
-              )}
-              <span className="w-8 shrink-0 select-none px-1 text-right tabular-nums text-muted-foreground">
-                {gutter(line.newLineNumber)}
-              </span>
-              <span className="w-3 shrink-0 select-none text-center text-muted-foreground">
-                {KIND_SIGN[line.kind]}
-              </span>
-              <span className="whitespace-pre pr-2">{line.text}</span>
-            </div>
-          ))}
+                <span className="w-3 shrink-0 select-none text-center text-muted-foreground">
+                  {KIND_SIGN[line.kind]}
+                </span>
+                {highlighted !== null ? (
+                  <span
+                    className="whitespace-pre pr-2"
+                    // The token spans carry only colour; the row's tint and the
+                    // reader's text selection are untouched.
+                    dangerouslySetInnerHTML={{ __html: highlighted }}
+                  />
+                ) : (
+                  <span className="whitespace-pre pr-2">{line.text}</span>
+                )}
+              </div>
+            );
+          })}
         </div>
       ))}
       {hiddenLines > 0 && (

--- a/web/src/conversation/FileExcerptView.test.tsx
+++ b/web/src/conversation/FileExcerptView.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import { FileExcerptView } from "./FileExcerptView";
+
+const TS_CONTENT = ["40\tconst answer = 42;", "41\treturn answer;"].join("\n");
+
+describe("FileExcerptView", () => {
+  it("shows the file path above the excerpt, with each line's real number", () => {
+    render(<FileExcerptView filePath="src/answer.ts" content={TS_CONTENT} />);
+
+    expect(screen.getByText("src/answer.ts")).not.toBeNull();
+
+    const rows = screen.getAllByTestId("excerpt-line");
+    expect(within(rows[0]).getByText("40")).not.toBeNull();
+    expect(within(rows[1]).getByText("41")).not.toBeNull();
+    expect(within(rows[1]).getByText("return answer;")).not.toBeNull();
+  });
+
+  it("highlights the code, with the language taken from the file path", async () => {
+    const { container } = render(
+      <FileExcerptView filePath="src/answer.ts" content={TS_CONTENT} />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector(".hljs-keyword")).not.toBeNull()
+    );
+    // The number stays in the gutter, uncoloured — only the code is tokenised.
+    expect(container.querySelector(".hljs-keyword")?.textContent).toBe("const");
+  });
+
+  it("renders plain, with no token markup, for an unrecognised language", async () => {
+    const { container } = render(
+      <FileExcerptView filePath="notes/journal.xyz" content={TS_CONTENT} />
+    );
+
+    await Promise.resolve();
+    expect(container.querySelector("[class^='hljs-']")).toBeNull();
+    expect(screen.getByText("const answer = 42;")).not.toBeNull();
+  });
+
+  it("stops highlighting past the cap, so the rest renders plain", async () => {
+    const { container } = render(
+      <FileExcerptView
+        filePath="src/answer.ts"
+        content={TS_CONTENT}
+        highlightCap={1}
+      />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelectorAll(".hljs-keyword")).toHaveLength(1)
+    );
+    const rows = screen.getAllByTestId("excerpt-line");
+    expect(within(rows[1]).getByText("return answer;")).not.toBeNull();
+  });
+
+  it("caps a long excerpt and reveals the rest on demand", async () => {
+    const content = ["1\ta", "2\tb", "3\tc", "4\td"].join("\n");
+
+    render(<FileExcerptView filePath="a.txt" content={content} lineCap={2} />);
+
+    expect(screen.getAllByTestId("excerpt-line")).toHaveLength(2);
+
+    const reveal = screen.getByRole("button");
+    expect(reveal.textContent).toContain("2");
+    await userEvent.click(reveal);
+
+    expect(screen.getAllByTestId("excerpt-line")).toHaveLength(4);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("drops the gutter for output that carries no line numbers", () => {
+    render(
+      <FileExcerptView filePath="a.ts" content={"plain output\nno numbers"} />
+    );
+
+    const rows = screen.getAllByTestId("excerpt-line");
+    expect(within(rows[0]).getByText("plain output")).not.toBeNull();
+    // One child only: the text. No gutter column was drawn.
+    expect(rows[0].children).toHaveLength(1);
+  });
+});

--- a/web/src/conversation/FileExcerptView.tsx
+++ b/web/src/conversation/FileExcerptView.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { buildExcerpt } from "@/conversation/fileExcerpt";
+import { useHighlighter } from "@/conversation/codeHighlight";
+
+interface FileExcerptViewProps {
+  filePath: string;
+  /** The Read result verbatim, line numbers and all. */
+  content: string;
+  /**
+   * Most lines rendered before the rest is folded behind a reveal control. A
+   * whole file read into the pane is capped so it cannot stall it; the reader
+   * opts into the tail, as with a long diff (#240).
+   */
+  lineCap?: number;
+  /**
+   * How many rendered lines get syntax highlighting. Lines past this cap render
+   * plain, so revealing a very long file is never blocked on colouring all of
+   * it (#240).
+   */
+  highlightCap?: number;
+}
+
+const DEFAULT_LINE_CAP = 40;
+const DEFAULT_HIGHLIGHT_CAP = 500;
+
+function gutter(n: number | null): string {
+  return n === null ? "" : String(n);
+}
+
+/**
+ * A file as a Read tool reported it: the path, then its numbered lines.
+ *
+ * The same shape a diff renders in — path header, line-number gutter, code —
+ * minus the added/removed grounds, which a read has no use for. Sharing the
+ * layout is the point: a file looks like a file wherever the pane shows one.
+ */
+export function FileExcerptView({
+  filePath,
+  content,
+  lineCap = DEFAULT_LINE_CAP,
+  highlightCap = DEFAULT_HIGHLIGHT_CAP,
+}: FileExcerptViewProps) {
+  const [showAll, setShowAll] = useState(false);
+  const { lines, hiddenLines } = buildExcerpt(
+    content,
+    showAll ? Number.POSITIVE_INFINITY : lineCap
+  );
+
+  // Null until the lazy highlighter lands, and forever for a path whose
+  // language we do not recognise — the excerpt renders plain in both cases.
+  const highlight = useHighlighter(filePath);
+
+  // A result with no numbering is not a file excerpt; dropping the gutter
+  // leaves it reading as the plain output it is, rather than a dead column.
+  const hasGutter = lines.some((line) => line.lineNumber !== null);
+
+  return (
+    <div className="overflow-x-auto rounded bg-card font-mono text-xs">
+      <div className="border-b border-border px-2 py-1 text-muted-foreground">
+        {filePath}
+      </div>
+      {lines.map((line, index) => {
+        const highlighted =
+          highlight && index < highlightCap ? highlight(line.text) : null;
+
+        return (
+          <div
+            key={index}
+            data-testid="excerpt-line"
+            className="flex text-foreground"
+          >
+            {hasGutter && (
+              <span className="w-10 shrink-0 select-none px-1 text-right tabular-nums text-muted-foreground">
+                {gutter(line.lineNumber)}
+              </span>
+            )}
+            {highlighted !== null ? (
+              <span
+                className="whitespace-pre pr-2"
+                dangerouslySetInnerHTML={{ __html: highlighted }}
+              />
+            ) : (
+              <span className="whitespace-pre pr-2">{line.text}</span>
+            )}
+          </div>
+        );
+      })}
+      {hiddenLines > 0 && (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="w-full cursor-pointer border-t border-border px-2 py-1 text-left text-muted-foreground transition-colors hover:bg-white/[0.04] hover:text-foreground"
+        >
+          Show {hiddenLines} more {hiddenLines === 1 ? "line" : "lines"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/conversation/JsonView.test.tsx
+++ b/web/src/conversation/JsonView.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { JsonView } from "./JsonView";
+
+describe("JsonView", () => {
+  it("pretty-prints the value, one line per key", () => {
+    render(<JsonView value={{ pattern: "useState", path: "web/src" }} />);
+
+    const rows = screen.getAllByTestId("json-line");
+    expect(rows).toHaveLength(4);
+    expect(rows[1].textContent).toBe('  "pattern": "useState",');
+    expect(rows[2].textContent).toBe('  "path": "web/src"');
+  });
+
+  it("colours it as JSON, with keys told apart from their values", async () => {
+    const { container } = render(<JsonView value={{ pattern: "useState" }} />);
+
+    await waitFor(() =>
+      expect(container.querySelector(".hljs-attr")).not.toBeNull()
+    );
+    expect(container.querySelector(".hljs-attr")?.textContent).toBe(
+      '"pattern"'
+    );
+    expect(container.querySelector(".hljs-string")?.textContent).toBe(
+      '"useState"'
+    );
+  });
+
+  it("stops colouring past the cap, so the rest still renders", async () => {
+    const { container } = render(
+      <JsonView value={{ a: "one", b: "two", c: "three" }} highlightCap={2} />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelectorAll(".hljs-attr")).toHaveLength(1)
+    );
+    const rows = screen.getAllByTestId("json-line");
+    expect(rows[3].textContent).toBe('  "c": "three"');
+    expect(rows[3].querySelector("[class^='hljs-']")).toBeNull();
+  });
+});

--- a/web/src/conversation/JsonView.tsx
+++ b/web/src/conversation/JsonView.tsx
@@ -1,0 +1,55 @@
+import { useLanguageHighlighter } from "@/conversation/codeHighlight";
+
+interface JsonViewProps {
+  /** The value to show. A tool call's input, in practice. */
+  value: unknown;
+  /**
+   * How many lines get syntax highlighting. Lines past this cap render plain,
+   * so an unusually large input never delays the expansion (#251).
+   */
+  highlightCap?: number;
+}
+
+const DEFAULT_HIGHLIGHT_CAP = 500;
+
+/**
+ * A value serialised as JSON, one line per row.
+ *
+ * The language is not inferred here the way a file's is: the block is produced
+ * by serialising the value, so it is always well-formed JSON (#251).
+ */
+export function JsonView({
+  value,
+  highlightCap = DEFAULT_HIGHLIGHT_CAP,
+}: JsonViewProps) {
+  const lines = JSON.stringify(value, null, 2).split("\n");
+
+  // Null until the lazy highlighter lands — the JSON renders plain until then,
+  // so colour only ever arrives as an improvement.
+  const highlight = useLanguageHighlighter("json");
+
+  return (
+    <div
+      data-testid="json-input"
+      className="overflow-x-auto rounded bg-card p-2 font-mono text-xs text-muted-foreground"
+    >
+      {lines.map((line, index) => {
+        const highlighted =
+          highlight && index < highlightCap ? highlight(line) : null;
+
+        return highlighted !== null ? (
+          <div
+            key={index}
+            data-testid="json-line"
+            className="whitespace-pre"
+            dangerouslySetInnerHTML={{ __html: highlighted }}
+          />
+        ) : (
+          <div key={index} data-testid="json-line" className="whitespace-pre">
+            {line}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/conversation/MarkdownText.test.tsx
+++ b/web/src/conversation/MarkdownText.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MarkdownText } from "@/conversation/MarkdownText";
@@ -67,6 +67,36 @@ describe("MarkdownText code block copying", () => {
     render(<MarkdownText>{"use the `id` field"}</MarkdownText>);
 
     expect(screen.queryByRole("button", { name: "Copy code" })).toBeNull();
+  });
+});
+
+describe("MarkdownText code block highlighting", () => {
+  it("colours a fenced block's keywords", async () => {
+    const { container } = render(
+      <MarkdownText>{"```ts\nconst x = 1;\nreturn x;\n```"}</MarkdownText>
+    );
+
+    // The tokens are what the reader sees as colour; the surface they sit on is
+    // the `.hljs` block the theme paints.
+    await waitFor(() => {
+      expect(container.querySelector(".hljs-keyword")).not.toBeNull();
+    });
+    expect(container.querySelector("code.hljs")).not.toBeNull();
+    expect(container.textContent).toContain("const x = 1;");
+  });
+
+  it("still shows the code for a language it cannot colour", async () => {
+    // A fence carries whatever word its writer typed, and the bundle carries a
+    // common set. The block has to stay readable either way.
+    const { container } = render(
+      <MarkdownText>{"```mermaid\ngraph TD;\nA-->B;\n```"}</MarkdownText>
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("code.hljs")).not.toBeNull();
+    });
+    expect(container.textContent).toContain("graph TD;");
+    expect(container.querySelector(".hljs-keyword")).toBeNull();
   });
 });
 

--- a/web/src/conversation/MarkdownText.tsx
+++ b/web/src/conversation/MarkdownText.tsx
@@ -1,13 +1,10 @@
-import Markdown, {
-  defaultUrlTransform,
-  type Components,
-} from "react-markdown";
+import Markdown, { defaultUrlTransform, type Components } from "react-markdown";
 import type { Element, ElementContent } from "hast";
-import rehypeHighlight from "rehype-highlight";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { CopyButton } from "@/shared/CopyButton";
 import { FileChip } from "@/conversation/FileChip";
+import { useLanguageHighlighter } from "@/conversation/codeHighlight";
 
 // The code as written, read off the syntax tree rather than the rendered
 // output: highlighting has already wrapped keywords in spans by the time this
@@ -23,6 +20,55 @@ function nodeText(node: ElementContent): string {
 function codeSource(node: Element | undefined): string {
   if (!node) return "";
   return node.children.map(nodeText).join("").replace(/\n$/, "");
+}
+
+// The word the writer typed after the opening backticks. react-markdown leaves
+// it on the `code` child as `language-<token>`; it is passed through as written,
+// because highlight.js resolves its own aliases (`ts`, `sh`, `yml`) and answers
+// for anything it does not carry.
+function fenceLanguage(node: Element | undefined): string | null {
+  const code = node?.children.find(
+    (child): child is Element =>
+      child.type === "element" && child.tagName === "code"
+  );
+  const classes = code?.properties.className;
+  if (!Array.isArray(classes)) return null;
+  for (const name of classes) {
+    if (typeof name === "string" && name.startsWith("language-")) {
+      return name.slice("language-".length);
+    }
+  }
+  return null;
+}
+
+/**
+ * A fenced block, coloured by the one shared highlighter (#253).
+ *
+ * The `hljs` class is on the block from first paint, so the theme's surface is
+ * there immediately and only the token colours wait on the lazy load. A fence
+ * with no language, or one the bundle does not carry, simply stays plain — the
+ * same way a diff does for a file type we do not recognise.
+ */
+function CodeBlock({
+  source,
+  language,
+}: {
+  source: string;
+  language: string | null;
+}) {
+  const highlight = useLanguageHighlighter(language);
+  const highlighted = highlight ? highlight(source) : null;
+
+  return (
+    <pre>
+      <code
+        className={language ? `hljs language-${language}` : "hljs"}
+        {...(highlighted !== null
+          ? { dangerouslySetInnerHTML: { __html: highlighted } }
+          : { children: source })}
+      />
+    </pre>
+  );
 }
 
 const markdownComponents: Components = {
@@ -48,16 +94,22 @@ const markdownComponents: Components = {
   // Only fenced blocks get a copy button — inline code is a word inside a
   // sentence, not something to take away. `group` scopes the hover reveal to
   // this block, so one button appears at a time.
-  pre: ({ children, node, ...props }) => (
-    <div className="group relative">
-      <pre {...props}>{children}</pre>
-      <CopyButton
-        value={codeSource(node)}
-        label="Copy code"
-        className="absolute right-2 top-2 bg-[#002b36]/80"
-      />
-    </div>
-  ),
+  pre: ({ node }) => {
+    // Rebuilt from the syntax tree rather than passed through, so the block and
+    // the copy button read the same source: one string, highlighted for the eye
+    // and copied as written.
+    const source = codeSource(node);
+    return (
+      <div className="group relative">
+        <CodeBlock source={source} language={fenceLanguage(node)} />
+        <CopyButton
+          value={source}
+          label="Copy code"
+          className="absolute right-2 top-2 bg-[#002b36]/80"
+        />
+      </div>
+    );
+  },
 };
 
 // prose-sm keeps chat turns tighter than prose's article-scale defaults.
@@ -88,7 +140,6 @@ export function MarkdownText({ children }: { children: string }) {
         // spaces silently reflows what they actually wrote. Structure (lists,
         // tables, code) still parses normally.
         remarkPlugins={[remarkGfm, remarkBreaks]}
-        rehypePlugins={[rehypeHighlight]}
         // react-markdown drops `file:` URLs by default, as a defence against
         // links a page might navigate to. These never navigate — the chip
         // copies the path instead — so the URL has to survive to be read.

--- a/web/src/conversation/codeHighlight.test.ts
+++ b/web/src/conversation/codeHighlight.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { languageForPath } from "./codeHighlight";
+
+describe("languageForPath", () => {
+  it("infers the highlight language from a file's extension", () => {
+    expect(languageForPath("web/src/conversation/DiffView.tsx")).toBe(
+      "typescript"
+    );
+  });
+
+  it("returns null for an unrecognised extension, so the diff renders plain", () => {
+    expect(languageForPath("notes/journal.xyz")).toBeNull();
+  });
+});

--- a/web/src/conversation/codeHighlight.test.ts
+++ b/web/src/conversation/codeHighlight.test.ts
@@ -1,5 +1,10 @@
+import { act, renderHook } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
-import { languageForPath } from "./codeHighlight";
+import {
+  languageForPath,
+  loadHighlighter,
+  useLanguageHighlighter,
+} from "./codeHighlight";
 
 describe("languageForPath", () => {
   it("infers the highlight language from a file's extension", () => {
@@ -10,5 +15,21 @@ describe("languageForPath", () => {
 
   it("returns null for an unrecognised extension, so the diff renders plain", () => {
     expect(languageForPath("notes/journal.xyz")).toBeNull();
+  });
+});
+
+describe("useLanguageHighlighter", () => {
+  it("renders plain for a language the bundle does not carry", async () => {
+    // A markdown fence carries whatever word the writer typed after the
+    // backticks. `mermaid` is a real one, and not a language the common bundle
+    // registers — asking the highlighter for it must leave the block plain,
+    // the same as an unrecognised file extension, rather than throw.
+    const { result } = renderHook(() => useLanguageHighlighter("mermaid"));
+
+    await act(async () => {
+      await loadHighlighter();
+    });
+
+    expect(result.current).toBeNull();
   });
 });

--- a/web/src/conversation/codeHighlight.ts
+++ b/web/src/conversation/codeHighlight.ts
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from "react";
+import type { HLJSApi } from "highlight.js";
+
+/**
+ * Map a file extension to a highlight.js language id.
+ *
+ * Only the common set is registered (see `loadHighlighter`), so this maps to
+ * ids that set is known to carry. An extension not listed here resolves to
+ * `null`, and the caller renders the diff plain — the same as today for a file
+ * whose language we do not recognise (#240).
+ */
+const EXTENSION_LANGUAGE: Record<string, string> = {
+  ts: "typescript",
+  tsx: "typescript",
+  mts: "typescript",
+  cts: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  json: "json",
+  css: "css",
+  scss: "scss",
+  less: "less",
+  html: "xml",
+  xml: "xml",
+  svg: "xml",
+  md: "markdown",
+  markdown: "markdown",
+  py: "python",
+  rb: "ruby",
+  go: "go",
+  rs: "rust",
+  java: "java",
+  kt: "kotlin",
+  swift: "swift",
+  c: "c",
+  h: "c",
+  cpp: "cpp",
+  cc: "cpp",
+  hpp: "cpp",
+  cs: "csharp",
+  php: "php",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  yml: "yaml",
+  yaml: "yaml",
+  toml: "ini",
+  ini: "ini",
+  sql: "sql",
+  diff: "diff",
+  dockerfile: "dockerfile",
+};
+
+/**
+ * The highlight.js language for a path, or `null` when its extension is not one
+ * we highlight. Pure, so the mapping is testable without loading the
+ * highlighter — and a `null` result lets the view skip the load entirely.
+ */
+export function languageForPath(path: string): string | null {
+  const name = path.split("/").pop() ?? path;
+  const dot = name.lastIndexOf(".");
+  const ext = dot === -1 ? name : name.slice(dot + 1);
+  return EXTENSION_LANGUAGE[ext.toLowerCase()] ?? null;
+}
+
+// Cached so the highlighter is fetched at most once per session, on whichever
+// code view opens first. Chats that open none never touch this promise, so they
+// never pay for the highlighter (#240).
+let highlighterPromise: Promise<HLJSApi> | null = null;
+
+/**
+ * Load the highlighter, lazily. The common-language bundle is imported on first
+ * call and reused thereafter, so it is code-split out of the initial load and
+ * fetched only when some code view is first expanded.
+ */
+export function loadHighlighter(): Promise<HLJSApi> {
+  if (!highlighterPromise) {
+    highlighterPromise = import("highlight.js/lib/common").then(
+      (module) => module.default
+    );
+  }
+  return highlighterPromise;
+}
+
+/**
+ * A highlighter for one file's lines, or `null` while it cannot colour them.
+ *
+ * `null` covers both cases a view renders plain: a path whose language we do
+ * not recognise — where the highlighter is never even loaded — and the moment
+ * before the lazy load resolves. Callers render `line.text` then, so code is
+ * always readable and highlighting only ever arrives as an improvement.
+ *
+ * Highlighting a line at a time drops multi-line context (a string opened on
+ * one line and closed on the next), which is the trade both a diff and a read
+ * excerpt already make: neither is guaranteed to hold a whole file, and it
+ * keeps each line's markup independent of its neighbours.
+ */
+export function useHighlighter(
+  filePath: string
+): ((text: string) => string) | null {
+  const language = useMemo(() => languageForPath(filePath), [filePath]);
+  const [hljs, setHljs] = useState<HLJSApi | null>(null);
+
+  useEffect(() => {
+    if (!language) return;
+    let active = true;
+    loadHighlighter().then((loaded) => {
+      if (active) setHljs(loaded);
+    });
+    return () => {
+      active = false;
+    };
+  }, [language]);
+
+  return useMemo(() => {
+    if (!language || !hljs) return null;
+    return (text: string) =>
+      hljs.highlight(text, { language, ignoreIllegals: true }).value;
+  }, [language, hljs]);
+}

--- a/web/src/conversation/codeHighlight.ts
+++ b/web/src/conversation/codeHighlight.ts
@@ -101,6 +101,19 @@ export function useHighlighter(
   filePath: string
 ): ((text: string) => string) | null {
   const language = useMemo(() => languageForPath(filePath), [filePath]);
+  return useLanguageHighlighter(language);
+}
+
+/**
+ * The same highlighter, for a caller that already knows its language.
+ *
+ * A tool call's input is serialised JSON, so nothing has to be inferred from a
+ * path — the language is known at the call site (#251). Passing `null` keeps
+ * the highlighter unloaded and the caller rendering plain.
+ */
+export function useLanguageHighlighter(
+  language: string | null
+): ((text: string) => string) | null {
   const [hljs, setHljs] = useState<HLJSApi | null>(null);
 
   useEffect(() => {

--- a/web/src/conversation/codeHighlight.ts
+++ b/web/src/conversation/codeHighlight.ts
@@ -129,6 +129,10 @@ export function useLanguageHighlighter(
 
   return useMemo(() => {
     if (!language || !hljs) return null;
+    // The bundle carries the common languages, not every one a caller can name:
+    // a markdown fence says whatever word its writer typed. An unregistered one
+    // stays null, so the block renders plain instead of throwing.
+    if (!hljs.getLanguage(language)) return null;
     return (text: string) =>
       hljs.highlight(text, { language, ignoreIllegals: true }).value;
   }, [language, hljs]);

--- a/web/src/conversation/commandOutput.test.ts
+++ b/web/src/conversation/commandOutput.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { capLines } from "./commandOutput";
+
+describe("capLines", () => {
+  it("keeps only the first lines and reports how many it held back", () => {
+    const output = ["one", "two", "three", "four"].join("\n");
+
+    expect(capLines(output, 2)).toEqual({
+      lines: ["one", "two"],
+      hiddenLines: 2,
+    });
+  });
+});

--- a/web/src/conversation/commandOutput.ts
+++ b/web/src/conversation/commandOutput.ts
@@ -1,0 +1,18 @@
+export interface CappedOutput {
+  lines: string[];
+  /** Lines held back past the cap; 0 when the whole output renders. */
+  hiddenLines: number;
+}
+
+/**
+ * Bound a block of plain output to a number of lines.
+ *
+ * What a command printed carries no structure to lift out — no line numbers, no
+ * added/removed sides — so unlike a file excerpt this only counts. The overflow
+ * comes back as `hiddenLines` so the view can offer to reveal the rest (#252).
+ */
+export function capLines(output: string, lineCap: number): CappedOutput {
+  const all = output.split("\n");
+  const lines = all.slice(0, lineCap);
+  return { lines, hiddenLines: all.length - lines.length };
+}

--- a/web/src/conversation/fileExcerpt.test.ts
+++ b/web/src/conversation/fileExcerpt.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { buildExcerpt } from "./fileExcerpt";
+
+describe("buildExcerpt", () => {
+  it("splits a Read result's line numbers off its content", () => {
+    const excerpt = buildExcerpt("1\tconst a = 1;\n2\tconst b = 2;", 100);
+
+    expect(excerpt.lines).toEqual([
+      { lineNumber: 1, text: "const a = 1;" },
+      { lineNumber: 2, text: "const b = 2;" },
+    ]);
+    expect(excerpt.hiddenLines).toBe(0);
+  });
+
+  it("keeps a file's real numbers, which need not start at one", () => {
+    const excerpt = buildExcerpt("40\tfourty\n41\tfourty-one", 100);
+
+    expect(excerpt.lines.map((l) => l.lineNumber)).toEqual([40, 41]);
+  });
+
+  it("renders content with no number prefix as plain, unnumbered lines", () => {
+    const excerpt = buildExcerpt("just some output\nno numbers here", 100);
+
+    expect(excerpt.lines).toEqual([
+      { lineNumber: null, text: "just some output" },
+      { lineNumber: null, text: "no numbers here" },
+    ]);
+  });
+
+  it("caps a long excerpt and reports what it withheld", () => {
+    const content = ["1\ta", "2\tb", "3\tc", "4\td", "5\te"].join("\n");
+
+    const excerpt = buildExcerpt(content, 3);
+
+    expect(excerpt.lines.map((l) => l.text)).toEqual(["a", "b", "c"]);
+    expect(excerpt.hiddenLines).toBe(2);
+  });
+});

--- a/web/src/conversation/fileExcerpt.ts
+++ b/web/src/conversation/fileExcerpt.ts
@@ -1,0 +1,45 @@
+/**
+ * One line of a file as a Read tool reported it.
+ *
+ * `lineNumber` is the file's own number, taken from the prefix the tool wrote —
+ * not a running count from one, so an excerpt that starts at line 40 says so.
+ * It is `null` when the result carries no numbering at all, which is how a
+ * result that is not a file excerpt still renders (#240).
+ */
+export interface ExcerptLine {
+  lineNumber: number | null;
+  text: string;
+}
+
+export interface FileExcerpt {
+  lines: ExcerptLine[];
+  /** Lines dropped past the cap; 0 when the whole excerpt renders. */
+  hiddenLines: number;
+}
+
+// A Read result numbers each line as `<n>\t<content>`. Anchored to the start of
+// the line, so a tab inside the content itself is left alone.
+const NUMBERED_LINE = /^(\d+)\t(.*)$/;
+
+/**
+ * Turn a Read result into numbered lines, bounded by a cap.
+ *
+ * Whether the result is numbered is decided once, from the first line, rather
+ * than per line: a file whose own text happens to open with digits and a tab
+ * would otherwise have that read as a line number partway down. `lineCap`
+ * bounds the lines rendered and reports the overflow as `hiddenLines`, so the
+ * view can offer to reveal the rest — the same bargain a long diff strikes.
+ */
+export function buildExcerpt(content: string, lineCap: number): FileExcerpt {
+  const rawLines = content.split("\n");
+  const numbered = NUMBERED_LINE.test(rawLines[0] ?? "");
+
+  const kept = rawLines.slice(0, lineCap);
+  const lines = kept.map((raw) => {
+    const match = numbered ? NUMBERED_LINE.exec(raw) : null;
+    if (!match) return { lineNumber: null, text: raw };
+    return { lineNumber: Number(match[1]), text: match[2] };
+  });
+
+  return { lines, hiddenLines: Math.max(0, rawLines.length - kept.length) };
+}

--- a/web/src/conversation/fileExcerpt.ts
+++ b/web/src/conversation/fileExcerpt.ts
@@ -1,3 +1,5 @@
+import { capLines } from "@/conversation/commandOutput";
+
 /**
  * One line of a file as a Read tool reported it.
  *
@@ -31,15 +33,14 @@ const NUMBERED_LINE = /^(\d+)\t(.*)$/;
  * view can offer to reveal the rest — the same bargain a long diff strikes.
  */
 export function buildExcerpt(content: string, lineCap: number): FileExcerpt {
-  const rawLines = content.split("\n");
-  const numbered = NUMBERED_LINE.test(rawLines[0] ?? "");
+  const { lines: kept, hiddenLines } = capLines(content, lineCap);
+  const numbered = NUMBERED_LINE.test(kept[0] ?? "");
 
-  const kept = rawLines.slice(0, lineCap);
   const lines = kept.map((raw) => {
     const match = numbered ? NUMBERED_LINE.exec(raw) : null;
     if (!match) return { lineNumber: null, text: raw };
     return { lineNumber: Number(match[1]), text: match[2] };
   });
 
-  return { lines, hiddenLines: Math.max(0, rawLines.length - kept.length) };
+  return { lines, hiddenLines };
 }

--- a/web/src/conversation/generateToolSummary.test.ts
+++ b/web/src/conversation/generateToolSummary.test.ts
@@ -10,7 +10,7 @@ describe("generateToolSummary", () => {
         name: "Read",
         input: { file_path: "src/index.ts" },
       })
-    ).toBe("Read: src/index.ts");
+    ).toEqual({ label: "Read: src/index.ts" });
   });
 
   it("summarizes Bash tool with command", () => {
@@ -21,7 +21,7 @@ describe("generateToolSummary", () => {
         name: "Bash",
         input: { command: "npm test" },
       })
-    ).toBe("Bash: npm test");
+    ).toEqual({ label: "Bash: npm test" });
   });
 
   it("truncates long Bash commands", () => {
@@ -32,10 +32,10 @@ describe("generateToolSummary", () => {
       name: "Bash",
       input: { command: longCommand },
     });
-    expect(result.length).toBeLessThanOrEqual(
+    expect(result.label.length).toBeLessThanOrEqual(
       100 + "Bash: ".length + "…".length
     );
-    expect(result).toMatch(/^Bash: a+…$/);
+    expect(result.label).toMatch(/^Bash: a+…$/);
   });
 
   it("summarizes Edit tool with file path", () => {
@@ -50,7 +50,7 @@ describe("generateToolSummary", () => {
           new_string: "bar",
         },
       })
-    ).toBe("Edit: src/app.ts");
+    ).toEqual({ label: "Edit: src/app.ts" });
   });
 
   it("summarizes Write tool with file path", () => {
@@ -61,10 +61,10 @@ describe("generateToolSummary", () => {
         name: "Write",
         input: { file_path: "README.md", content: "hello" },
       })
-    ).toBe("Write: README.md");
+    ).toEqual({ label: "Write: README.md" });
   });
 
-  it("summarizes an Edit that carries a patch as a diff line", () => {
+  it("hands an Edit's counts out separately from its label", () => {
     expect(
       generateToolSummary(
         {
@@ -89,7 +89,10 @@ describe("generateToolSummary", () => {
           ],
         }
       )
-    ).toBe("Edited CollapsibleToolCall.tsx +3 -1");
+    ).toEqual({
+      label: "Edited CollapsibleToolCall.tsx",
+      diffStat: { added: 3, removed: 1 },
+    });
   });
 
   it("summarizes a Write as written, counting a whole new file as added", () => {
@@ -117,7 +120,10 @@ describe("generateToolSummary", () => {
           ],
         }
       )
-    ).toBe("Wrote README.md +2 -0");
+    ).toEqual({
+      label: "Wrote README.md",
+      diffStat: { added: 2, removed: 0 },
+    });
   });
 
   it("sums a MultiEdit's hunks into one pair of counts", () => {
@@ -152,7 +158,10 @@ describe("generateToolSummary", () => {
           ],
         }
       )
-    ).toBe("Edited app.ts +3 -2");
+    ).toEqual({
+      label: "Edited app.ts",
+      diffStat: { added: 3, removed: 2 },
+    });
   });
 
   it("keeps the plain summary for an edit whose result carries no patch", () => {
@@ -166,7 +175,7 @@ describe("generateToolSummary", () => {
         },
         { type: "tool_result", tool_use_id: "t7", content: "updated" }
       )
-    ).toBe("Edit: src/app.ts");
+    ).toEqual({ label: "Edit: src/app.ts" });
   });
 
   it("summarizes Glob tool with pattern", () => {
@@ -177,7 +186,7 @@ describe("generateToolSummary", () => {
         name: "Glob",
         input: { pattern: "**/*.ts" },
       })
-    ).toBe("Glob: **/*.ts");
+    ).toEqual({ label: "Glob: **/*.ts" });
   });
 
   it("summarizes Grep tool with pattern", () => {
@@ -188,7 +197,7 @@ describe("generateToolSummary", () => {
         name: "Grep",
         input: { pattern: "TODO" },
       })
-    ).toBe("Grep: TODO");
+    ).toEqual({ label: "Grep: TODO" });
   });
 
   it("falls back to tool name for unknown tools", () => {
@@ -199,6 +208,6 @@ describe("generateToolSummary", () => {
         name: "CustomTool",
         input: { foo: "bar" },
       })
-    ).toBe("CustomTool");
+    ).toEqual({ label: "CustomTool" });
   });
 });

--- a/web/src/conversation/generateToolSummary.ts
+++ b/web/src/conversation/generateToolSummary.ts
@@ -13,7 +13,23 @@ const EDIT_VERBS: Record<string, string> = {
   Write: "Wrote",
 };
 
-function countLines(patch: PatchHunk[]): { added: number; removed: number } {
+/** How big an edit was, in lines. */
+export interface DiffStat {
+  added: number;
+  removed: number;
+}
+
+export interface ToolSummary {
+  /** The one-line description: the verb and what it applied to. */
+  label: string;
+  /**
+   * The counts, kept out of the label so the row can place them at its trailing
+   * edge — where a truncating path cannot push them off the end (#250).
+   */
+  diffStat?: DiffStat;
+}
+
+function countLines(patch: PatchHunk[]): DiffStat {
   let added = 0;
   let removed = 0;
   for (const hunk of patch) {
@@ -51,24 +67,26 @@ function getString(value: unknown): string | undefined {
 export function generateToolSummary(
   block: ToolUseBlock,
   result?: ToolResultBlock
-): string {
+): ToolSummary {
   const { name } = block;
   const input = getInput(block.input);
 
   const verb = EDIT_VERBS[name];
   if (verb && result?.file_path && result.patch?.length) {
-    const { added, removed } = countLines(result.patch);
-    return `${verb} ${basename(result.file_path)} +${added} -${removed}`;
+    return {
+      label: `${verb} ${basename(result.file_path)}`,
+      diffStat: countLines(result.patch),
+    };
   }
 
   const filePath = getString(input.file_path);
-  if (filePath) return `${name}: ${filePath}`;
+  if (filePath) return { label: `${name}: ${filePath}` };
 
   const command = getString(input.command);
-  if (command) return `${name}: ${truncate(command)}`;
+  if (command) return { label: `${name}: ${truncate(command)}` };
 
   const pattern = getString(input.pattern);
-  if (pattern) return `${name}: ${pattern}`;
+  if (pattern) return { label: `${name}: ${pattern}` };
 
-  return name;
+  return { label: name };
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -28,6 +28,10 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-diff-add: var(--diff-add);
+  --color-diff-remove: var(--diff-remove);
+  --color-diff-add-muted: var(--diff-add-muted);
+  --color-diff-remove-muted: var(--diff-remove-muted);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -86,6 +90,25 @@
   --accent-foreground: #93a1a1;
   /* Solarized red */
   --destructive: #dc322f;
+  /* An edit's line counts, added and removed (#250). Measured against
+     --background #002b36 and against a row's hover ground #0a333e (white/4%
+     laid over it):
+       --diff-add          6.59:1 / 5.92:1 — clears the 4.5:1 AA text floor
+       --diff-remove       5.48:1 / 4.93:1 — clears it as well. Solarized red
+                           itself (--destructive) is only 3.25:1 as text, so
+                           the text tone is the lifted red; the diff's 10%
+                           ground keeps --destructive, where no text floor
+                           applies.
+       --diff-add-muted    3.06:1 / 2.75:1
+       --diff-remove-muted 3.42:1 / 3.07:1
+     The muted pair is what the counts wear at rest, next to a
+     --muted-foreground label sitting at 2.79:1 — quiet enough that a long
+     session's rows don't out-shout the prose, and never quieter than the
+     label beside them. They resolve to the full pair on hover or expansion. */
+  --diff-add: #22c55e;
+  --diff-remove: #ff6e64;
+  --diff-add-muted: #4f7a5e;
+  --diff-remove-muted: #9e6b6e;
   --border: #073642;
   --input: #073642;
   /* Solarized cyan */
@@ -125,6 +148,10 @@
   --accent: #073642;
   --accent-foreground: #93a1a1;
   --destructive: #dc322f;
+  --diff-add: #22c55e;
+  --diff-remove: #ff6e64;
+  --diff-add-muted: #4f7a5e;
+  --diff-remove-muted: #9e6b6e;
   --border: #073642;
   --input: #073642;
   --ring: #2aa198;


### PR DESCRIPTION
## Background (Why)

The conversation pane showed code in four places and coloured it in one. A diff was red/green with line numbers but no token colours; a Read result was dumped whole into a `pre`, its line numbers and code tangled in a single column; a tool call's input JSON was flat grey; a Bash command sat as an undifferentiated string. Only markdown fences were highlighted — and they paid for it eagerly, in the initial bundle, whether or not a chat had a code block in it.

This branch colours all four, on one highlighter, loaded once and only when there is code to colour.

## Approach (How)

**One lazily-loaded highlighter, four callers.** `codeHighlight.ts` holds a module-level promise for `highlight.js/lib/common`, so the grammars are fetched at most once per session, by whichever view opens first. A chat that opens no code never touches it. Views take a highlight function that is `null` until the load lands — and `null` forever for a language we cannot colour — so code is readable immediately and colour only ever arrives as an improvement.

**Highlighting never blocks a read.** Every view caps how many lines it colours and folds long content behind a reveal, so expanding a 200-line diff cannot stall the pane. Both are measured in a real browser rather than only in component tests.

**Markdown moved onto the same highlighter last (#253),** which removed the second copy of the grammars. That is a deliberate trade: a fenced block now paints plain for a moment before its colours arrive. The `.hljs` surface is present from first paint so nothing reflows, and it matches what a diff already does.

**One colour decision, not four.** `#250` added `--diff-add` / `--diff-remove` and a muted pair for the collapsed row's line counts, with contrast ratios measured against both the background and a row's hover ground, recorded in `index.css` and `docs/DESIGN.md`.

## Changes (What)

- [x] **#240** — diffs and Read results are highlighted; a read renders as a numbered file excerpt instead of raw `<n>\t<line>` output. Adds the shared `useHighlighter` hook, `FileExcerptView`, `fileExcerpt.ts`
- [x] **#250** — the collapsed row's `+N -N` diff stat is pinned to the row's trailing edge instead of being truncated away by a long path, and given its own colour tokens
- [x] **#251** — a tool call with no view of its own shows its input as coloured JSON
- [x] **#252** — a Bash unit renders its command as shell, with its output separated
- [x] **#253** — one copy of the grammars ships, shared by all four; `rehype-highlight` removed

### Test Verification

Bundle, measured with `pnpm build` against `main`:

| | main | this branch | delta |
| --- | --- | --- | --- |
| initial JS | 806.42 kB / gzip 252.21 | 646.45 kB / gzip 201.05 | **−159.97 kB / −51.16 kB** |
| lazy grammars | — (in the entry chunk) | 152.02 kB / gzip 51.98 | fetched only when code is shown |
| CSS | 73.50 kB | 74.13 kB | +0.63 kB |

A reader who opens code ends up close to where `main` was, but with highlighting in four places `main` had none. A reader who opens none is 160 kB lighter.

- [x] 867 unit tests (api 401, web 466) and 21 e2e, all passing on the merged branch
- [x] `pnpm typecheck` and `pnpm build` clean
- [x] A large diff and a large read each expand and highlight in a real browser inside a generous time bound, with the tail folded behind a reveal
- [x] Added/removed row tints stay legible underneath the token colours
- [x] A chat with no code of any kind issues zero requests for grammar modules
- [x] An unrecognised file type, and a fence naming a language the bundle lacks, both render plain rather than throwing
- [x] The markdown copy button still yields the source without highlighting markup
- [x] Diff-stat contrast ratios measured against both the background and the hover ground

## Additional Notes

- The lazy chunk carries 152 kB where the same grammars occupied roughly 131 kB as a separate chunk mid-branch. The entry chunk previously held hljs code the lazy chunk could omit; with nothing left in the entry it carries the whole set. Both the initial load and a code-free session went down, which is what a reader actually downloads.
- Known debt, recorded rather than fixed here: the muted diff-stat pair (`--diff-add-muted` 3.06:1, `--diff-remove-muted` 3.42:1) sits under the 4.5:1 floor. Both are above the `--muted-foreground` label beside them, so they are no quieter than the row already is; the muted skim layer as a whole belongs to #219.
- Highlighting is per line, not per file. A string opened on one line and closed on the next loses its context. Neither a diff nor an excerpt is guaranteed to hold a whole file, and it keeps each line's markup independent of its neighbours.

## Related Links

- Closes #240
- Closes #250
- Closes #251
- Closes #252
- Closes #253