### PR TITLE
feat: count a folded stretch by what it did, not which tools ran

### DIFF
--- a/web/src/conversation/folds.test.ts
+++ b/web/src/conversation/folds.test.ts
@@ -1,17 +1,39 @@
 import { describe, it, expect } from "vitest";
-import type { ContentBlock, Message } from "@/types";
+import type { ActionKind, ContentBlock, Message } from "@/types";
 import { planFolds, planLayout } from "@/conversation/folds";
 
 function message(id: string, content: ContentBlock[]): Message {
   return { id, role: "assistant", content, timestamp: "2026-07-22T00:00:00Z" };
 }
 
-function tool(id: string, name: string): Message {
-  return message(id, [{ type: "tool_use", id, name, input: {} }]);
+// Names no Claude Code archive would hold, so every test here asserts the
+// grouping comes from the Action rather than from the tool that ran (#261).
+const FOREIGN_NAMES: Record<ActionKind, string> = {
+  edit: "apply_patch",
+  write: "write_file",
+  read: "read_file",
+  search: "ripgrep",
+  execute: "shell",
+  delegate: "spawn",
+  other: "update_plan",
+};
+
+function unit(id: string, kind: ActionKind): Message {
+  return message(id, [toolBlock(id, kind)]);
+}
+
+function toolBlock(id: string, kind: ActionKind): ContentBlock {
+  return {
+    type: "tool_use",
+    id,
+    name: FOREIGN_NAMES[kind],
+    input: {},
+    action: { kind },
+  };
 }
 
 function bash(id: string): Message {
-  return tool(id, "Bash");
+  return unit(id, "execute");
 }
 
 function summaryOf(messages: Message[]): string | undefined {
@@ -61,13 +83,23 @@ describe("planFolds", () => {
     ]);
   });
 
+  it("groups by what each call did, not by the tool that ran it", () => {
+    const summary = summaryOf([
+      unit("t1", "execute"),
+      unit("t2", "execute"),
+      unit("t3", "execute"),
+    ]);
+
+    expect(summary).toBe("Ran 3 commands");
+  });
+
   it("names what happened, largest group first", () => {
     const summary = summaryOf([
       bash("t1"),
-      tool("t2", "Edit"),
+      unit("t2", "edit"),
       bash("t3"),
       bash("t4"),
-      tool("t5", "Edit"),
+      unit("t5", "edit"),
       bash("t6"),
       bash("t7"),
       bash("t8"),
@@ -76,8 +108,22 @@ describe("planFolds", () => {
     expect(summary).toBe("Ran 6 commands, edited 2 files");
   });
 
+  // The rows this hides say `Read` and `Searched for` apart, because a search's
+  // object is a pattern and `Read "useMessages"` does not parse. One line above
+  // them, both are the Agent looking things up, and splitting the count would
+  // only make the summary harder to skim (#199).
+  it("counts reading and searching as one group", () => {
+    const summary = summaryOf([
+      unit("t1", "read"),
+      unit("t2", "search"),
+      unit("t3", "read"),
+    ]);
+
+    expect(summary).toBe("Read 3 files");
+  });
+
   it("writes a group of one in the singular", () => {
-    const summary = summaryOf([bash("t1"), bash("t2"), tool("t3", "Write")]);
+    const summary = summaryOf([bash("t1"), bash("t2"), unit("t3", "write")]);
 
     expect(summary).toBe("Ran 2 commands, wrote 1 file");
   });
@@ -87,20 +133,55 @@ describe("planFolds", () => {
       bash("t1"),
       bash("t2"),
       bash("t3"),
-      tool("t4", "Edit"),
-      tool("t5", "Edit"),
-      tool("t6", "Read"),
-      tool("t7", "Write"),
+      unit("t4", "edit"),
+      unit("t5", "edit"),
+      unit("t6", "read"),
+      unit("t7", "write"),
     ]);
 
     expect(summary).toBe("Ran 3 commands, edited 2 files, +2 more");
   });
 
+  it("names delegation as its own group", () => {
+    const summary = summaryOf([
+      unit("t1", "delegate"),
+      unit("t2", "delegate"),
+      unit("t3", "delegate"),
+    ]);
+
+    expect(summary).toBe("Delegated 3 tasks");
+  });
+
+  it("counts a call that fits no group rather than hiding it", () => {
+    const summary = summaryOf([
+      bash("t1"),
+      unit("t2", "other"),
+      bash("t3"),
+      unit("t4", "other"),
+      bash("t5"),
+    ]);
+
+    expect(summary).toBe("Ran 3 commands, +2 more");
+  });
+
+  // A unit normalized before Actions existed, still in flight until
+  // re-normalize catches up. It reads as `Used` on its row, and here it counts
+  // toward the total the same way `other` does (#260).
+  it("counts a unit that has no Action yet", () => {
+    const summary = summaryOf([
+      bash("t1"),
+      bash("t2"),
+      message("t3", [{ type: "tool_use", id: "t3", name: "Bash", input: {} }]),
+    ]);
+
+    expect(summary).toBe("Ran 2 commands, +1 more");
+  });
+
   it("falls back to a plain count when nothing fits a known group", () => {
     const summary = summaryOf([
-      tool("t1", "WebFetch"),
-      tool("t2", "TodoWrite"),
-      tool("t3", "WebSearch"),
+      unit("t1", "other"),
+      unit("t2", "other"),
+      unit("t3", "other"),
     ]);
 
     expect(summary).toBe("Ran 3 tools");
@@ -161,9 +242,9 @@ describe("planLayout", () => {
     const layouts = planLayout([
       message("m1", [
         { type: "thinking", thinking: "Let me look." },
-        { type: "tool_use", id: "t1", name: "Read", input: {} },
-        { type: "tool_use", id: "t2", name: "Read", input: {} },
-        { type: "tool_use", id: "t3", name: "Read", input: {} },
+        toolBlock("t1", "read"),
+        toolBlock("t2", "read"),
+        toolBlock("t3", "read"),
       ]),
     ]);
 

--- a/web/src/conversation/folds.ts
+++ b/web/src/conversation/folds.ts
@@ -1,4 +1,4 @@
-import type { ContentBlock, Message } from "@/types";
+import type { ActionKind, ContentBlock, Message } from "@/types";
 import {
   groupRuns,
   planRunLayout,
@@ -142,28 +142,49 @@ function foldEntries(
   return entries;
 }
 
-/** What a tool did, in the reader's terms rather than the tool's name. */
-interface Action {
+/** How a group of Actions reads once it is counted. */
+interface Phrasing {
   verb: string;
   noun: string;
 }
 
-// Grouped by what the tool did, not by which tool ran: a reader skimming a
-// folded stretch wants to know it was six commands, not six Bashes. Reading and
-// searching land in one group — both are the Agent looking things up (#199).
+// Keyed on the Action, not on the tool that ran: a reader skimming a folded
+// stretch wants to know it was six commands, not six Bashes — and an Agent that
+// calls its shell `shell` must land in the same group (#261).
 //
-// `wrote` rather than `created` because Write covers both a new file and an
-// overwrite, and the summary sits one click above rows that already say
-// `Wrote foo.ts +12 -0`. One act, one word, at both densities.
-const ACTIONS: Record<string, Action> = {
-  Bash: { verb: "ran", noun: "command" },
-  Edit: { verb: "edited", noun: "file" },
-  MultiEdit: { verb: "edited", noun: "file" },
-  Write: { verb: "wrote", noun: "file" },
-  Read: { verb: "read", noun: "file" },
-  Grep: { verb: "read", noun: "file" },
-  Glob: { verb: "read", noun: "file" },
+// The wording lives here rather than in the stored Action, the same split the
+// row density draws (ADR-0025). `wrote` rather than `created` because write
+// covers both a new file and an overwrite, and the summary sits one click above
+// rows that already say `Wrote foo.ts +12 -0`. One act, one word, at both
+// densities.
+//
+// Every kind but `other` has a phrasing: `other` is the unbounded tail — an MCP
+// server a reader happened to install — with nothing to be counted as. Typed
+// exhaustively so a kind added later cannot land in that tail by accident.
+const PHRASINGS: Record<Exclude<ActionKind, "other">, Phrasing> = {
+  execute: { verb: "ran", noun: "command" },
+  edit: { verb: "edited", noun: "file" },
+  write: { verb: "wrote", noun: "file" },
+  read: { verb: "read", noun: "file" },
+  // One group with read, though the rows they hide keep the two apart: a search
+  // reads as `Searched for "useMessages"` because its object is a pattern, but
+  // a line above, both are the Agent looking things up (#199). Merging here
+  // rather than in the Action keeps grouping a matter of wording (ADR-0025).
+  search: { verb: "read", noun: "file" },
+  // A subagent's whole run comes back as one unit, so what was handed off is a
+  // task rather than a call.
+  delegate: { verb: "delegated", noun: "task" },
 };
+
+/**
+ * How a call's Action reads in a summary, or nothing when it has no group.
+ *
+ * A unit normalized before Actions existed has no kind at all, and counts the
+ * same way `other` does rather than reaching back for its tool name (#260).
+ */
+function phrasingOf(kind: ActionKind | undefined): Phrasing | undefined {
+  return kind === undefined || kind === "other" ? undefined : PHRASINGS[kind];
+}
 
 // Two groups is what a one-line summary carries before it stops being skimmable.
 const MAX_NAMED_GROUPS = 2;
@@ -182,20 +203,20 @@ function capitalize(text: string): string {
  * A pure function of the units, so the row can be planned before layout.
  */
 export function foldSummary(blocks: ToolUseBlock[]): string {
-  const groups = new Map<string, { action: Action; count: number }>();
-  // A tool that fits no group still happened, so it is counted in the
+  const groups = new Map<string, { phrasing: Phrasing; count: number }>();
+  // A call that fits no group still happened, so it is counted in the
   // remainder rather than dropped — the summary would otherwise hide it.
   let unknown = 0;
   for (const block of blocks) {
-    const action = ACTIONS[block.name];
-    if (!action) {
+    const phrasing = phrasingOf(block.action?.kind);
+    if (!phrasing) {
       unknown += 1;
       continue;
     }
-    const key = `${action.verb} ${action.noun}`;
+    const key = `${phrasing.verb} ${phrasing.noun}`;
     const group = groups.get(key);
     if (group) group.count += 1;
-    else groups.set(key, { action, count: 1 });
+    else groups.set(key, { phrasing, count: 1 });
   }
 
   // Largest first, and insertion order breaks a tie, so equal groups read in
@@ -206,7 +227,7 @@ export function foldSummary(blocks: ToolUseBlock[]): string {
   const named = ranked.slice(0, MAX_NAMED_GROUPS);
 
   const phrases = named.map(
-    ({ action, count }) => `${action.verb} ${plural(count, action.noun)}`
+    ({ phrasing, count }) => `${phrasing.verb} ${plural(count, phrasing.noun)}`
   );
 
   const remainder =


### PR DESCRIPTION
## Background (Why)

#260 moved the collapsed row off Claude Code's tool names and onto the Action. The fold summary did not come with it: it kept a second table of its own, keyed on `Bash`, `Edit`, `MultiEdit`, `Write`, `Read`, `Grep`, `Glob`.

Left there, the two densities drift apart on any Agent that is not Claude Code. Codex calls its shell `shell` and its patcher `apply_patch`, so a Codex chat would fold into `Ran 6 tools` — the fallback — while the rows underneath read `Ran "pnpm test"` and `Edited folds.ts` correctly. A summary is a promise about what it hides; that one would have been lying by omission.

The summary also had gaps the row does not: `delegate` had no group at all, so a stretch of subagent calls read as a bare count.

## Approach (How)

The table is now keyed on `ActionKind`, and the wording still lives in the frontend — the same meaning/wording split ADR-0025 draws for the row. Nothing about the stored Action changed, and no re-normalize is needed.

One deliberate difference between the densities, which #199 had already decided and this keeps: **`read` and `search` count as one group in a summary while staying distinct on their rows.** A line above the detail, both are the Agent looking things up, and splitting the count only makes the summary harder to skim. On the row they must stay apart, because a search's object is a pattern and `Read "useMessages"` does not parse. Merging at render rather than in the Action is what keeps grouping a matter of wording.

`PHRASINGS` is typed `Record<Exclude<ActionKind, "other">, Phrasing>` rather than a `Partial`. `other` is the unbounded tail — an MCP server a reader happened to install — and has nothing to be counted as; every other kind must have a phrasing, so a kind added later fails to compile here instead of silently falling into the remainder.

## Changes (What)

- [x] `foldSummary` groups on `block.action.kind`; the tool-name table in `folds.ts` is gone, and the frontend now holds no table keyed on a tool name at either density
- [x] `search` shares `read`'s group in the summary while the row keeps `Searched for`
- [x] `delegate` gains a group — `Delegated 3 tasks` — which the old table never had
- [x] `other`, and a unit normalized before Actions existed, are counted in the `+N more` remainder rather than dropped
- [x] `phrasingOf()` holds the "no group" rule in one place instead of spreading it across the loop
- [x] The test fixtures use Codex-style tool names (`shell`, `apply_patch`, `ripgrep`), so every test asserts the grouping does not come from the name

### Test Verification

- [x] Three `execute` calls named `shell` fold into `Ran 3 commands` — a name the frontend has never seen still lands in the right group
- [x] `edit` and `write` keep their own verbs, and a group of one stays singular (`wrote 1 file`)
- [x] 2 `read` + 1 `search` reads `Read 3 files`, while `generateToolSummary`'s existing tests hold the row's `Searched for` apart
- [x] 3 `delegate` reads `Delegated 3 tasks`
- [x] 3 `execute` + 2 `other` reads `Ran 3 commands, +2 more` — nothing is hidden from the total
- [x] A `tool_use` with no `action` at all counts the same way `other` does
- [x] All `other` still falls back to a plain `Ran 3 tools`
- [x] Largest group first, two named groups at most, and the thinking boundary are unchanged
- [x] Full suite: 894 passed, 0 failed; typecheck clean
- [x] `run-grouping.spec.ts` e2e: 3 passed — its fixtures already carried Actions from #260, so `Read 3 files` still holds

## Additional Notes

**One judgment call beyond the issue text.** `delegate` needed a noun the old table never had to pick. It reads `Delegated 3 tasks` — a subagent's whole run comes back as one unit, so what was handed off is a task rather than a call. Changing that word is one line.

**Not closed here:** `CollapsibleToolCall.tsx` still checks `block.name === "Read"` and `=== "Bash"` to pick a renderer for the *expanded* view. Those are not a label table — an Action says what a call did, but not the verbatim command a shell renderer expands onto — and they are #263's subject.

## Related Links

- Closes #261