### PR TITLE
feat: name what a tool call did, so a row reads as a sentence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,9 +52,13 @@ _Avoid_: segment, part, chunk
 A tool call paired with its tool result, shown as one collapsible row — the result belongs to the call, not to the turn it happened to arrive in. Collapsed it is a one-line summary; expanded it shows the call's input and output.
 _Avoid_: tool call (when the pair is meant), tool block pair
 
+**Action**:
+What a Tool unit did, said in a way no Agent owns: one of `edit`, `write`, `read`, `search`, `execute`, `delegate`, or `other`. Every Plugin translates its Agent's tool names into this set, so the UI renders Actions and never tool names. An Action carries meaning; the wording it is shown as (`Edited`, `Ran`) belongs to the UI, and changing that wording never touches stored rows.
+_Avoid_: verb, operation, tool type, tool name
+
 **Run**:
 A consecutive stretch of skim-layer rows — Tool units and thinking — with no message text between them, presented as one tight visual group. A Run of enough Tool units folds into a single summary row that names what happened; thinking rows share the Run's density but are never hidden behind that summary.
-_Avoid_: tool group, batch, sequence
+_Avoid_: tool group, batch, sequence; never "run" for executing a command — that is the Action `execute`
 
 **chat id**:
 The short, user-facing id for a Chat that you can paste anywhere and any agent can pattern-match. The code field is `chat_id`; the wire form is `clog_` + 6 Crockford base-32 characters (e.g. `clog_a3f7kx`).

--- a/api/src/ingestion/renormalize.test.ts
+++ b/api/src/ingestion/renormalize.test.ts
@@ -391,6 +391,10 @@ describe("renormalizeFromRaw → visualize widgets", () => {
         id: "toolu_w1",
         name: "mcp__visualize__show_widget",
         input: { title: "diagram", widget_code: WIDGET_SVG },
+        action: {
+          kind: "other",
+          object: { type: "phrase", value: "visualize" },
+        },
       },
       { type: "image", mediaType: "image/svg+xml", ref: "m-wid.0" },
     ]);
@@ -479,5 +483,72 @@ describe("renormalizeFromRaw → inline images", () => {
     expect(archive.getNormalizeVersion()).toBe(NORMALIZE_VERSION);
 
     archive.close();
+  });
+});
+
+describe("renormalizeFromRaw → Actions", () => {
+  it("gives an Action to a tool row archived before Actions existed", () => {
+    const archive = createArchiveRepository({ dataDir });
+    archive.ensureChat("claude-code", "session-1", new Date(1700000000000));
+    const toolUse = {
+      type: "tool_use",
+      id: "toolu_a1",
+      name: "Bash",
+      input: { command: "pnpm test", description: "Run the suite" },
+    };
+    const { id: rawId } = archive.insertRawMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      sourcePath: "/fake/session-1.jsonl",
+      sourceLocator: "L1",
+      payload: {
+        type: "assistant",
+        message: { role: "assistant", content: [toolUse] },
+        uuid: "m-act",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+      ingestedAt: new Date(1700000000000),
+    });
+    // The stale row a pre-Action plugin produced: the tool's own name, and no
+    // word for what it did.
+    archive.upsertNormalizedMessage({
+      agent: "claude-code",
+      sourceId: "session-1",
+      rawId,
+      message: {
+        messageId: "m-act",
+        role: "assistant",
+        ts: "2024-01-01T00:00:00Z",
+        text: "",
+        blocks: [toolUse as never],
+      },
+    });
+
+    renormalizeFromRaw({ archive, plugins: [new ClaudeCodePlugin()] });
+
+    const [message] = archive.read.listMessagesByChat(
+      "claude-code",
+      "session-1"
+    );
+    expect(message.blocks).toEqual([
+      {
+        ...toolUse,
+        action: {
+          kind: "execute",
+          object: { type: "phrase", value: "Run the suite" },
+        },
+      },
+    ]);
+    // Raw is what re-normalize reads, never what it writes (ADR-0004).
+    expect(archive.read.listRawMessages()).toHaveLength(1);
+
+    archive.close();
+  });
+
+  it("is ahead of the version that shipped widget drawings, so #260 re-normalizes", () => {
+    // Version 9 shipped the code-highlighting pass. Naming what a tool call did
+    // is the next normalize-output change, and only a bump reaches chats whose
+    // Source files are long gone.
+    expect(NORMALIZE_VERSION).toBeGreaterThanOrEqual(10);
   });
 });

--- a/api/src/ingestion/renormalize.ts
+++ b/api/src/ingestion/renormalize.ts
@@ -81,7 +81,7 @@ export function renormalizeFromRaw({
  * patch for a new-file Write, which records none, so archived creates render as
  * a diff instead of raw JSON: version 9.
  */
-export const NORMALIZE_VERSION = 9;
+export const NORMALIZE_VERSION = 10;
 
 export interface RunRenormalizeIfStaleOptions {
   plugins: readonly AgentPlugin[];

--- a/api/src/plugins/claude-code/actions.test.ts
+++ b/api/src/plugins/claude-code/actions.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { ClaudeCodePlugin } from "./plugin.js";
+import type { NormalizedBlock, RawRecord } from "../types.js";
+
+const plugin = new ClaudeCodePlugin();
+
+function rawRecord(payload: unknown): RawRecord {
+  return {
+    sourceId: "session-1",
+    sourcePath: "/fake/session-1.jsonl",
+    sourceLocator: "L1",
+    payload,
+  };
+}
+
+/** The Action the plugin gave the one tool call in a normalized assistant turn. */
+function actionOf(name: string, input: unknown) {
+  const message = plugin.normalize(
+    rawRecord({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "t1", name, input }],
+      },
+      uuid: "msg-1",
+      timestamp: "2024-01-01T00:00:00Z",
+    })
+  );
+  const block = message?.blocks[0] as Extract<
+    NormalizedBlock,
+    { type: "tool_use" }
+  >;
+  return block.action;
+}
+
+describe("Actions the Claude Code plugin gives a tool call", () => {
+  it("calls a shell command an execute, named by what the call said it was for", () => {
+    expect(
+      actionOf("Bash", {
+        command: 'sqlite3 archive.db "SELECT name FROM sqlite_master"',
+        description: "List archive tables",
+      })
+    ).toEqual({
+      kind: "execute",
+      object: { type: "phrase", value: "List archive tables" },
+    });
+  });
+
+  it("falls back to the command's first line when the call described nothing", () => {
+    expect(
+      actionOf("Bash", {
+        command: "pnpm test \\\n  --reporter=verbose",
+      })
+    ).toEqual({
+      kind: "execute",
+      object: { type: "phrase", value: "pnpm test \\" },
+    });
+  });
+
+  // Three acts the reader tells apart at a glance: a local replacement, a whole
+  // file written, and a file only looked at. Each names the file as a path, so
+  // the UI knows it may drop leading directories rather than the filename.
+  it.each([
+    ["Edit", "edit"],
+    ["MultiEdit", "edit"],
+    ["Write", "write"],
+    ["Read", "read"],
+  ])("calls %s a %s of the file it names", (name, kind) => {
+    expect(actionOf(name, { file_path: "/repo/web/src/types.ts" })).toEqual({
+      kind,
+      object: { type: "path", value: "/repo/web/src/types.ts" },
+    });
+  });
+
+  // A search names what was looked for, not where — so it is a phrase, and it
+  // reads as `Searched for "…"` rather than as a file the Agent opened.
+  it.each([
+    ["Grep", { pattern: "useMessages" }],
+    ["Glob", { pattern: "useMessages" }],
+    ["WebSearch", { query: "useMessages" }],
+    ["ToolSearch", { query: "useMessages" }],
+  ])("calls %s a search for what it was given", (name, input) => {
+    expect(actionOf(name, input)).toEqual({
+      kind: "search",
+      object: { type: "phrase", value: "useMessages" },
+    });
+  });
+
+  // Handing work to another agent, named by the task rather than by which
+  // agent took it — the task is what the reader is scanning for.
+  it.each([
+    [
+      "Agent",
+      { subagent_type: "Explore", description: "Research the plugins" },
+    ],
+    ["SendMessage", { to: "a24a", summary: "Research the plugins" }],
+  ])("calls %s a delegation of the task it names", (name, input) => {
+    expect(actionOf(name, input)).toEqual({
+      kind: "delegate",
+      object: { type: "phrase", value: "Research the plugins" },
+    });
+  });
+
+  // MCP tool names are unbounded — they come from whichever servers the reader
+  // installed — so `other` is permanent rather than a gap waiting to be filled.
+  // The server is the part that means something; the tool half is that server's
+  // own internal action name, and `mcp__` is transport.
+  it.each([
+    ["mcp__Claude_Browser__computer", "Claude Browser"],
+    ["mcp__context7__query-docs", "context7"],
+    ["mcp__ccd_session_mgmt__search_session_transcripts", "ccd session mgmt"],
+  ])("names %s after the server behind it", (name, server) => {
+    expect(actionOf(name, { action: "screenshot" })).toEqual({
+      kind: "other",
+      object: { type: "phrase", value: server },
+    });
+  });
+
+  // Fetching a URL is reading, so it shares the kind — but a URL is a phrase,
+  // not a path: what identifies it sits at the front, so the UI must not treat
+  // its leading parts as droppable the way it does a directory.
+  it("calls a fetched URL a read, and keeps the URL whole", () => {
+    expect(
+      actionOf("WebFetch", { url: "https://example.com/docs/api" })
+    ).toEqual({
+      kind: "read",
+      object: { type: "phrase", value: "https://example.com/docs/api" },
+    });
+  });
+
+  // A built-in with no mapping keeps its own name, which is already written for
+  // a reader. Skill lands here rather than under delegate: it sometimes loads
+  // instructions into the current turn and sometimes hands off, so calling it a
+  // delegation would be wrong half the time.
+  it.each(["Skill", "TaskCreate", "AskUserQuestion"])(
+    "keeps %s's own name when nothing else describes it",
+    (name) => {
+      expect(actionOf(name, { some: "input" })).toEqual({
+        kind: "other",
+        object: { type: "phrase", value: name },
+      });
+    }
+  );
+});

--- a/api/src/plugins/claude-code/actions.ts
+++ b/api/src/plugins/claude-code/actions.ts
@@ -1,0 +1,74 @@
+import { mcpServerName } from "../mcp-tool-name.js";
+import type { Action, ActionKind } from "../types.js";
+
+function getString(input: unknown, key: string): string | undefined {
+  if (typeof input !== "object" || input === null) return undefined;
+  const value = (input as Record<string, unknown>)[key];
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+// Write covers both a new file and an overwrite, which is why it stays apart
+// from edit: a reader scanning a Run wants to see that the last of three
+// touches rewrote the file rather than patched it (#260).
+const FILE_KINDS: Record<string, ActionKind> = {
+  Edit: "edit",
+  MultiEdit: "edit",
+  Write: "write",
+  Read: "read",
+};
+
+// Kept apart from read, unlike the fold summary that merges the two (#199):
+// a search's object is what was looked for, and `Read "useMessages"` does not
+// parse. The summary merges them at render, where wording belongs.
+const SEARCH_TOOLS = new Set(["Grep", "Glob", "WebSearch", "ToolSearch"]);
+
+function firstLine(text: string | undefined): string | undefined {
+  return text?.split("\n", 1)[0];
+}
+
+/** An object clause, omitted entirely when there is nothing to name. */
+function phrase(value: string | undefined) {
+  return value ? { object: { type: "phrase" as const, value } } : {};
+}
+
+function path(value: string | undefined) {
+  return value ? { object: { type: "path" as const, value } } : {};
+}
+
+/**
+ * The Action behind one Claude Code tool call (ADR-0025).
+ *
+ * This is the whole of what the frontend needs to know about Claude Code's tool
+ * names — nothing downstream ever sees them again.
+ */
+export function toolAction(name: string, input: unknown): Action {
+  if (name === "Bash") {
+    // The description is what the call said it was for, and nearly every call
+    // carries one. The command itself is the worse label: most run past a
+    // readable width and many are several lines (#260).
+    const said =
+      getString(input, "description") ?? firstLine(getString(input, "command"));
+    return { kind: "execute", ...phrase(said) };
+  }
+
+  if (name === "Agent" || name === "SendMessage") {
+    const task = getString(input, "description") ?? getString(input, "summary");
+    return { kind: "delegate", ...phrase(task) };
+  }
+
+  if (SEARCH_TOOLS.has(name)) {
+    const looked = getString(input, "pattern") ?? getString(input, "query");
+    return { kind: "search", ...phrase(looked) };
+  }
+
+  const fileKind = FILE_KINDS[name];
+  if (fileKind) {
+    return { kind: fileKind, ...path(getString(input, "file_path")) };
+  }
+
+  if (name === "WebFetch") {
+    return { kind: "read", ...phrase(getString(input, "url")) };
+  }
+
+  return { kind: "other", ...phrase(mcpServerName(name) ?? name) };
+}

--- a/api/src/plugins/claude-code/plugin.test.ts
+++ b/api/src/plugins/claude-code/plugin.test.ts
@@ -258,6 +258,10 @@ describe("ClaudeCodePlugin.normalize", () => {
         id: "tool-1",
         name: "Read",
         input: { file_path: "src/index.ts" },
+        action: {
+          kind: "read",
+          object: { type: "path", value: "src/index.ts" },
+        },
       },
     ]);
     expect(result?.text).toBe("");
@@ -849,6 +853,10 @@ describe("ClaudeCodePlugin.normalize → visualize widgets", () => {
         id: "toolu_w1",
         name: "mcp__visualize__show_widget",
         input: { title: "arch_diagram", widget_code: svg },
+        action: {
+          kind: "other",
+          object: { type: "phrase", value: "visualize" },
+        },
       },
       { type: "image", mediaType: "image/svg+xml", ref: "msg-w-1.0" },
     ]);
@@ -866,6 +874,10 @@ describe("ClaudeCodePlugin.normalize → visualize widgets", () => {
         id: "toolu_w1",
         name: "mcp__visualize__show_widget",
         input: { title: "arch_diagram", widget_code: html },
+        action: {
+          kind: "other",
+          object: { type: "phrase", value: "visualize" },
+        },
       },
     ]);
   });

--- a/api/src/plugins/claude-code/plugin.ts
+++ b/api/src/plugins/claude-code/plugin.ts
@@ -11,6 +11,7 @@ import type {
   ChatRef,
 } from "../types.js";
 import { svgWidgetCode, themeWidgetSvg } from "../visualize-widget.js";
+import { toolAction } from "./actions.js";
 
 export class ClaudeCodePlugin implements AgentPlugin {
   readonly id = "claude-code";
@@ -496,13 +497,16 @@ function normalizeOneBlock(
       return { type: "text", text: String(b.text ?? "") };
     case "thinking":
       return { type: "thinking", thinking: String(b.thinking ?? "") };
-    case "tool_use":
+    case "tool_use": {
+      const name = String(b.name ?? "");
       return {
         type: "tool_use",
         id: String(b.id ?? ""),
-        name: String(b.name ?? ""),
+        name,
         input: b.input,
+        action: toolAction(name, b.input),
       };
+    }
     case "tool_result":
       return {
         type: "tool_result",

--- a/api/src/plugins/mcp-tool-name.ts
+++ b/api/src/plugins/mcp-tool-name.ts
@@ -1,0 +1,28 @@
+/**
+ * MCP tool names, which every Agent that speaks MCP shares.
+ *
+ * A call arrives as `mcp__<server>__<tool>`. That structure belongs to the
+ * protocol rather than to any one Agent, so reading it lives here and not in a
+ * Plugin — a second Agent with MCP servers gets the same handling for free.
+ */
+
+const PREFIX = "mcp__";
+const SEPARATOR = "__";
+
+/**
+ * The server a tool call came from, in a form worth showing a reader, or null
+ * when this is not an MCP tool name.
+ *
+ * The server is the useful half: in `mcp__Claude_Browser__computer` a reader
+ * can use "Claude Browser", while `computer` is that server's own action name
+ * and means nothing on its own (#260).
+ */
+export function mcpServerName(toolName: string): string | null {
+  if (!toolName.startsWith(PREFIX)) return null;
+  const rest = toolName.slice(PREFIX.length);
+  const end = rest.indexOf(SEPARATOR);
+  const server = end === -1 ? rest : rest.slice(0, end);
+  if (!server) return null;
+  // Servers name themselves in identifier case; a reader is not reading code.
+  return server.replace(/_/g, " ");
+}

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -30,10 +30,53 @@ export interface PatchHunk {
   lines: string[];
 }
 
+/**
+ * What a Tool unit did, said in a way no Agent owns (ADR-0025).
+ *
+ * Every Plugin translates its own Agent's tool names into this set, so the UI
+ * renders Actions and never tool names. `execute` rather than `run` because Run
+ * already names the visual grouping of skim-layer rows.
+ */
+export type ActionKind =
+  | "edit"
+  | "write"
+  | "read"
+  | "search"
+  | "execute"
+  | "delegate"
+  | "other";
+
+/**
+ * What an Action applied to. A path says the value is a file location, which is
+ * the UI's cue that it may drop leading directories to fit — a phrase has no
+ * such structure and truncates from the end. A URL is a phrase for that reason:
+ * its identifying part is at the front.
+ */
+export type ActionObject =
+  | { type: "path"; value: string }
+  | { type: "phrase"; value: string };
+
+export interface Action {
+  kind: ActionKind;
+  /** Absent when the call named nothing to act on. */
+  object?: ActionObject;
+}
+
 export type NormalizedBlock =
   | { type: "text"; text: string }
   | { type: "thinking"; thinking: string }
-  | { type: "tool_use"; id: string; name: string; input: unknown }
+  | {
+      type: "tool_use";
+      id: string;
+      name: string;
+      input: unknown;
+      /**
+       * Required here because every call has one — an unrecognized tool is
+       * `other`, not nothing. Optional on the read side, where rows normalized
+       * before this field existed are still in flight until re-normalize runs.
+       */
+      action: Action;
+    }
   | {
       type: "tool_result";
       toolUseId: string;

--- a/docs/adr/0023-normalized-block-vocabulary.md
+++ b/docs/adr/0023-normalized-block-vocabulary.md
@@ -39,6 +39,8 @@ Three adjacent rules ride on the same contract:
 - **`NormalizedMessage.model`** — an optional field capturing the model id the Agent recorded on the message (e.g. `claude-opus-4-8`). Absent when the Agent doesn't record one.
 - **`NormalizedMessage.effort`** — an optional field capturing the reasoning effort the Agent recorded for the message (e.g. `medium`). Per message, exactly like `model`, and absent when the Agent recorded none. Claude Code writes it beside the message rather than inside it, so the Plugin reads it off the record's top level. Stored in the Agent's own wording. Unlike a model id, an effort is already a readable word, so the frontend needs no id→name table for it — it capitalizes the first letter at render and shows the rest untouched.
 
+- **`tool_use.action`** — what the call did, as one of `edit`, `write`, `read`, `search`, `execute`, `delegate`, `other`, together with what it applied to (a path, or a phrase such as a command's description or a search pattern). The Plugin decides it from its own Agent's tool names, so nothing downstream keys on a tool name — which is what the last bullet under Consequences promises, and what the row label did not honour until ADR-0025. Required on the write side, since an unrecognized tool is `other` rather than nothing; the read side treats it as optional, because rows normalized before it existed read as `other` until re-normalize catches up. The word a reader sees is not stored: see ADR-0025 for why.
+
 The API serves these shapes as-is (with `tool_result.toolUseId` mapped to wire-form `tool_use_id`, matching the existing convention).
 
 ## Considered alternatives

--- a/docs/adr/0025-actions-carry-meaning-ui-carries-wording.md
+++ b/docs/adr/0025-actions-carry-meaning-ui-carries-wording.md
@@ -1,0 +1,23 @@
+# Actions carry meaning, the UI carries wording
+
+A `tool_use` block stores an **Action** — one of `edit`, `write`, `read`, `search`, `execute`, `delegate`, `other`, plus what it applied to. The English a reader sees (`Edited`, `Ran`, `Searched for`) is not stored anywhere. Each Plugin maps its own Agent's tool names onto the Action set at normalize time; the frontend maps Actions onto words at render time. Nothing downstream of a Plugin ever sees a tool name.
+
+The line matters because the two halves change for different reasons and at different costs. What a call _did_ is a fact about the archived conversation: it is settled the moment the row is normalized, and re-deciding it means re-normalizing from Raw. What a call is _called_ is a presentation choice: someone may prefer `Executed` to `Ran`, or want the column in another language, and none of that should touch a stored row. Storing the English word would have made a one-word edit a full re-normalize of every chat.
+
+The naming has one visible seam: the kind is `execute` but it renders as `Ran`. `run` was unavailable because **Run** already names the visual grouping of consecutive skim-layer rows, and "four runs inside this Run" is not a sentence worth shipping. The mismatch is the split working rather than an inconsistency in it.
+
+## Considered alternatives
+
+**Keep the mapping in the frontend, keyed on tool names.** This is what shipped before, in two separate tables — one for row labels, one for fold summaries. It contradicts this repo's own promise that "a new Agent plugin ships with zero frontend changes as long as it speaks this vocabulary" (ADR-0023): Codex names its tools `shell` and `apply_patch`, so #35 would have landed with every row falling back to a raw tool name. ADR-0023 had already solved the same problem once for diffs, by keying on the shape of what it found rather than on a list of tool names; the row label simply had not caught up. This ADR closes that gap.
+
+**Store the English verb in Normalized.** Rejected for the reason above: it pins wording into the archive. It also invites the verb and the fold summary's verb to drift, since only one of them would be stored.
+
+**Let `other` fall back to the tool's raw name on screen.** Rejected. MCP tool names are unbounded — they come from whichever servers the reader installed — so `other` is permanent rather than a gap waiting to be filled, and on one real archive it covers about a tenth of all calls. Falling back would have left the machine register on screen for exactly the rows nobody planned for. An MCP call is named after its server instead (`mcp__Claude_Browser__computer` → "Claude Browser"), which loses which tool ran and keeps what a reader can use.
+
+## Consequences
+
+- Changing a verb, or translating the column, is a frontend edit. Changing what a kind _means_ is a re-normalize.
+- The Action set is a cross-layer contract and stays small for the same reason the block vocabulary does (ADR-0023): prefer widening a kind over adding one. `fetch` was folded into `read` on those grounds.
+- Two densities can group Actions differently without either lying. The row keeps `read` and `search` apart, because a search's object is a pattern and `Read "useMessages"` does not parse; the fold summary merges them, per #199. Grouping is wording, so it lives in the UI.
+- `mcp__<server>__<tool>` is parsed by shared code rather than by a Plugin: that structure belongs to MCP, so a second Agent with MCP servers inherits the handling.
+- Not yet closed: the _expanded_ view still keys on tool names to choose between a shell renderer and a file excerpt. An Action names what happened but does not carry the verbatim command that renderer needs, so that coupling outlives this ADR.

--- a/web/e2e/code-highlighting.spec.ts
+++ b/web/e2e/code-highlighting.spec.ts
@@ -114,6 +114,10 @@ test("a large diff expands and highlights in a real browser without stalling", a
       id: "tool_1",
       name: "Write",
       input: { file_path: "web/src/constants.ts" },
+      action: {
+        kind: "write",
+        object: { type: "path", value: "web/src/constants.ts" },
+      },
     },
     {
       type: "tool_result",
@@ -166,6 +170,10 @@ test("a large read expands as a highlighted, numbered excerpt without stalling",
       id: "tool_2",
       name: "Read",
       input: { file_path: "web/src/constants.ts" },
+      action: {
+        kind: "read",
+        object: { type: "path", value: "web/src/constants.ts" },
+      },
     },
     {
       type: "tool_result",
@@ -174,7 +182,7 @@ test("a large read expands as a highlighted, numbered excerpt without stalling",
     },
   ]);
 
-  const summary = page.getByText("Read: web/src/constants.ts");
+  const summary = page.getByText("Read constants.ts");
   await expect(summary).toBeVisible();
 
   const start = Date.now();
@@ -210,11 +218,15 @@ test("a tool call with no view of its own shows its input as coloured JSON", asy
         // block did not scroll on its own.
         path: `web/src/${"very-long-directory-name/".repeat(20)}index.ts`,
       },
+      action: {
+        kind: "search",
+        object: { type: "phrase", value: "useState" },
+      },
     },
     { type: "tool_result", tool_use_id: "tool_3", content: "No matches found" },
   ]);
 
-  await page.getByText("Grep", { exact: false }).first().click();
+  await page.getByText('Searched for "useState"').first().click();
 
   const input = page.getByTestId("json-input");
   await expect(input.locator(".hljs-attr").first()).toBeVisible();

--- a/web/e2e/diff-stat.spec.ts
+++ b/web/e2e/diff-stat.spec.ts
@@ -85,6 +85,7 @@ function editOf(filePath: string, added: number, removed: number) {
       id: "tool_1",
       name: "Edit",
       input: { file_path: filePath },
+      action: { kind: "edit", object: { type: "path", value: filePath } },
     },
     {
       type: "tool_result",

--- a/web/e2e/run-grouping.spec.ts
+++ b/web/e2e/run-grouping.spec.ts
@@ -39,6 +39,7 @@ async function openRunChat(page: import("@playwright/test").Page) {
     id,
     name: "Read",
     input: { file_path: path },
+    action: { kind: "read", object: { type: "path", value: path } },
   });
   await page.route(/\/api\/chats\/clog_run1(\?|$)/, (route) =>
     route.fulfill({
@@ -85,7 +86,8 @@ async function rowTop(
   path: string
 ): Promise<{ top: number; bottom: number }> {
   const box = await page
-    .getByRole("button", { name: new RegExp(`Read: ${path}`) })
+    // The row names the file, not the path it sits at.
+    .getByRole("button", { name: new RegExp(`Read ${path.split("/").pop()}`) })
     .boundingBox();
   return { top: box!.y, bottom: box!.y + box!.height };
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1478,7 +1478,7 @@ describe("Tool call rendering", () => {
     await user.click(await screen.findByText("Refactor utils"));
 
     // Tool call summary should be visible
-    expect(await screen.findByText("Read: src/utils.ts")).toBeInTheDocument();
+    expect(await screen.findByText("Read utils.ts")).toBeInTheDocument();
 
     // The file it read should NOT be visible when collapsed
     expect(screen.queryByTestId("excerpt-line")).not.toBeInTheDocument();
@@ -1489,7 +1489,7 @@ describe("Tool call rendering", () => {
     render(<App />);
 
     await user.click(await screen.findByText("Refactor utils"));
-    const summary = await screen.findByText("Read: src/utils.ts");
+    const summary = await screen.findByText("Read utils.ts");
 
     // Click to expand
     await user.click(summary);
@@ -1504,7 +1504,7 @@ describe("Tool call rendering", () => {
     render(<App />);
 
     await user.click(await screen.findByText("Refactor utils"));
-    const summary = await screen.findByText("Read: src/utils.ts");
+    const summary = await screen.findByText("Read utils.ts");
 
     // Expand then collapse
     await user.click(summary);
@@ -1521,7 +1521,7 @@ describe("Thinking block rendering", () => {
     render(<App />);
 
     await user.click(await screen.findByText("Refactor utils"));
-    await screen.findByText("Read: src/utils.ts");
+    await screen.findByText("Read utils.ts");
 
     // session-3 has one empty thinking and one with content
     // Only one "Thinking..." button should appear
@@ -1730,7 +1730,7 @@ describe("Tool call rendering (continued)", () => {
     render(<App />);
 
     await user.click(await screen.findByText("Refactor utils"));
-    await screen.findByText("Read: src/utils.ts");
+    await screen.findByText("Read utils.ts");
 
     // tool_result content should not appear
     expect(

--- a/web/src/conversation/CollapsibleToolCall.test.tsx
+++ b/web/src/conversation/CollapsibleToolCall.test.tsx
@@ -11,6 +11,7 @@ const editCall: ToolUseBlock = {
   id: "t1",
   name: "Edit",
   input: { file_path: "a.tsx", old_string: "x", new_string: "y" },
+  action: { kind: "edit", object: { type: "path", value: "src/a.tsx" } },
 };
 
 describe("CollapsibleToolCall", () => {
@@ -74,7 +75,35 @@ describe("CollapsibleToolCall", () => {
     );
 
     expect(screen.getByTestId("row-diff-stat").textContent).toBe("+3 -1");
-    expect(screen.getByText("Edited CollapsibleToolCall.tsx")).not.toBeNull();
+    expect(screen.getByText("Edited a.tsx")).not.toBeNull();
+  });
+
+  // One register across the whole column: a row says what happened, never which
+  // tool ran or what its JSON held (#260).
+  it.each([
+    [
+      { kind: "execute", object: { type: "phrase", value: "Run the suite" } },
+      'Ran "Run the suite"',
+    ],
+    [
+      { kind: "search", object: { type: "phrase", value: "useMessages" } },
+      'Searched for "useMessages"',
+    ],
+    [
+      { kind: "other", object: { type: "phrase", value: "Claude Browser" } },
+      'Used "Claude Browser"',
+    ],
+    [{ kind: "other" }, "Used"],
+  ] as const)("reads as a sentence, never as a tool name", (action, label) => {
+    render(
+      <CollapsibleToolCall
+        block={{ ...editCall, name: "mcp__Claude_Browser__computer", action }}
+        isExpanded={false}
+        onToggle={() => {}}
+      />
+    );
+
+    expect(screen.getByText(label)).not.toBeNull();
   });
 
   it("falls back to the raw rendering when the result carries no patch", () => {

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -1,5 +1,5 @@
 import { Terminal } from "lucide-react";
-import type { ContentBlock } from "@/types";
+import type { ActionObject, ContentBlock } from "@/types";
 import { CollapsibleRow } from "@/conversation/CollapsibleRow";
 import { CommandView } from "@/conversation/CommandView";
 import { DiffView } from "@/conversation/DiffView";
@@ -32,6 +32,21 @@ function shellCommand(input: unknown): string | undefined {
   if (typeof input !== "object" || input === null) return undefined;
   const { command } = input as { command?: unknown };
   return typeof command === "string" ? command : undefined;
+}
+
+/**
+ * The row's one line: what happened, then what it happened to.
+ *
+ * A path stands on its own — it is already a name. A phrase is text the call
+ * supplied, so quoting it keeps `Searched for "npm test"` from reading as if
+ * the words were ours. The filename alone for now; #262 gives the row a shape
+ * that can show the directory too without ever clipping the name.
+ */
+function sentence(verb: string, object?: ActionObject): string {
+  if (!object) return verb;
+  if (object.type === "phrase") return `${verb} "${object.value}"`;
+  const slash = object.value.lastIndexOf("/");
+  return `${verb} ${slash === -1 ? object.value : object.value.slice(slash + 1)}`;
 }
 
 /**
@@ -68,12 +83,12 @@ export function CollapsibleToolCall({
   // dumped as JSON above it (#252).
   const command = block.name === "Bash" ? shellCommand(block.input) : undefined;
 
-  const { label, diffStat } = generateToolSummary(block, result);
+  const { verb, object, diffStat } = generateToolSummary(block, result);
 
   return (
     <CollapsibleRow
       icon={Terminal}
-      summary={label}
+      summary={sentence(verb, object)}
       diffStat={diffStat}
       hasError={result?.is_error}
       isExpanded={isExpanded}

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -536,6 +536,10 @@ describe("Conversation collapsed units", () => {
                 id: "t1",
                 name: "Read",
                 input: { file_path: "/tmp/a.ts" },
+                action: {
+                  kind: "read",
+                  object: { type: "path", value: "/tmp/a.ts" },
+                },
               },
             ],
             timestamp: "2024-01-01T00:01:00Z",
@@ -545,7 +549,7 @@ describe("Conversation collapsed units", () => {
     );
 
     // The collapsed row is still rendered — it is content, just not authored.
-    expect(await screen.findByText("Read: /tmp/a.ts")).not.toBeNull();
+    expect(await screen.findByText("Read a.ts")).not.toBeNull();
     // ...but the header belongs to the text turn alone.
     expect(screen.getAllByText("Claude Code")).toHaveLength(1);
   });
@@ -569,6 +573,10 @@ describe("Conversation tool units", () => {
                 id: "t1",
                 name: "Read",
                 input: { file_path: "/tmp/a.ts" },
+                action: {
+                  kind: "read",
+                  object: { type: "path", value: "/tmp/a.ts" },
+                },
               },
               {
                 type: "tool_result",
@@ -582,7 +590,7 @@ describe("Conversation tool units", () => {
       />
     );
 
-    await user.click(await screen.findByText("Read: /tmp/a.ts"));
+    await user.click(await screen.findByText("Read a.ts"));
 
     // Highlighting splits the code into token spans, so match on the row's
     // whole text rather than a single node's (#240).
@@ -609,6 +617,10 @@ describe("Conversation tool units", () => {
                 id: "t1",
                 name: "Bash",
                 input: { command: "pnpm test" },
+                action: {
+                  kind: "execute",
+                  object: { type: "phrase", value: "pnpm test" },
+                },
               },
             ],
             timestamp: "2024-01-01T00:00:00Z",
@@ -625,7 +637,7 @@ describe("Conversation tool units", () => {
       />
     );
 
-    await user.click(await screen.findByText("Bash: pnpm test"));
+    await user.click(await screen.findByText('Ran "pnpm test"'));
 
     expect(await screen.findByText(/17 passed/)).not.toBeNull();
   });
@@ -647,6 +659,10 @@ describe("Conversation tool units", () => {
                 id: "t1",
                 name: "Edit",
                 input: { file_path: "/repo/web/src/App.tsx" },
+                action: {
+                  kind: "edit",
+                  object: { type: "path", value: "/repo/web/src/App.tsx" },
+                },
               },
             ],
             timestamp: "2024-01-01T00:00:00Z",
@@ -701,6 +717,10 @@ describe("Conversation tool units", () => {
                 id: "t1",
                 name: "Bash",
                 input: { command: "pnpm test" },
+                action: {
+                  kind: "execute",
+                  object: { type: "phrase", value: "pnpm test" },
+                },
               },
               { type: "tool_result", tool_use_id: "t1", content: "17 passed" },
             ],
@@ -710,7 +730,7 @@ describe("Conversation tool units", () => {
       />
     );
 
-    await user.click(await screen.findByText("Bash: pnpm test"));
+    await user.click(await screen.findByText('Ran "pnpm test"'));
 
     const detail = container.querySelector('[data-testid="unit-detail"]')!;
     expect(detail).not.toBeNull();
@@ -738,6 +758,10 @@ describe("Conversation tool units", () => {
                 id: "t1",
                 name: "Read",
                 input: { file_path: "/tmp/a.ts" },
+                action: {
+                  kind: "read",
+                  object: { type: "path", value: "/tmp/a.ts" },
+                },
               },
             ],
             timestamp: "2024-01-01T00:00:00Z",
@@ -747,7 +771,7 @@ describe("Conversation tool units", () => {
     );
 
     const row = await screen.findByRole("button", {
-      name: /Read: \/tmp\/a\.ts/,
+      name: /Read a\.ts/,
     });
     expect(row).toHaveAttribute("aria-expanded", "false");
     expect(row.querySelector('[data-testid="row-chevron"]')).not.toBeNull();
@@ -805,6 +829,10 @@ describe("Conversation tool units", () => {
                 id: "t1",
                 name: "Bash",
                 input: { command: "pnpm test" },
+                action: {
+                  kind: "execute",
+                  object: { type: "phrase", value: "pnpm test" },
+                },
               },
             ],
             timestamp: "2024-01-01T00:00:00Z",
@@ -826,7 +854,7 @@ describe("Conversation tool units", () => {
       />
     );
 
-    const row = await screen.findByRole("button", { name: /Bash: pnpm test/ });
+    const row = await screen.findByRole("button", { name: /Ran "pnpm test"/ });
     expect(row.querySelector('[data-testid="row-error"]')).not.toBeNull();
   });
 
@@ -844,6 +872,10 @@ describe("Conversation tool units", () => {
                 id: "t1",
                 name: "Bash",
                 input: { command: "pnpm test" },
+                action: {
+                  kind: "execute",
+                  object: { type: "phrase", value: "pnpm test" },
+                },
               },
               { type: "tool_result", tool_use_id: "t1", content: "17 passed" },
             ],
@@ -853,7 +885,7 @@ describe("Conversation tool units", () => {
       />
     );
 
-    const row = await screen.findByRole("button", { name: /Bash: pnpm test/ });
+    const row = await screen.findByRole("button", { name: /Ran "pnpm test"/ });
     expect(row.querySelector('[data-testid="row-error"]')).toBeNull();
   });
 });
@@ -998,6 +1030,10 @@ describe("ConversationView — visualize widgets", () => {
     id: "toolu_w1",
     name: "mcp__visualize__show_widget",
     input: { title: "arch_diagram", widget_code: "<svg />" },
+    action: {
+      kind: "other" as const,
+      object: { type: "phrase" as const, value: "visualize" },
+    },
   };
 
   it("draws the widget beside its tool row, named as a drawing not a screenshot", async () => {
@@ -1024,7 +1060,7 @@ describe("ConversationView — visualize widgets", () => {
     expect(img.getAttribute("alt")).toBe("Diagram");
     // The source stays reachable — the drawing is the point, but the reader can
     // still open the row that produced it.
-    expect(screen.getByText(/show_widget/)).toBeTruthy();
+    expect(screen.getByText(/visualize/)).toBeTruthy();
   });
 });
 
@@ -1050,7 +1086,13 @@ describe("copying a whole message", () => {
             content: [
               { type: "thinking", thinking: "considering" },
               { type: "text", text: "Here is the answer." },
-              { type: "tool_use", id: "t1", name: "Read", input: {} },
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Read",
+                input: {},
+                action: { kind: "read" },
+              },
             ],
             timestamp: "2024-01-01T00:00:00Z",
           },
@@ -1077,7 +1119,15 @@ describe("messages with nothing to take away", () => {
           {
             id: "m-tool-only",
             role: "assistant",
-            content: [{ type: "tool_use", id: "t1", name: "Read", input: {} }],
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Read",
+                input: {},
+                action: { kind: "read" },
+              },
+            ],
             timestamp: "2024-01-01T00:00:00Z",
           },
         ]}
@@ -1098,7 +1148,13 @@ describe("messages with nothing to take away", () => {
             role: "assistant",
             content: [
               { type: "text", text: "Reading the file." },
-              { type: "tool_use", id: "t2", name: "Read", input: {} },
+              {
+                type: "tool_use",
+                id: "t2",
+                name: "Read",
+                input: {},
+                action: { kind: "read" },
+              },
             ],
             timestamp: "2024-01-01T00:00:00Z",
           },
@@ -1122,14 +1178,28 @@ describe("Run grouping", () => {
       role: "assistant",
       content: [
         { type: "thinking", thinking: "weighing the options" },
-        { type: "tool_use", id: "t1", name: "Read", input: {} },
+        {
+          type: "tool_use",
+          id: "t1",
+          name: "Read",
+          input: {},
+          action: { kind: "read" },
+        },
       ],
       timestamp: "2024-01-01T00:00:00Z",
     },
     {
       id: "m-2",
       role: "assistant",
-      content: [{ type: "tool_use", id: "t2", name: "Bash", input: {} }],
+      content: [
+        {
+          type: "tool_use",
+          id: "t2",
+          name: "Bash",
+          input: {},
+          action: { kind: "execute" },
+        },
+      ],
       timestamp: "2024-01-01T00:01:00Z",
     },
     {
@@ -1196,7 +1266,16 @@ describe("Folding a long Run", () => {
       id,
       role: "assistant",
       content: [
-        { type: "tool_use", id: `t-${id}`, name: "Bash", input: { command } },
+        {
+          type: "tool_use",
+          id: `t-${id}`,
+          name: "Bash",
+          input: { command },
+          action: {
+            kind: "execute",
+            object: { type: "phrase", value: command },
+          },
+        },
       ],
       timestamp: "2024-01-01T00:00:00Z",
     };
@@ -1277,6 +1356,7 @@ describe("Row expansion", () => {
           id: `t-${id}`,
           name: "Read",
           input: { file_path: path },
+          action: { kind: "read", object: { type: "path", value: path } },
         },
       ],
       timestamp: "2024-01-01T00:00:00Z",
@@ -1295,9 +1375,7 @@ describe("Row expansion", () => {
       />
     );
 
-    await user.click(
-      await screen.findByRole("button", { name: /Read: \/b\.ts/ })
-    );
+    await user.click(await screen.findByRole("button", { name: /Read b\.ts/ }));
 
     rerender(
       <ConversationView
@@ -1318,12 +1396,13 @@ describe("Row expansion", () => {
     );
 
     expect(
-      await screen.findByRole("button", { name: /Read: \/b\.ts/ })
+      await screen.findByRole("button", { name: /Read b\.ts/ })
     ).toHaveAttribute("aria-expanded", "true");
     // and no neighbour inherited it
-    expect(
-      screen.getByRole("button", { name: /Read: \/a\.ts/ })
-    ).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: /Read a\.ts/ })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
   });
   it("remembers each row of a turn separately", async () => {
     const user = userEvent.setup();
@@ -1340,12 +1419,20 @@ describe("Row expansion", () => {
                 id: "t1",
                 name: "Read",
                 input: { file_path: "/a.ts" },
+                action: {
+                  kind: "read",
+                  object: { type: "path", value: "/a.ts" },
+                },
               },
               {
                 type: "tool_use",
                 id: "t2",
                 name: "Read",
                 input: { file_path: "/b.ts" },
+                action: {
+                  kind: "read",
+                  object: { type: "path", value: "/b.ts" },
+                },
               },
             ],
             timestamp: "2024-01-01T00:00:00Z",
@@ -1354,16 +1441,16 @@ describe("Row expansion", () => {
       />
     );
 
-    await user.click(
-      await screen.findByRole("button", { name: /Read: \/b\.ts/ })
-    );
+    await user.click(await screen.findByRole("button", { name: /Read b\.ts/ }));
 
-    expect(
-      screen.getByRole("button", { name: /Read: \/b\.ts/ })
-    ).toHaveAttribute("aria-expanded", "true");
-    expect(
-      screen.getByRole("button", { name: /Read: \/a\.ts/ })
-    ).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: /Read b\.ts/ })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    expect(screen.getByRole("button", { name: /Read a\.ts/ })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
   });
 
   it("opens a different chat with every row closed", async () => {
@@ -1372,9 +1459,7 @@ describe("Row expansion", () => {
       <ConversationView chat={chat} messages={[tool("m-a", "/a.ts")]} />
     );
 
-    await user.click(
-      await screen.findByRole("button", { name: /Read: \/a\.ts/ })
-    );
+    await user.click(await screen.findByRole("button", { name: /Read a\.ts/ }));
 
     rerender(
       <ConversationView
@@ -1384,7 +1469,7 @@ describe("Row expansion", () => {
     );
 
     expect(
-      await screen.findByRole("button", { name: /Read: \/a\.ts/ })
+      await screen.findByRole("button", { name: /Read a\.ts/ })
     ).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/web/src/conversation/generateToolSummary.test.ts
+++ b/web/src/conversation/generateToolSummary.test.ts
@@ -1,213 +1,86 @@
 import { describe, it, expect } from "vitest";
+import type { Action, ContentBlock } from "@/types";
 import { generateToolSummary } from "./generateToolSummary";
 
+type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
+
+function toolUse(action?: Action): ToolUseBlock {
+  // The tool's name and input stay on the block, and the summary is expected to
+  // ignore both: what the call did is the Action's to say, not the tool's.
+  return {
+    type: "tool_use",
+    id: "t1",
+    name: "Edit",
+    input: { file_path: "/repo/web/src/types.ts" },
+    ...(action ? { action } : {}),
+  };
+}
+
 describe("generateToolSummary", () => {
-  it("summarizes Read tool with file path", () => {
+  it("says what an edit did, and names the file as a path", () => {
     expect(
-      generateToolSummary({
-        type: "tool_use",
-        id: "t1",
-        name: "Read",
-        input: { file_path: "src/index.ts" },
-      })
-    ).toEqual({ label: "Read: src/index.ts" });
-  });
-
-  it("summarizes Bash tool with command", () => {
-    expect(
-      generateToolSummary({
-        type: "tool_use",
-        id: "t2",
-        name: "Bash",
-        input: { command: "npm test" },
-      })
-    ).toEqual({ label: "Bash: npm test" });
-  });
-
-  it("truncates long Bash commands", () => {
-    const longCommand = "a".repeat(120);
-    const result = generateToolSummary({
-      type: "tool_use",
-      id: "t3",
-      name: "Bash",
-      input: { command: longCommand },
+      generateToolSummary(
+        toolUse({
+          kind: "edit",
+          object: { type: "path", value: "/repo/web/src/types.ts" },
+        })
+      )
+    ).toEqual({
+      verb: "Edited",
+      object: { type: "path", value: "/repo/web/src/types.ts" },
     });
-    expect(result.label.length).toBeLessThanOrEqual(
-      100 + "Bash: ".length + "…".length
+  });
+
+  // One word per act, and the same word the fold summary above these rows uses.
+  // `Wrote` stays apart from `Edited` because the difference is what a reader
+  // scanning a Run is looking for: the last of three touches rewrote the file.
+  it.each([
+    ["write", "Wrote"],
+    ["read", "Read"],
+    ["search", "Searched for"],
+    ["execute", "Ran"],
+    ["delegate", "Delegated"],
+    ["other", "Used"],
+  ] as const)("says %s as %s", (kind, verb) => {
+    expect(generateToolSummary(toolUse({ kind })).verb).toBe(verb);
+  });
+
+  // A row normalized before Actions existed, still in flight until re-normalize
+  // catches up. It reads as an unremarkable call rather than reaching back for
+  // the tool's name — that fallback is the machine register this replaced.
+  it("treats a row with no Action as an unremarkable one, not as its tool", () => {
+    const summary = generateToolSummary(toolUse());
+
+    expect(summary.verb).toBe("Used");
+    expect(summary.object).toBeUndefined();
+  });
+
+  // The counts come from the patch the result carried, not from the Action:
+  // how big an edit was is a fact about what came back, and ADR-0023 keeps it
+  // derived at render rather than stored.
+  it("counts an edit's lines from the patch its result carried", () => {
+    const summary = generateToolSummary(
+      toolUse({
+        kind: "edit",
+        object: { type: "path", value: "/repo/web/src/types.ts" },
+      }),
+      {
+        type: "tool_result",
+        tool_use_id: "t1",
+        content: "updated",
+        file_path: "/repo/web/src/types.ts",
+        patch: [
+          {
+            oldStart: 1,
+            oldLines: 2,
+            newStart: 1,
+            newLines: 3,
+            lines: [" kept", "-gone", "+new", "+also new"],
+          },
+        ],
+      }
     );
-    expect(result.label).toMatch(/^Bash: a+…$/);
-  });
 
-  it("summarizes Edit tool with file path", () => {
-    expect(
-      generateToolSummary({
-        type: "tool_use",
-        id: "t4",
-        name: "Edit",
-        input: {
-          file_path: "src/app.ts",
-          old_string: "foo",
-          new_string: "bar",
-        },
-      })
-    ).toEqual({ label: "Edit: src/app.ts" });
-  });
-
-  it("summarizes Write tool with file path", () => {
-    expect(
-      generateToolSummary({
-        type: "tool_use",
-        id: "t5",
-        name: "Write",
-        input: { file_path: "README.md", content: "hello" },
-      })
-    ).toEqual({ label: "Write: README.md" });
-  });
-
-  it("hands an Edit's counts out separately from its label", () => {
-    expect(
-      generateToolSummary(
-        {
-          type: "tool_use",
-          id: "t4",
-          name: "Edit",
-          input: { file_path: "web/src/conversation/CollapsibleToolCall.tsx" },
-        },
-        {
-          type: "tool_result",
-          tool_use_id: "t4",
-          content: "updated",
-          file_path: "web/src/conversation/CollapsibleToolCall.tsx",
-          patch: [
-            {
-              oldStart: 3,
-              oldLines: 4,
-              newStart: 3,
-              newLines: 6,
-              lines: [" keep", "-gone", "+one", "+two", "+three"],
-            },
-          ],
-        }
-      )
-    ).toEqual({
-      label: "Edited CollapsibleToolCall.tsx",
-      diffStat: { added: 3, removed: 1 },
-    });
-  });
-
-  it("summarizes a Write as written, counting a whole new file as added", () => {
-    expect(
-      generateToolSummary(
-        {
-          type: "tool_use",
-          id: "t5",
-          name: "Write",
-          input: { file_path: "/repo/docs/README.md", content: "a\nb\n" },
-        },
-        {
-          type: "tool_result",
-          tool_use_id: "t5",
-          content: "created",
-          file_path: "/repo/docs/README.md",
-          patch: [
-            {
-              oldStart: 1,
-              oldLines: 0,
-              newStart: 1,
-              newLines: 2,
-              lines: ["+a", "+b"],
-            },
-          ],
-        }
-      )
-    ).toEqual({
-      label: "Wrote README.md",
-      diffStat: { added: 2, removed: 0 },
-    });
-  });
-
-  it("sums a MultiEdit's hunks into one pair of counts", () => {
-    expect(
-      generateToolSummary(
-        {
-          type: "tool_use",
-          id: "t6",
-          name: "MultiEdit",
-          input: { file_path: "/repo/src/app.ts" },
-        },
-        {
-          type: "tool_result",
-          tool_use_id: "t6",
-          content: "updated",
-          file_path: "/repo/src/app.ts",
-          patch: [
-            {
-              oldStart: 1,
-              oldLines: 2,
-              newStart: 1,
-              newLines: 2,
-              lines: ["-a", "+b"],
-            },
-            {
-              oldStart: 40,
-              oldLines: 3,
-              newStart: 40,
-              newLines: 4,
-              lines: [" keep", "-c", "+d", "+e"],
-            },
-          ],
-        }
-      )
-    ).toEqual({
-      label: "Edited app.ts",
-      diffStat: { added: 3, removed: 2 },
-    });
-  });
-
-  it("keeps the plain summary for an edit whose result carries no patch", () => {
-    expect(
-      generateToolSummary(
-        {
-          type: "tool_use",
-          id: "t7",
-          name: "Edit",
-          input: { file_path: "src/app.ts" },
-        },
-        { type: "tool_result", tool_use_id: "t7", content: "updated" }
-      )
-    ).toEqual({ label: "Edit: src/app.ts" });
-  });
-
-  it("summarizes Glob tool with pattern", () => {
-    expect(
-      generateToolSummary({
-        type: "tool_use",
-        id: "t6",
-        name: "Glob",
-        input: { pattern: "**/*.ts" },
-      })
-    ).toEqual({ label: "Glob: **/*.ts" });
-  });
-
-  it("summarizes Grep tool with pattern", () => {
-    expect(
-      generateToolSummary({
-        type: "tool_use",
-        id: "t7",
-        name: "Grep",
-        input: { pattern: "TODO" },
-      })
-    ).toEqual({ label: "Grep: TODO" });
-  });
-
-  it("falls back to tool name for unknown tools", () => {
-    expect(
-      generateToolSummary({
-        type: "tool_use",
-        id: "t8",
-        name: "CustomTool",
-        input: { foo: "bar" },
-      })
-    ).toEqual({ label: "CustomTool" });
+    expect(summary.diffStat).toEqual({ added: 2, removed: 1 });
   });
 });

--- a/web/src/conversation/generateToolSummary.ts
+++ b/web/src/conversation/generateToolSummary.ts
@@ -1,17 +1,12 @@
-import type { ContentBlock, PatchHunk } from "@/types";
+import type {
+  ActionKind,
+  ActionObject,
+  ContentBlock,
+  PatchHunk,
+} from "@/types";
 
 type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
 type ToolResultBlock = Extract<ContentBlock, { type: "tool_result" }>;
-
-// A file edit reads better as what changed than as which tool ran, so a result
-// carrying a patch names the act and the shape of it. `Wrote` covers both of
-// Write's cases — a new file and an overwrite — where `Created` would be wrong
-// for one of them.
-const EDIT_VERBS: Record<string, string> = {
-  Edit: "Edited",
-  MultiEdit: "Edited",
-  Write: "Wrote",
-};
 
 /** How big an edit was, in lines. */
 export interface DiffStat {
@@ -20,11 +15,16 @@ export interface DiffStat {
 }
 
 export interface ToolSummary {
-  /** The one-line description: the verb and what it applied to. */
-  label: string;
+  /** What the call did, as the word the reader sees. */
+  verb: string;
+  /**
+   * What it did it to, kept apart from the verb so a narrow row can shrink the
+   * object without ever losing the verb (#262).
+   */
+  object?: ActionObject;
   /**
    * The counts, kept out of the label so the row can place them at its trailing
-   * edge — where a truncating path cannot push them off the end (#250).
+   * edge — where a truncating object cannot push them off the end (#250).
    */
   diffStat?: DiffStat;
 }
@@ -41,52 +41,29 @@ function countLines(patch: PatchHunk[]): DiffStat {
   return { added, removed };
 }
 
-function basename(filePath: string): string {
-  const slash = filePath.lastIndexOf("/");
-  return slash === -1 ? filePath : filePath.slice(slash + 1);
-}
-
-const MAX_DETAIL_LENGTH = 100;
-
-function truncate(text: string): string {
-  if (text.length <= MAX_DETAIL_LENGTH) return text;
-  return text.slice(0, MAX_DETAIL_LENGTH) + "…";
-}
-
-function getInput(input: unknown): Record<string, unknown> {
-  if (typeof input === "object" && input !== null) {
-    return input as Record<string, unknown>;
-  }
-  return {};
-}
-
-function getString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
-}
+// The wording lives here rather than in the stored Action, so changing a word
+// is a frontend edit and not a re-normalize of the whole archive (ADR-0025).
+// `Wrote` covers both of write's cases — a new file and an overwrite — where
+// `Created` would be wrong for one of them.
+const VERBS: Record<ActionKind, string> = {
+  edit: "Edited",
+  write: "Wrote",
+  read: "Read",
+  search: "Searched for",
+  execute: "Ran",
+  delegate: "Delegated",
+  other: "Used",
+};
 
 export function generateToolSummary(
   block: ToolUseBlock,
   result?: ToolResultBlock
 ): ToolSummary {
-  const { name } = block;
-  const input = getInput(block.input);
-
-  const verb = EDIT_VERBS[name];
-  if (verb && result?.file_path && result.patch?.length) {
-    return {
-      label: `${verb} ${basename(result.file_path)}`,
-      diffStat: countLines(result.patch),
-    };
-  }
-
-  const filePath = getString(input.file_path);
-  if (filePath) return { label: `${name}: ${filePath}` };
-
-  const command = getString(input.command);
-  if (command) return { label: `${name}: ${truncate(command)}` };
-
-  const pattern = getString(input.pattern);
-  if (pattern) return { label: `${name}: ${pattern}` };
-
-  return { label: name };
+  const action = block.action;
+  const patch = result?.patch;
+  return {
+    verb: VERBS[action?.kind ?? "other"],
+    ...(action?.object ? { object: action.object } : {}),
+    ...(patch?.length ? { diffStat: countLines(patch) } : {}),
+  };
 }

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -274,6 +274,10 @@ export const fakeMessages: Record<string, Message[]> = {
           id: "tool-1",
           name: "Read",
           input: { file_path: "src/utils.ts" },
+          action: {
+            kind: "read",
+            object: { type: "path", value: "src/utils.ts" },
+          },
         },
         {
           type: "tool_result",

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -35,10 +35,48 @@ export interface PatchHunk {
   lines: string[];
 }
 
+/**
+ * What a Tool unit did, said in a way no Agent owns (ADR-0025). The Plugin
+ * decides it at normalize time, so nothing here keys on a tool's name.
+ */
+export type ActionKind =
+  | "edit"
+  | "write"
+  | "read"
+  | "search"
+  | "execute"
+  | "delegate"
+  | "other";
+
+/**
+ * What an Action applied to. A path may drop leading directories to fit, since
+ * its filename is the identifying part; a phrase may not, and truncates from
+ * the end like ordinary prose.
+ */
+export type ActionObject =
+  | { type: "path"; value: string }
+  | { type: "phrase"; value: string };
+
+export interface Action {
+  kind: ActionKind;
+  object?: ActionObject;
+}
+
 export type ContentBlock =
   | { type: "text"; text: string }
   | { type: "thinking"; thinking: string }
-  | { type: "tool_use"; id: string; name: string; input: unknown }
+  | {
+      type: "tool_use";
+      id: string;
+      name: string;
+      input: unknown;
+      /**
+       * Optional only because rows normalized before Actions existed are still
+       * in flight until re-normalize catches up; such a row reads as `other`
+       * rather than falling back to its tool name.
+       */
+      action?: Action;
+    }
   | {
       type: "tool_result";
       tool_use_id: string;


### PR DESCRIPTION
## Background (Why)

A collapsed tool row spoke in four registers at once. `Edited CommandView.tsx +8 -4` was written for a reader; `Read: /Users/eva/Documents/.../CollapsibleToo…` and `Bash: sqlite3 archive.db "SELECT …"` put the tool's own JSON on screen; `Agent` was a bare tool name with nothing beside it. Three of the four were the fallback path, and on a real archive of 19,749 tool calls they covered about 12%.

Underneath that was a portability problem. The two lookup tables deciding the wording lived in the frontend and were keyed on **Claude Code's tool names**. ADR-0023 promises "a new Agent plugin ships with zero frontend changes as long as it speaks this vocabulary" — but Codex names its tools `shell` and `apply_patch`, so #35 would have landed with every row falling back to the machine register. ADR-0023 had already solved the same problem once for diffs, by keying on the shape of what it finds rather than on a list of names; the row label had not caught up.

## Approach (How)

`tool_use` gains an **Action**: what the call did, said in a way no Agent owns. Seven kinds — `edit`, `write`, `read`, `search`, `execute`, `delegate`, `other` — plus what it applied to, as either a path or a phrase. Each Plugin maps its own tool names at normalize time; the frontend maps kinds onto words at render time.

The load-bearing decision, recorded in ADR-0025: **the Action carries meaning, the UI carries wording.** Stored rows hold `execute`; the screen says `Ran`. Storing the English verb was considered and rejected — it would pin wording into the archive, so changing one word, or translating the column, would mean re-normalizing every chat.

`execute` rather than `run` because **Run** already names the visual grouping of consecutive skim-layer rows. The kind/word mismatch is that split working, not an inconsistency in it.

The kinds came from what the archive actually holds rather than from invention: the top five tools are 88% of calls, and `mcp__*` is 7.2% spread over 47 distinct names. That tail is unbounded — it depends on which servers a reader installed — so `other` is permanent by design. An MCP call is named after its server (`mcp__Claude_Browser__computer` → "Claude Browser"), parsed by shared code since that structure belongs to MCP rather than to any one Agent.

Two object choices replace worse fields that were already there:

- **`execute` takes the call's description, not the command.** 98% of archived Bash calls carry one; 85% of the commands run past 60 characters and 20% are multi-line. `Ran "Count tool_use names"` beats twelve rows of `Bash: sqlite3 …`.
- **A URL is a phrase, not a path.** Its identifying part is at the front, so the UI must not treat its leading parts as droppable the way it does a directory.

## Changes (What)

- [x] `Action`, `ActionKind` and `ActionObject` join the Normalized block vocabulary; `tool_use.action` is required on the write side, optional on the read side
- [x] `mcp-tool-name.ts` reads `mcp__<server>__<tool>` as shared code, not Plugin code
- [x] The Claude Code plugin maps its tool names onto Actions in its own module, keeping `plugin.ts` from growing
- [x] `NORMALIZE_VERSION` 9 → 10, so already-archived chats pick Actions up by re-normalizing from Raw. `blocks` is a JSON text column, so there is no schema migration
- [x] `generateToolSummary` reads the Action and hands back the verb and the object separately; the `EDIT_VERBS` table is gone
- [x] ADR-0025 records the meaning/wording split and the rejected alternatives; ADR-0023 lists the new field and no longer contradicts the code

### Test Verification

- [x] Each kind is derived from a real tool call: Bash, Edit, MultiEdit, Write, Read, Grep, Glob, WebSearch, ToolSearch, Agent, SendMessage, WebFetch
- [x] A Bash call with no description falls back to the command's first line, including the multi-line case
- [x] Three real MCP names resolve to their servers, including one whose server has underscores
- [x] An unmapped built-in keeps its own name rather than vanishing
- [x] Re-normalizing an archive gives an Action to a tool row stored before the field existed, and leaves Raw untouched
- [x] Every kind renders as its verb, and a row with no Action reads as `Used` rather than as its tool name
- [x] Diff counts still come from the result's patch and still sit outside what truncates (#250 holds)
- [x] Full suite: 889 passed, 0 failed; typecheck clean

## Additional Notes

**Two deliberate deviations from the plan**, both worth a reviewer's eye:

1. **Phrase objects are quoted; paths are not.** `Ran "pnpm test"` but `Edited a.tsx`. The plan said `Used Claude Browser`; quoting won because a search pattern containing spaces has no readable boundary without it, and one rule beats two. The cost is that a server name reads slightly oddly in quotes. Reverting is one function in `CollapsibleToolCall.tsx`.
2. **A path still shows only its filename.** Showing the full path now would be a regression against today's basename. Left-truncation that keeps the filename while showing the directory is #262, which is what the verb/object split exists for.

**Not closed here:** the *expanded* view still picks its renderer by tool name, because an Action says what a call did but not the verbatim command a shell renderer expands onto. Filed as #263 with the design question stated.

## Related Links

- Closes #260