### PR TITLE
feat(web): truncate a row's directory, never its filename

### DIFF
--- a/web/e2e/code-highlighting.spec.ts
+++ b/web/e2e/code-highlighting.spec.ts
@@ -130,13 +130,17 @@ test("a large diff expands and highlights in a real browser without stalling", a
 
   // The collapsed tool unit summarises the write; the full path shows once the
   // diff is expanded.
-  const summary = page.getByText("Wrote constants.ts");
+  const summary = page.getByTestId("row-label");
   await expect(summary).toBeVisible();
   await expect(page.getByTestId("row-diff-stat")).toHaveText("+200 -0");
 
   const start = Date.now();
   await summary.click();
-  await expect(page.getByText("web/src/constants.ts")).toBeVisible();
+  // Scoped to what opened, since the collapsed row above it now names the
+  // same path (#262).
+  await expect(
+    page.getByTestId("unit-detail").getByText("web/src/constants.ts")
+  ).toBeVisible();
 
   // Highlighting arrives after the lazy highlighter load — the keyword tokens
   // appear, proving the language was inferred and applied.
@@ -182,7 +186,7 @@ test("a large read expands as a highlighted, numbered excerpt without stalling",
     },
   ]);
 
-  const summary = page.getByText("Read constants.ts");
+  const summary = page.getByTestId("row-label");
   await expect(summary).toBeVisible();
 
   const start = Date.now();

--- a/web/e2e/diff-stat.spec.ts
+++ b/web/e2e/diff-stat.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
-// The row names the file by its basename, so what has to give way is a long
-// name in a narrow pane — the case that used to eat the counts (#250).
+// What has to give way is a long name in a narrow pane — the case that used to
+// eat the counts (#250).
 const LONG_NAME =
   "CollapsibleToolCallSummaryRowWithAVeryLongDescriptiveFileName.test.tsx";
 const LONG_PATH = `web/src/conversation/${LONG_NAME}`;
@@ -113,7 +113,9 @@ test("the counts survive a name long enough to truncate", async ({ page }) => {
   const stat = page.getByTestId("row-diff-stat");
   await expect(stat).toHaveText("+39 -2");
 
-  const label = page.getByText(`Edited ${LONG_NAME}`);
+  // A name this long outruns even the directory it gave up first (#262), so
+  // the label as a whole is what runs out of room here.
+  const label = page.getByTestId("row-label");
   const truncated = await label.evaluate(
     (el) => el.scrollWidth > el.clientWidth
   );

--- a/web/e2e/row-label-truncation.spec.ts
+++ b/web/e2e/row-label-truncation.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+// Which end of a label gives way is a layout claim, and layout is what a jsdom
+// component test cannot see: every box there measures zero. Measured here (#262).
+
+const DIR = "/Users/eva/Documents/chat-logbook/web/src/conversation";
+const NAME = "CollapsibleToolCall.tsx";
+const LONG_PATH = `${DIR}/${NAME}`;
+
+const LONG_PHRASE =
+  "Count how many archived tool calls carry a description of their own";
+
+/** Mount a one-turn chat whose assistant message carries `blocks`. */
+async function openChatWith(page: Page, blocks: unknown[]) {
+  // Benign empty SSE stream so the live-update EventSource connects cleanly.
+  await page.route(/\/api\/chats\/stream(\?|$)/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: ":ok\n\n",
+    })
+  );
+  await page.route(/\/api\/chats\/counts(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1, projects: [], tags: [], untagged: 1 } })
+  );
+  await page.route(/\/api\/chats\/list-total(\?|$)/, (route) =>
+    route.fulfill({ json: { total: 1 } })
+  );
+  await page.route(/\/api\/chats(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        chats: [
+          {
+            id: "clog_label1",
+            sourceId: "label-chat",
+            agent: "claude-code",
+            title: "A long-winded conversation",
+            project: "/test/project",
+            sourceFilePath: null,
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      },
+    })
+  );
+  await page.route(/\/api\/chats\/clog_label1(\?|$)/, (route) =>
+    route.fulfill({
+      json: {
+        messages: [
+          {
+            role: "assistant",
+            content: blocks,
+            timestamp: "2023-11-14T22:13:20.000Z",
+          },
+        ],
+      },
+    })
+  );
+
+  await page.goto("/");
+  await page.getByText("A long-winded conversation").click();
+}
+
+function editOf(filePath: string) {
+  return [
+    {
+      type: "tool_use",
+      id: "tool_1",
+      name: "Edit",
+      input: { file_path: filePath },
+      action: { kind: "edit", object: { type: "path", value: filePath } },
+    },
+    {
+      type: "tool_result",
+      tool_use_id: "tool_1",
+      content: "File updated",
+      file_path: filePath,
+      patch: [
+        {
+          oldStart: 1,
+          oldLines: 1,
+          newStart: 1,
+          newLines: 2,
+          lines: ["-old", "+one", "+two"],
+        },
+      ],
+    },
+  ];
+}
+
+function ranOf(description: string) {
+  return [
+    {
+      type: "tool_use",
+      id: "tool_1",
+      name: "Bash",
+      input: { command: "sqlite3 archive.db", description },
+      action: {
+        kind: "execute",
+        object: { type: "phrase", value: description },
+      },
+    },
+  ];
+}
+
+/**
+ * Whether the first and last characters of a slot's text are still drawn inside
+ * it — which is how the reader can tell which end the ellipsis ate.
+ */
+async function endsInView(
+  slot: Locator
+): Promise<{ first: boolean; last: boolean }> {
+  return slot.evaluate((el) => {
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    const text = walker.nextNode() as Text;
+    const box = el.getBoundingClientRect();
+    const rectOf = (start: number, end: number) => {
+      const range = document.createRange();
+      range.setStart(text, start);
+      range.setEnd(text, end);
+      return range.getBoundingClientRect();
+    };
+    const inside = (rect: DOMRect) =>
+      rect.left >= box.left - 1 && rect.right <= box.right + 1;
+    return {
+      first: inside(rectOf(0, 1)),
+      last: inside(rectOf(text.length - 1, text.length)),
+    };
+  });
+}
+
+test("a squeezed path loses its directory, never its filename", async ({
+  page,
+}) => {
+  // A narrow window squeezes the third pane, so something has to give way.
+  await page.setViewportSize({ width: 760, height: 700 });
+  await openChatWith(page, editOf(LONG_PATH));
+
+  const dir = page.getByTestId("row-label-dir");
+  const name = page.getByTestId("row-label-name");
+  await expect(name).toHaveText(`/${NAME}`);
+
+  // The row is genuinely out of room, and the directory is what ran out of it.
+  const squeezed = await dir.evaluate((el) => el.scrollWidth > el.clientWidth);
+  expect(squeezed).toBe(true);
+
+  // The filename is drawn whole, inside the row rather than past its edge.
+  const clipped = await name.evaluate((el) => el.scrollWidth > el.clientWidth);
+  expect(clipped).toBe(false);
+  const nameBox = (await name.boundingBox())!;
+  const rowBox = (await page.getByTestId("row-label").boundingBox())!;
+  expect(nameBox.x).toBeGreaterThanOrEqual(rowBox.x);
+  expect(nameBox.x + nameBox.width).toBeLessThanOrEqual(
+    rowBox.x + rowBox.width + 1
+  );
+
+  // What the directory kept is its tail — the part next to the filename — so
+  // the ellipsis is at the left, not the right.
+  expect(await endsInView(dir)).toEqual({ first: false, last: true });
+
+  // The counts still sit at the trailing edge, outside anything truncating.
+  const statBox = (await page.getByTestId("row-diff-stat").boundingBox())!;
+  expect(statBox.width).toBeGreaterThan(0);
+  expect(statBox.x).toBeGreaterThanOrEqual(nameBox.x + nameBox.width);
+});
+
+test("the verb survives a width that leaves nothing else", async ({ page }) => {
+  await page.setViewportSize({ width: 620, height: 700 });
+  await openChatWith(page, editOf(LONG_PATH));
+
+  const verb = page.getByTestId("row-label-verb");
+  await expect(verb).toHaveText("Edited");
+  expect(await verb.evaluate((el) => el.scrollWidth > el.clientWidth)).toBe(
+    false
+  );
+});
+
+test("a phrase still gives way at its end", async ({ page }) => {
+  await page.setViewportSize({ width: 760, height: 700 });
+  await openChatWith(page, ranOf(LONG_PHRASE));
+
+  const label = page.getByTestId("row-label");
+  const squeezed = await label.evaluate(
+    (el) => el.scrollWidth > el.clientWidth
+  );
+  expect(squeezed).toBe(true);
+  expect(await endsInView(label)).toEqual({ first: true, last: false });
+});

--- a/web/e2e/run-grouping.spec.ts
+++ b/web/e2e/run-grouping.spec.ts
@@ -86,8 +86,9 @@ async function rowTop(
   path: string
 ): Promise<{ top: number; bottom: number }> {
   const box = await page
-    // The row names the file, not the path it sits at.
-    .getByRole("button", { name: new RegExp(`Read ${path.split("/").pop()}`) })
+    // The row names the path, verb and all, with the two joined by a space
+    // the layout cannot drop (#262).
+    .getByRole("button", { name: new RegExp(`Read\\s${path}`) })
     .boundingBox();
   return { top: box!.y, bottom: box!.y + box!.height };
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1477,8 +1477,11 @@ describe("Tool call rendering", () => {
 
     await user.click(await screen.findByText("Refactor utils"));
 
-    // Tool call summary should be visible
-    expect(await screen.findByText("Read utils.ts")).toBeInTheDocument();
+    // Tool call summary should be visible — the directory too, since a name on
+    // its own does not say which of several like-named files this was (#262).
+    expect((await screen.findByTestId("row-label")).textContent).toMatch(
+      /^Read\ssrc\/utils\.ts$/
+    );
 
     // The file it read should NOT be visible when collapsed
     expect(screen.queryByTestId("excerpt-line")).not.toBeInTheDocument();
@@ -1489,7 +1492,7 @@ describe("Tool call rendering", () => {
     render(<App />);
 
     await user.click(await screen.findByText("Refactor utils"));
-    const summary = await screen.findByText("Read utils.ts");
+    const summary = await screen.findByTestId("row-label");
 
     // Click to expand
     await user.click(summary);
@@ -1504,7 +1507,7 @@ describe("Tool call rendering", () => {
     render(<App />);
 
     await user.click(await screen.findByText("Refactor utils"));
-    const summary = await screen.findByText("Read utils.ts");
+    const summary = await screen.findByTestId("row-label");
 
     // Expand then collapse
     await user.click(summary);
@@ -1521,7 +1524,7 @@ describe("Thinking block rendering", () => {
     render(<App />);
 
     await user.click(await screen.findByText("Refactor utils"));
-    await screen.findByText("Read utils.ts");
+    await screen.findByTestId("row-label");
 
     // session-3 has one empty thinking and one with content
     // Only one "Thinking..." button should appear
@@ -1730,7 +1733,7 @@ describe("Tool call rendering (continued)", () => {
     render(<App />);
 
     await user.click(await screen.findByText("Refactor utils"));
-    await screen.findByText("Read utils.ts");
+    await screen.findByTestId("row-label");
 
     // tool_result content should not appear
     expect(

--- a/web/src/conversation/CollapsibleRow.tsx
+++ b/web/src/conversation/CollapsibleRow.tsx
@@ -5,8 +5,11 @@ import type { DiffStat } from "@/conversation/generateToolSummary";
 interface CollapsibleRowProps {
   /** The kind marker — a terminal for tool units, a brain for thinking. */
   icon: LucideIcon;
-  /** The one-line collapsed summary. */
-  summary: string;
+  /**
+   * The one-line collapsed summary. A node rather than a string, because a
+   * tool unit's label is several slots that truncate differently (#262).
+   */
+  summary: ReactNode;
   /** Marks the row as reporting a failure. */
   hasError?: boolean;
   /**

--- a/web/src/conversation/CollapsibleToolCall.test.tsx
+++ b/web/src/conversation/CollapsibleToolCall.test.tsx
@@ -14,6 +14,11 @@ const editCall: ToolUseBlock = {
   action: { kind: "edit", object: { type: "path", value: "src/a.tsx" } },
 };
 
+/** What the row reads as, with the label's own slots joined back up. */
+function labelOf(element: HTMLElement): string {
+  return (element.textContent ?? "").replace(/\s+/g, " ");
+}
+
 describe("CollapsibleToolCall", () => {
   it("renders an expanded edit result as a diff, not raw JSON", () => {
     const result: ToolResultBlock = {
@@ -75,7 +80,7 @@ describe("CollapsibleToolCall", () => {
     );
 
     expect(screen.getByTestId("row-diff-stat").textContent).toBe("+3 -1");
-    expect(screen.getByText("Edited a.tsx")).not.toBeNull();
+    expect(labelOf(screen.getByTestId("row-label"))).toBe("Edited src/a.tsx");
   });
 
   // One register across the whole column: a row says what happened, never which
@@ -104,6 +109,85 @@ describe("CollapsibleToolCall", () => {
     );
 
     expect(screen.getByText(label)).not.toBeNull();
+    // A phrase has no directory to give up, so it stays one slot and truncates
+    // from the end as before (#262).
+    expect(screen.queryByTestId("row-label-name")).toBeNull();
+  });
+
+  // Two rows reading `Edited types.ts` hide whether that was one file twice or
+  // two files once, so the row names the directory too (#262).
+  it("names the directory a path sits in, not the filename alone", () => {
+    render(
+      <CollapsibleToolCall
+        block={{
+          ...editCall,
+          action: {
+            kind: "edit",
+            object: {
+              type: "path",
+              value: "web/src/conversation/CollapsibleToolCall.tsx",
+            },
+          },
+        }}
+        isExpanded={false}
+        onToggle={() => {}}
+      />
+    );
+
+    expect(labelOf(screen.getByTestId("row-label"))).toBe(
+      "Edited web/src/conversation/CollapsibleToolCall.tsx"
+    );
+  });
+
+  // The filename is the part that identifies a path, so it gets a slot of its
+  // own — the directory beside it is what a narrow row gives away (#262).
+  it("keeps the filename in a slot the directory cannot squeeze", () => {
+    render(
+      <CollapsibleToolCall
+        block={{
+          ...editCall,
+          action: {
+            kind: "edit",
+            object: {
+              type: "path",
+              value: "web/src/conversation/CollapsibleToolCall.tsx",
+            },
+          },
+        }}
+        isExpanded={false}
+        onToggle={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId("row-label-dir").textContent).toBe(
+      "web/src/conversation"
+    );
+    // The separator travels with the name, so what is left after a squeeze
+    // still reads as a path rather than as a bare word.
+    expect(screen.getByTestId("row-label-name").textContent).toBe(
+      "/CollapsibleToolCall.tsx"
+    );
+  });
+
+  // Nothing to give up means nothing to split: the label stays one slot.
+  it("leaves a path with no directory as one whole label", () => {
+    render(
+      <CollapsibleToolCall
+        block={{
+          ...editCall,
+          action: {
+            kind: "read",
+            object: { type: "path", value: "README.md" },
+          },
+        }}
+        isExpanded={false}
+        onToggle={() => {}}
+      />
+    );
+
+    expect(screen.getByText("Read README.md")).not.toBeNull();
+    expect(screen.queryByTestId("row-label-dir")).toBeNull();
+    expect(screen.queryByTestId("row-label-name")).toBeNull();
   });
 
   it("falls back to the raw rendering when the result carries no patch", () => {

--- a/web/src/conversation/CollapsibleToolCall.tsx
+++ b/web/src/conversation/CollapsibleToolCall.tsx
@@ -1,11 +1,12 @@
 import { Terminal } from "lucide-react";
-import type { ActionObject, ContentBlock } from "@/types";
+import type { ContentBlock } from "@/types";
 import { CollapsibleRow } from "@/conversation/CollapsibleRow";
 import { CommandView } from "@/conversation/CommandView";
 import { DiffView } from "@/conversation/DiffView";
 import { FileExcerptView } from "@/conversation/FileExcerptView";
 import { generateToolSummary } from "@/conversation/generateToolSummary";
 import { JsonView } from "@/conversation/JsonView";
+import { RowLabel } from "@/conversation/RowLabel";
 import type { ToolResultBlock } from "@/conversation/toolUnits";
 
 type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
@@ -32,21 +33,6 @@ function shellCommand(input: unknown): string | undefined {
   if (typeof input !== "object" || input === null) return undefined;
   const { command } = input as { command?: unknown };
   return typeof command === "string" ? command : undefined;
-}
-
-/**
- * The row's one line: what happened, then what it happened to.
- *
- * A path stands on its own — it is already a name. A phrase is text the call
- * supplied, so quoting it keeps `Searched for "npm test"` from reading as if
- * the words were ours. The filename alone for now; #262 gives the row a shape
- * that can show the directory too without ever clipping the name.
- */
-function sentence(verb: string, object?: ActionObject): string {
-  if (!object) return verb;
-  if (object.type === "phrase") return `${verb} "${object.value}"`;
-  const slash = object.value.lastIndexOf("/");
-  return `${verb} ${slash === -1 ? object.value : object.value.slice(slash + 1)}`;
 }
 
 /**
@@ -88,7 +74,7 @@ export function CollapsibleToolCall({
   return (
     <CollapsibleRow
       icon={Terminal}
-      summary={sentence(verb, object)}
+      summary={<RowLabel verb={verb} object={object} />}
       diffStat={diffStat}
       hasError={result?.is_error}
       isExpanded={isExpanded}

--- a/web/src/conversation/ConversationView.test.tsx
+++ b/web/src/conversation/ConversationView.test.tsx
@@ -549,7 +549,11 @@ describe("Conversation collapsed units", () => {
     );
 
     // The collapsed row is still rendered — it is content, just not authored.
-    expect(await screen.findByText("Read a.ts")).not.toBeNull();
+    // The verb and the path are separate slots, so what joins them is an
+    // unbreakable space rather than a plain one (#262).
+    expect((await screen.findByTestId("row-label")).textContent).toMatch(
+      /^Read\s\/tmp\/a\.ts$/
+    );
     // ...but the header belongs to the text turn alone.
     expect(screen.getAllByText("Claude Code")).toHaveLength(1);
   });
@@ -590,7 +594,7 @@ describe("Conversation tool units", () => {
       />
     );
 
-    await user.click(await screen.findByText("Read a.ts"));
+    await user.click(await screen.findByTestId("row-label"));
 
     // Highlighting splits the code into token spans, so match on the row's
     // whole text rather than a single node's (#240).
@@ -693,7 +697,9 @@ describe("Conversation tool units", () => {
       />
     );
 
-    expect(await screen.findByText("Edited App.tsx")).not.toBeNull();
+    expect((await screen.findByTestId("row-label")).textContent).toMatch(
+      /^Edited\s\/repo\/web\/src\/App\.tsx$/
+    );
     // The counts keep their own place at the row's trailing edge (#250).
     expect((await screen.findByTestId("row-diff-stat")).textContent).toBe(
       "+3 -1"
@@ -771,7 +777,7 @@ describe("Conversation tool units", () => {
     );
 
     const row = await screen.findByRole("button", {
-      name: /Read a\.ts/,
+      name: /Read\s\/tmp\/a\.ts/,
     });
     expect(row).toHaveAttribute("aria-expanded", "false");
     expect(row.querySelector('[data-testid="row-chevron"]')).not.toBeNull();
@@ -1375,7 +1381,9 @@ describe("Row expansion", () => {
       />
     );
 
-    await user.click(await screen.findByRole("button", { name: /Read b\.ts/ }));
+    await user.click(
+      await screen.findByRole("button", { name: /Read \/b\.ts/ })
+    );
 
     rerender(
       <ConversationView
@@ -1396,13 +1404,12 @@ describe("Row expansion", () => {
     );
 
     expect(
-      await screen.findByRole("button", { name: /Read b\.ts/ })
+      await screen.findByRole("button", { name: /Read \/b\.ts/ })
     ).toHaveAttribute("aria-expanded", "true");
     // and no neighbour inherited it
-    expect(screen.getByRole("button", { name: /Read a\.ts/ })).toHaveAttribute(
-      "aria-expanded",
-      "false"
-    );
+    expect(
+      screen.getByRole("button", { name: /Read \/a\.ts/ })
+    ).toHaveAttribute("aria-expanded", "false");
   });
   it("remembers each row of a turn separately", async () => {
     const user = userEvent.setup();
@@ -1441,16 +1448,16 @@ describe("Row expansion", () => {
       />
     );
 
-    await user.click(await screen.findByRole("button", { name: /Read b\.ts/ }));
+    await user.click(
+      await screen.findByRole("button", { name: /Read \/b\.ts/ })
+    );
 
-    expect(screen.getByRole("button", { name: /Read b\.ts/ })).toHaveAttribute(
-      "aria-expanded",
-      "true"
-    );
-    expect(screen.getByRole("button", { name: /Read a\.ts/ })).toHaveAttribute(
-      "aria-expanded",
-      "false"
-    );
+    expect(
+      screen.getByRole("button", { name: /Read \/b\.ts/ })
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByRole("button", { name: /Read \/a\.ts/ })
+    ).toHaveAttribute("aria-expanded", "false");
   });
 
   it("opens a different chat with every row closed", async () => {
@@ -1459,7 +1466,9 @@ describe("Row expansion", () => {
       <ConversationView chat={chat} messages={[tool("m-a", "/a.ts")]} />
     );
 
-    await user.click(await screen.findByRole("button", { name: /Read a\.ts/ }));
+    await user.click(
+      await screen.findByRole("button", { name: /Read \/a\.ts/ })
+    );
 
     rerender(
       <ConversationView
@@ -1469,7 +1478,7 @@ describe("Row expansion", () => {
     );
 
     expect(
-      await screen.findByRole("button", { name: /Read a\.ts/ })
+      await screen.findByRole("button", { name: /Read \/a\.ts/ })
     ).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/web/src/conversation/RowLabel.tsx
+++ b/web/src/conversation/RowLabel.tsx
@@ -1,0 +1,77 @@
+import type { ActionObject } from "@/types";
+
+interface RowLabelProps {
+  /** What the call did, as the word the reader sees. */
+  verb: string;
+  /** What it did it to, if it named anything. */
+  object?: ActionObject;
+}
+
+/**
+ * The label as one string.
+ *
+ * Quoting a phrase keeps `Searched for "npm test"` from reading as if the
+ * words were ours. A path stands unquoted — it is already a name.
+ */
+function oneLine(verb: string, object?: ActionObject): string {
+  if (!object) return verb;
+  if (object.type === "phrase") return `${verb} "${object.value}"`;
+  return `${verb} ${object.value}`;
+}
+
+/**
+ * The row's one line: what happened, then what it happened to.
+ *
+ * A path with a directory in it gets three slots rather than one string,
+ * because a single truncating span clips the end — and the end of a path is
+ * the filename, the one part that identifies it (#262). The verb holds its
+ * width, the directory absorbs the squeeze, the filename holds its width. The
+ * diff stat already sits outside what truncates for the same reason (#250);
+ * this is that trick one slot further left.
+ *
+ * Everything else — a phrase, a bare filename, a verb on its own — has no
+ * directory to give up, so it stays one slot and truncates from the end as
+ * before.
+ */
+export function RowLabel({ verb, object }: RowLabelProps) {
+  if (object?.type === "path") {
+    const slash = object.value.lastIndexOf("/");
+    if (slash > 0) {
+      return (
+        <span data-testid="row-label" className="flex min-w-0">
+          <span data-testid="row-label-verb" className="shrink-0">
+            {verb}
+          </span>
+          {/* Unbreakable, because a plain space between two flex items is
+              whitespace the layout drops — and a space at the end of the verb
+              is whitespace the accessible name trims. */}
+          {" "}
+          <span className="flex min-w-0">
+            {/* Reversing the box puts the ellipsis at the line's end, which in
+                an RTL box is its left edge. The path itself is isolated back
+                to LTR, so its slashes stay where they were written. */}
+            <span
+              data-testid="row-label-dir"
+              className="min-w-0 truncate [direction:rtl]"
+            >
+              <bdi dir="ltr">{object.value.slice(0, slash)}</bdi>
+            </span>
+            {/* The separator travels with the name, so what survives a squeeze
+                still reads as a path rather than as a bare word. */}
+            <span data-testid="row-label-name" className="shrink-0">
+              {object.value.slice(slash)}
+            </span>
+          </span>
+        </span>
+      );
+    }
+  }
+
+  // It owns its truncation rather than leaning on the row's, so either shape
+  // of label is one measurable box.
+  return (
+    <span data-testid="row-label" className="block truncate">
+      {oneLine(verb, object)}
+    </span>
+  );
+}


### PR DESCRIPTION
## Background (Why)

A collapsed row's label truncated with a CSS ellipsis, which clips the end. So a long path lost its filename — the one part that identifies it — and the reader was left with `…/Documents/chat-logbook/web/src/conversa…`.

Now that a label arrives as a verb and an object (#260), the row can truncate the part worth losing.

Showing the directory at all, rather than the basename alone, is the point: this repo has a `types.ts`, a `plugin.ts` and a `registry.ts` in several places, and two consecutive rows reading `Edited types.ts` hide whether that was one file twice or two files once.

## Approach (How)

A path with a directory in it gets three slots instead of one string. The verb holds its width, the directory absorbs the squeeze, the filename holds its width. The diff stat already sits outside what truncates for the same reason (#250) — this applies that trick one slot further left.

The directory's box is reversed (`direction: rtl`), which puts the ellipsis at the line's end and, in an RTL box, that end is the left edge. The path inside is isolated back to LTR with `<bdi>`, so its slashes stay where they were written rather than being reordered by bidi.

Anything with no directory to give up — a phrase, a bare filename, a verb on its own — stays one slot and truncates from the end as before.

`CollapsibleRow`'s `summary` widens from `string` to `ReactNode` to carry the slots; its markup is otherwise untouched, so #250's placement of the counts is unchanged.

## Changes (What)

- [x] New `RowLabel` renders a path as verb / directory / filename, with only the directory able to shrink
- [x] The separator `/` travels with the filename, so what survives a squeeze still reads as a path rather than a bare word
- [x] A row now names the directory a file sits in, not the basename alone
- [x] A phrase, and a path with no directory, stay one slot and truncate from the end
- [x] `CollapsibleRow.summary` accepts a node; the diff stat keeps its place at the trailing edge
- [x] Existing unit and e2e specs updated to reach the label by its handle, since it is several elements now

### Screenshots or Recordings

At a 760px viewport, where the third pane is genuinely out of room:

```
> >_ Edited …sation/CollapsibleToolCall.tsx  +2 -1
```

The directory is eaten from the left, the filename is whole, and the counts are still on the row.

### Test Verification

- [x] A path label reads `Edited web/src/conversation/CollapsibleToolCall.tsx`, directory included
- [x] The directory and the filename are separate slots, with the separator on the filename's side
- [x] A path with no directory stays one whole label, growing no empty slots
- [x] A phrase still renders as one slot
- [x] In a real browser at a narrow width: the directory keeps its tail and loses its head, the filename is drawn whole and inside the row, and the diff stat sits past it at the trailing edge
- [x] In a real browser: the verb is never clipped
- [x] In a real browser: a long phrase keeps its head and loses its tail
- [x] The browser assertion was checked against a mutation — removing `direction: rtl` turns it red, so it is not a vacuous test
- [x] Full suite: 892 unit tests, 24 e2e tests, typecheck, lint, build

## Additional Notes

One honest limit: a filename longer than the whole column still clips at the right. By then the directory has already been squeezed to nothing and there is nothing left to give, so the outer ellipsis takes over — the same behaviour `diff-stat.spec.ts` has always covered. The guarantee holds whenever the filename itself fits: the directory is always sacrificed first.

The verb and its object are joined by a non-breaking space. A plain space between two flex items is whitespace the layout drops, and a space at the end of the verb is whitespace the accessible name trims — so specs that match the label match the separator as `\s`.

## Related Links

- Closes #262